### PR TITLE
Decapitalize keywords in completion, add syntax highlighting for decapitalized blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ Link to detailed documentation: [DOCS](DOCS.md)
 
 ## Plugins
 * [org-bullets.nvim](https://github.com/akinsho/org-bullets.nvim)
+* [headlines.nvim](https://github.com/lukas-reineke/headlines.nvim)
+
+See all available plugins on [orgmode-nvim](https://github.com/topics/orgmode-nvim)
+
+**If you built a plugin please add "orgmode-nvim" topic to it.**
 
 **NOTE**: None of the Emacs Orgmode plugins will be built into orgmode.nvim.
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.

--- a/lua/orgmode/org/autocompletion/cmp.lua
+++ b/lua/orgmode/org/autocompletion/cmp.lua
@@ -17,7 +17,7 @@ Source.get_debug_name = function()
 end
 
 function Source:is_available()
-  return true
+  return vim.bo.filetype == 'org'
 end
 
 function Source:get_trigger_characters(_)

--- a/lua/orgmode/org/syntax.lua
+++ b/lua/orgmode/org/syntax.lua
@@ -12,7 +12,7 @@ local function load_code_blocks()
   end
 
   for _, ft in ipairs(orgfile.source_code_filetypes) do
-    vim.cmd(string.format([[syntax include @orgmodeBlockSrc%s syntax/%s.vim]], ft, ft))
+    vim.cmd(string.format([[silent! syntax include @orgmodeBlockSrc%s syntax/%s.vim]], ft, ft))
     vim.cmd([[unlet! b:current_syntax]])
   end
 

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -11,7 +11,7 @@ let s:conceal = luaeval('require("orgmode.config").org_hide_emphasis_markers')
 if s:conceal
   let s:concealends = ' concealends'
 endif
-exe 'syntax region org_bold      matchgroup=org_bold_delimiter       start="\S\zs\*\|\*\S\@="  end="\S\zs\*\|\*\S\@="  keepend oneline contains=@Spell' . s:concealends
+exe 'syntax region org_bold      matchgroup=org_bold_delimiter       start="[^\*]\zs\*\|\*[^\*]\@="  end="\S\zs\*\|\*\S\@="  keepend oneline contains=@Spell' . s:concealends
 exe 'syntax region org_italic    matchgroup=org_italic_delimiter     start="\S\zs\/\|\/\S\@="  end="\S\zs\/\|\/\S\@="  keepend oneline contains=@Spell' . s:concealends
 exe 'syntax region org_underline matchgroup=org_underline_delimiter  start="\S\zs_\|_\S\@="    end="\S\zs_\|_\S\@="    keepend oneline contains=@Spell' . s:concealends
 exe 'syntax region org_code      matchgroup=org_code_delimiter       start="\S\zs\~\|\~\S\@="  end="\S\zs\~\|\~\S\@="  keepend oneline contains=@Spell' . s:concealends

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -127,17 +127,17 @@ describe('Autocompletion', function()
     -- Directives
     result = OrgmodeOmniCompletion(0, '#')
     local directives = {
-      { menu = '[Org]', word = '#+TITLE' },
-      { menu = '[Org]', word = '#+AUTHOR' },
-      { menu = '[Org]', word = '#+EMAIL' },
-      { menu = '[Org]', word = '#+NAME' },
-      { menu = '[Org]', word = '#+FILETAGS' },
-      { menu = '[Org]', word = '#+ARCHIVE' },
-      { menu = '[Org]', word = '#+OPTIONS' },
-      { menu = '[Org]', word = '#+BEGIN_SRC' },
-      { menu = '[Org]', word = '#+END_SRC' },
-      { menu = '[Org]', word = '#+BEGIN_EXAMPLE' },
-      { menu = '[Org]', word = '#+END_EXAMPLE' },
+      { menu = '[Org]', word = '#+title' },
+      { menu = '[Org]', word = '#+author' },
+      { menu = '[Org]', word = '#+email' },
+      { menu = '[Org]', word = '#+name' },
+      { menu = '[Org]', word = '#+filetags' },
+      { menu = '[Org]', word = '#+archive' },
+      { menu = '[Org]', word = '#+options' },
+      { menu = '[Org]', word = '#+begin_src' },
+      { menu = '[Org]', word = '#+end_src' },
+      { menu = '[Org]', word = '#+begin_example' },
+      { menu = '[Org]', word = '#+end_example' },
     }
     assert.are.same(directives, result)
 
@@ -146,8 +146,8 @@ describe('Autocompletion', function()
 
     result = OrgmodeOmniCompletion(0, '#+B')
     assert.are.same({
-      { menu = '[Org]', word = '#+BEGIN_SRC' },
-      { menu = '[Org]', word = '#+BEGIN_EXAMPLE' },
+      { menu = '[Org]', word = '#+begin_src' },
+      { menu = '[Org]', word = '#+begin_example' },
     }, result)
 
     -- Headline


### PR DESCRIPTION
lowercase keywords are the norm in org-mode, uppercase is just used in the manuals to make them stand out more. This changes the completion to use lowercase instead of uppercase 

TODO: Add back syntax highlighting for uppercase keywords