### PR TITLE
feat: Edit source blocks in a buffer with the associated filetype

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,8 +9,9 @@
    2. [Agenda mappings](#agenda-mappings)
    3. [Capture mappings](#capture-mappings)
    4. [Org mappings](#org-mappings)
-   5. [Text objects](#text-objects)
-   6. [Dot repeat](#dot-repeat)
+   5. [Edit Src mappings](#edit-src)
+   6. [Text objects](#text-objects)
+   7. [Dot repeat](#dot-repeat)
 3. [Document Diagnostics](#document-diagnostics)
 4. [Autocompletion](#autocompletion)
 5. [Abbreviations](#abbreviations)
@@ -146,7 +147,6 @@ Marker used to indicate a folded headline.
 When set to `time`(default), adds `CLOSED` date when marking headline as done.<br />
 When set to `false`, it is disabled.
 
-
 #### **org_highlight_latex_and_related**
 *type*: `string|nil`<br />
 *default value*: `nil`<br />
@@ -165,6 +165,19 @@ Possible values:
 Possible values:
 * `indent` - Use default indentation that follows headlines/checkboxes/previous line indent
 * `noindent` - Disable indentation. All lines start from 1st column
+
+#### **org_src_window_setup**
+*type*: `string|function`<br />
+*default value*: "top 16new"<br />
+If the value is a string, it will be run directly as input to `:h vim.cmd`, otherwise if the value is a function it will be called. Both
+values have the responsibility of opening a buffer (within a window) to show the special edit buffer. The content of the buffer will be
+set automatically, so this option only needs to handle opening an empty buffer.
+
+#### **org_edit_src_content_indentation**
+*type*: `number`<br />
+*default value*: 0<br />
+The indent value for content within `SRC` block types beyond the existing indent of the block itself. Only applied when exiting from
+an `org_edit_special` action on a `SRC` block.
 
 #### **org_custom_exports**
 *type*: `table`<br />
@@ -623,6 +636,11 @@ using the '+' character. Example: `file:/home/user/.config/nvim/init.lua +10`
 * Headline with `CUSTOM_ID` property (starts with `#`)
 * Fallback: If file path, opens the file, otherwise, tries to find the Headline title.
 When date is under the cursor, open the agenda for that day.<br />
+#### **org_edit_special**
+*mapped to*: `<Leader>o'`<br />
+Open a source block for editing in a temporary buffer of the associated `filetype`.<br />
+This is useful for editing text with language servers attached, etc. When the buffer is closed, the text of the underlying source block in the original Org file is updated.
+*Note that if the Org file that the source block comes from is edited before the special edit buffer is closed, the edits will not be applied. The special edit buffer contents can be recovered from :messages output*
 #### **org_cycle**
 *mapped to*: `<TAB>`<br />
 Cycle folding for current headline
@@ -738,6 +756,22 @@ require('orgmode').setup({
   }
 })
 ```
+
+### Edit Src
+
+Mappings applied when editing a `SRC` block content via `org_edit_special`.
+
+#### **org_edit_src_abort**
+*mapped to*: `<Leader>ok`<br />
+Abort changes made to temporary buffer created from the content of a `SRC` block, see above.<br />
+
+#### **org_edit_src_save**
+*mapped to*: `<Leader>ow`<br />
+Apply changes from the special buffer to the source Org buffer<br />
+
+#### **org_edit_src_show_help**
+*mapped to*: `g?`<br />
+Show help within the temporary buffer used to edit the content of a `SRC` block.<br />
 
 ### Text objects
 
@@ -919,6 +953,7 @@ For adding/changing TODO keyword colors see [org-todo-keyword-faces](#org_todo_k
 
 * The following use vanilla _Vim_ syntax matching, and will work without _Treesitter_ highlighting enabled.
 
+`OrgEditSrcHighlight`: The highlight for the source content in an _Org_ buffer while it is being edited in an edit special buffer
 `OrgAgendaDeadline`: A item deadline in the agenda view
 `OrgAgendaScheduled`: A scheduled item in the agenda view
 `OrgAgendaScheduledPast`: A item past its scheduled date in the agenda view

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -20,9 +20,11 @@ CONTENTS                                                        *orgmode-content
             1.1.1.10. org_log_done..........................|orgmode-org_log_done|
             1.1.1.11. org_highlight_latex_and_related.|orgmode-org_highlight_latex_and_related|
             1.1.1.12. org_indent_mode....................|orgmode-org_indent_mode|
-            1.1.1.13. org_custom_exports..............|orgmode-org_custom_exports|
-            1.1.1.14. org_time_stamp_rounding_minutes.|orgmode-org_time_stamp_rounding_minutes|
-            1.1.1.15. org_blank_before_new_entry.|orgmode-org_blank_before_new_entry|
+            1.1.1.13. org_src_window_setup..........|orgmode-org_src_window_setup|
+            1.1.1.14. org_edit_src_content_indentation.|orgmode-org_edit_src_content_indentation|
+            1.1.1.15. org_custom_exports..............|orgmode-org_custom_exports|
+            1.1.1.16. org_time_stamp_rounding_minutes.|orgmode-org_time_stamp_rounding_minutes|
+            1.1.1.17. org_blank_before_new_entry.|orgmode-org_blank_before_new_entry|
         1.1.2. Agenda settings...........................|orgmode-agenda_settings|
             1.1.2.1. org_deadline_warning_days.|orgmode-org_deadline_warning_days|
             1.1.2.2. org_agenda_span.....................|orgmode-org_agenda_span|
@@ -90,47 +92,52 @@ CONTENTS                                                        *orgmode-content
             1.2.4.11. org_todo_prev........................|orgmode-org_todo_prev|
             1.2.4.12. org_toggle_checkbox............|orgmode-org_toggle_checkbox|
             1.2.4.13. org_open_at_point................|orgmode-org_open_at_point|
-            1.2.4.14. org_cycle................................|orgmode-org_cycle|
-            1.2.4.15. org_global_cycle..................|orgmode-org_global_cycle|
-            1.2.4.16. org_archive_subtree............|orgmode-org_archive_subtree|
-            1.2.4.17. org_set_tags_command..........|orgmode-org_set_tags_command|
-            1.2.4.18. org_toggle_archive_tag......|orgmode-org_toggle_archive_tag|
-            1.2.4.19. org_do_promote......................|orgmode-org_do_promote|
-            1.2.4.20. org_do_demote........................|orgmode-org_do_demote|
-            1.2.4.21. org_promote_subtree............|orgmode-org_promote_subtree|
-            1.2.4.22. org_demote_subtree..............|orgmode-org_demote_subtree|
-            1.2.4.23. org_meta_return....................|orgmode-org_meta_return|
-            1.2.4.24. org_insert_heading_respect_content.|orgmode-org_insert_heading_respect_content|
-            1.2.4.25. org_insert_todo_heading....|orgmode-org_insert_todo_heading|
-            1.2.4.26. org_insert_todo_heading_respect_content.|orgmode-org_insert_todo_heading_respect_content|
-            1.2.4.27. org_move_subtree_up............|orgmode-org_move_subtree_up|
-            1.2.4.28. org_move_subtree_down........|orgmode-org_move_subtree_down|
-            1.2.4.29. org_export..............................|orgmode-org_export|
-            1.2.4.30. org_next_visible_heading..|orgmode-org_next_visible_heading|
-            1.2.4.31. org_previous_visible_heading.|orgmode-org_previous_visible_heading|
-            1.2.4.32. org_forward_heading_same_level.|orgmode-org_forward_heading_same_level|
-            1.2.4.33. org_backward_heading_same_level.|orgmode-org_backward_heading_same_level|
-            1.2.4.34. outline_up_heading..............|orgmode-outline_up_heading|
-            1.2.4.35. org_deadline..........................|orgmode-org_deadline|
-            1.2.4.36. org_schedule..........................|orgmode-org_schedule|
-            1.2.4.37. org_time_stamp......................|orgmode-org_time_stamp|
-            1.2.4.38. org_time_stamp_inactive....|orgmode-org_time_stamp_inactive|
-            1.2.4.39. org_clock_in..........................|orgmode-org_clock_in|
-            1.2.4.40. org_clock_out........................|orgmode-org_clock_out|
-            1.2.4.41. org_clock_cancel..................|orgmode-org_clock_cancel|
-            1.2.4.42. org_clock_goto......................|orgmode-org_clock_goto|
-            1.2.4.43. org_set_effort......................|orgmode-org_set_effort|
-            1.2.4.44. org_show_help........................|orgmode-org_show_help|
-        1.2.5. Text objects.................................|orgmode-text_objects|
-            1.2.5.1. inner_heading.........................|orgmode-inner_heading|
-            1.2.5.2. around_heading.......................|orgmode-around_heading|
-            1.2.5.3. inner_subtree.........................|orgmode-inner_subtree|
-            1.2.5.4. around_subtree.......................|orgmode-around_subtree|
-            1.2.5.5. inner_heading_from_root.....|orgmode-inner_heading_from_root|
-            1.2.5.6. around_heading_from_root...|orgmode-around_heading_from_root|
-            1.2.5.7. inner_subtree_from_root.....|orgmode-inner_subtree_from_root|
-            1.2.5.8. around_subtree_from_root...|orgmode-around_subtree_from_root|
-        1.2.6. Dot repeat.....................................|orgmode-dot_repeat|
+            1.2.4.14. org_edit_special..................|orgmode-org_edit_special|
+            1.2.4.15. org_cycle................................|orgmode-org_cycle|
+            1.2.4.16. org_global_cycle..................|orgmode-org_global_cycle|
+            1.2.4.17. org_archive_subtree............|orgmode-org_archive_subtree|
+            1.2.4.18. org_set_tags_command..........|orgmode-org_set_tags_command|
+            1.2.4.19. org_toggle_archive_tag......|orgmode-org_toggle_archive_tag|
+            1.2.4.20. org_do_promote......................|orgmode-org_do_promote|
+            1.2.4.21. org_do_demote........................|orgmode-org_do_demote|
+            1.2.4.22. org_promote_subtree............|orgmode-org_promote_subtree|
+            1.2.4.23. org_demote_subtree..............|orgmode-org_demote_subtree|
+            1.2.4.24. org_meta_return....................|orgmode-org_meta_return|
+            1.2.4.25. org_insert_heading_respect_content.|orgmode-org_insert_heading_respect_content|
+            1.2.4.26. org_insert_todo_heading....|orgmode-org_insert_todo_heading|
+            1.2.4.27. org_insert_todo_heading_respect_content.|orgmode-org_insert_todo_heading_respect_content|
+            1.2.4.28. org_move_subtree_up............|orgmode-org_move_subtree_up|
+            1.2.4.29. org_move_subtree_down........|orgmode-org_move_subtree_down|
+            1.2.4.30. org_export..............................|orgmode-org_export|
+            1.2.4.31. org_next_visible_heading..|orgmode-org_next_visible_heading|
+            1.2.4.32. org_previous_visible_heading.|orgmode-org_previous_visible_heading|
+            1.2.4.33. org_forward_heading_same_level.|orgmode-org_forward_heading_same_level|
+            1.2.4.34. org_backward_heading_same_level.|orgmode-org_backward_heading_same_level|
+            1.2.4.35. outline_up_heading..............|orgmode-outline_up_heading|
+            1.2.4.36. org_deadline..........................|orgmode-org_deadline|
+            1.2.4.37. org_schedule..........................|orgmode-org_schedule|
+            1.2.4.38. org_time_stamp......................|orgmode-org_time_stamp|
+            1.2.4.39. org_time_stamp_inactive....|orgmode-org_time_stamp_inactive|
+            1.2.4.40. org_clock_in..........................|orgmode-org_clock_in|
+            1.2.4.41. org_clock_out........................|orgmode-org_clock_out|
+            1.2.4.42. org_clock_cancel..................|orgmode-org_clock_cancel|
+            1.2.4.43. org_clock_goto......................|orgmode-org_clock_goto|
+            1.2.4.44. org_set_effort......................|orgmode-org_set_effort|
+            1.2.4.45. org_show_help........................|orgmode-org_show_help|
+        1.2.5. Edit Src.........................................|orgmode-edit_src|
+            1.2.5.1. org_edit_src_abort...............|orgmode-org_edit_src_abort|
+            1.2.5.2. org_edit_src_save.................|orgmode-org_edit_src_save|
+            1.2.5.3. org_edit_src_show_help.......|orgmode-org_edit_src_show_help|
+        1.2.6. Text objects.................................|orgmode-text_objects|
+            1.2.6.1. inner_heading.........................|orgmode-inner_heading|
+            1.2.6.2. around_heading.......................|orgmode-around_heading|
+            1.2.6.3. inner_subtree.........................|orgmode-inner_subtree|
+            1.2.6.4. around_subtree.......................|orgmode-around_subtree|
+            1.2.6.5. inner_heading_from_root.....|orgmode-inner_heading_from_root|
+            1.2.6.6. around_heading_from_root...|orgmode-around_heading_from_root|
+            1.2.6.7. inner_subtree_from_root.....|orgmode-inner_subtree_from_root|
+            1.2.6.8. around_subtree_from_root...|orgmode-around_subtree_from_root|
+        1.2.7. Dot repeat.....................................|orgmode-dot_repeat|
     1.3. Document Diagnostics.......................|orgmode-document_diagnostics|
     1.4. Autocompletion...................................|orgmode-autocompletion|
     1.5. Abbreviations.....................................|orgmode-abbreviations|
@@ -165,8 +172,9 @@ TABLE OF CONTENT                                        *orgmode-table_of_conten
     2.  Agenda mappings (#agenda-mappings)
     3.  Capture mappings (#capture-mappings)
     4.  Org mappings (#org-mappings)
-    5.  Text objects (#text-objects)
-    6.  Dot repeat (#dot-repeat)
+    5.  Edit Src mappings (#edit-src)
+    6.  Text objects (#text-objects)
+    7.  Dot repeat (#dot-repeat)
 3.  Document Diagnostics (#document-diagnostics)
 4.  Autocompletion (#autocompletion)
 5.  Abbreviations (#abbreviations)
@@ -333,6 +341,21 @@ default value: `indent`
 Possible values:
 * `indent` - Use default indentation that follows headlines/checkboxes/previous line indent
 * `noindent` - Disable indentation. All lines start from 1st column
+
+ORG_SRC_WINDOW_SETUP                                *orgmode-org_src_window_setup*
+
+type: `string|function`
+default value: "top 16new"
+If the value is a string, it will be run directly as input to `:h vim.cmd`, otherwise if the value is a function it will be called. Both
+values have the responsibility of opening a buffer (within a window) to show the special edit buffer. The content of the buffer will be
+set automatically, so this option only needs to handle opening an empty buffer.
+
+ORG_EDIT_SRC_CONTENT_INDENTATION        *orgmode-org_edit_src_content_indentation*
+
+type: `number`
+default value: 0
+The indent value for content within `SRC` block types beyond the existing indent of the block itself. Only applied when exiting from
+an `org_edit_special` action on a `SRC` block.
 
 ORG_CUSTOM_EXPORTS                                    *orgmode-org_custom_exports*
 
@@ -894,6 +917,13 @@ using the '+' character. Example: `file:/home/user/.config/nvim/init.lua +10`
 * Fallback: If file path, opens the file, otherwise, tries to find the Headline title.
 When date is under the cursor, open the agenda for that day.
 
+ORG_EDIT_SPECIAL                                        *orgmode-org_edit_special*
+
+mapped to: `<Leader>o'`
+Open a source block for editing in a temporary buffer of the associated `filetype`.
+This is useful for editing text with language servers attached, etc. When the buffer is closed, the text of the underlying source block in the original Org file is updated.
+Note that if the Org file that the source block comes from is edited before the special edit buffer is closed, the edits will not be applied. The special edit buffer contents can be recovered from :messages output
+
 ORG_CYCLE                                                      *orgmode-org_cycle*
 
 mapped to: `<TAB>`
@@ -1069,6 +1099,25 @@ These mappings live under `mappings.org`, and can be changed like this:
       }
     })
 <
+
+EDIT SRC                                                        *orgmode-edit_src*
+
+Mappings applied when editing a `SRC` block content via `org_edit_special`.
+
+ORG_EDIT_SRC_ABORT                                    *orgmode-org_edit_src_abort*
+
+mapped to: `<Leader>ok`
+Abort changes made to temporary buffer created from the content of a `SRC` block, see above.
+
+ORG_EDIT_SRC_SAVE                                      *orgmode-org_edit_src_save*
+
+mapped to: `<Leader>ow`
+Apply changes from the special buffer to the source Org buffer
+
+ORG_EDIT_SRC_SHOW_HELP                            *orgmode-org_edit_src_show_help*
+
+mapped to: `g?`
+Show help within the temporary buffer used to edit the content of a `SRC` block.
 
 TEXT OBJECTS                                                *orgmode-text_objects*
 
@@ -1264,6 +1313,7 @@ HIGHLIGHT GROUPS                                        *orgmode-highlight_group
 
 *   The following use vanilla Vim syntax matching, and will work without Treesitter highlighting enabled.
 
+`OrgEditSrcHighlight`: The highlight for the source content in an Org buffer while it is being edited in an edit special buffer
 `OrgAgendaDeadline`: A item deadline in the agenda view
 `OrgAgendaScheduled`: A scheduled item in the agenda view
 `OrgAgendaScheduledPast`: A item past its scheduled date in the agenda view

--- a/lua/orgmode/colors/highlights.lua
+++ b/lua/orgmode/colors/highlights.lua
@@ -36,6 +36,16 @@ function M.link_ts_highlights()
   end
 end
 
+function M.link_highlights()
+  local links = {
+    OrgEditSrcHighlight = 'Visual',
+  }
+
+  for src, def in pairs(links) do
+    vim.cmd(string.format([[hi def link %s %s]], src, def))
+  end
+end
+
 function M.define_agenda_colors()
   local keyword_colors = colors.get_todo_keywords_colors()
   local c = {
@@ -123,6 +133,8 @@ function M.define_highlights()
   if config:ts_highlights_enabled() then
     M.link_ts_highlights()
   end
+
+  M.link_highlights()
 
   local faces = M.define_org_todo_keyword_colors(true)
   return M.define_org_headline_colors(faces)

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -35,6 +35,8 @@ return {
     heading = true,
     plain_list_item = false,
   },
+  org_src_window_setup = 'top 16new',
+  org_edit_src_content_indentation = 0,
   diagnostics = true,
   notifications = {
     enabled = false,
@@ -101,6 +103,7 @@ return {
       org_todo_prev = 'ciT',
       org_toggle_checkbox = '<C-Space>',
       org_open_at_point = '<Leader>oo',
+      org_edit_special = [[<Leader>o']],
       org_cycle = '<TAB>',
       org_global_cycle = '<S-TAB>',
       org_archive_subtree = '<Leader>o$',
@@ -132,6 +135,11 @@ return {
       org_clock_goto = '<leader>oxj',
       org_set_effort = '<leader>oxe',
       org_show_help = 'g?',
+    },
+    edit_src = {
+      org_edit_src_abort = '<Leader>ok',
+      org_edit_src_save = '<Leader>ow',
+      org_edit_src_show_help = 'g?',
     },
     text_objects = {
       inner_heading = 'ih',

--- a/lua/orgmode/config/mappings.lua
+++ b/lua/orgmode/config/mappings.lua
@@ -49,6 +49,7 @@ return {
     org_todo_prev = { 'org_mappings.todo_prev_state' },
     org_toggle_checkbox = { 'org_mappings.toggle_checkbox' },
     org_open_at_point = { 'org_mappings.open_at_point' },
+    org_edit_special = { 'org_mappings.edit_special' },
     org_cycle = { 'org_mappings.cycle' },
     org_global_cycle = { 'org_mappings.global_cycle' },
     org_archive_subtree = { 'org_mappings.archive' },

--- a/lua/orgmode/objects/edit_special/init.lua
+++ b/lua/orgmode/objects/edit_special/init.lua
@@ -1,0 +1,170 @@
+local Files = require('orgmode.parser.files')
+local Help = require('orgmode.objects.help')
+local config = require('orgmode.config')
+local utils = require('orgmode.utils')
+
+local EditSpecial = {
+  context_var = '__org_edit_special_ctx',
+  aborted_var = '__org_edit_special_aborted',
+  block_types = {
+    SRC = require('orgmode.objects.edit_special.types.src'),
+  },
+}
+
+function EditSpecial:new()
+  local o = {}
+
+  setmetatable(o, self)
+  self.__index = self
+
+  return o
+end
+
+function EditSpecial:_parse_position()
+  local nearest_block_node_info = utils.get_nearest_block_node(
+    self.file,
+    { 'name', 'contents', 'parameters' },
+    self.org_pos,
+    true
+  )
+
+  if not nearest_block_node_info then
+    utils.echo_warning('No block node found near cursor')
+    self.block_type = nil
+
+    return
+  end
+
+  self.block_type = nearest_block_node_info.children.name.text:upper()
+
+  if not self.block_types[self.block_type] then
+    utils.echo_warning(string.format([[Edit special for block of type '%s' is not supported]]))
+
+    return
+  end
+
+  return nearest_block_node_info
+end
+
+function EditSpecial:_set_context(bufnr, ctx)
+  vim.api.nvim_buf_set_var(bufnr, self.context_var, ctx)
+end
+
+function EditSpecial:get_context(bufnr)
+  local exists, ctx = pcall(vim.api.nvim_buf_get_var, bufnr or self.org_bufnr, self.context_var)
+  if not exists then
+    error({ message = 'Unable to find context for edit special action' })
+  end
+
+  if not vim.api.nvim_buf_is_valid(ctx.org_bufnr) then
+    error({ message = 'Org buffer associated with edit special no longer valid' })
+  end
+
+  ctx.file = Files.get(ctx.filename)
+  if not ctx.file then
+    error({ message = 'Edit special callback with invalid file: ' .. (ctx.filename or '?') })
+  end
+
+  ctx.start_extmark_pos = vim.api.nvim_buf_get_extmark_by_id(ctx.org_bufnr, ctx.extmark_ns, ctx.start_extmark, {})
+  ctx.end_extmark_pos = vim.api.nvim_buf_get_extmark_by_id(ctx.org_bufnr, ctx.extmark_ns, ctx.end_extmark, {})
+
+  return ctx
+end
+
+function EditSpecial:init_in_org_buffer()
+  self.org_bufnr = vim.api.nvim_get_current_buf()
+  self.org_pos = vim.api.nvim_win_get_cursor(0)
+  self.file = Files.get_current_file()
+end
+
+function EditSpecial:init()
+  local position_info = self:_parse_position()
+  if not position_info then
+    return
+  end
+
+  local bufnr, ctx = self.block_types[self.block_type]
+    :new({
+      file = self.file,
+      org_bufnr = self.org_bufnr,
+      org_pos = self.org_pos,
+      position_info = position_info,
+    })
+    :init()
+
+  self:_set_context(bufnr, ctx)
+
+  utils.buf_keymap(
+    bufnr,
+    'n',
+    config.mappings.edit_src.org_edit_src_abort,
+    string.format([[<Cmd>let b:%s = v:true | q!<CR>]], self.aborted_var)
+  )
+  utils.buf_keymap(
+    bufnr,
+    'n',
+    config.mappings.edit_src.org_edit_src_save,
+    [[<Cmd>lua require('orgmode.objects.edit_special'):new():write()<CR>]]
+  )
+  utils.buf_keymap(
+    bufnr,
+    'n',
+    config.mappings.edit_src.org_edit_src_show_help,
+    [[<Cmd>lua require('orgmode.objects.help').show({ type = 'edit_src' })<CR>]]
+  )
+
+  vim.cmd([[autocmd BufWipeout <buffer> ++once lua require('orgmode').action('org_mappings._edit_special_callback')]])
+end
+
+function EditSpecial:write()
+  local ctx = self:get_context(vim.api.nvim_get_current_buf())
+
+  self.block_types[ctx.block_type]
+    :new({
+      org_bufnr = ctx.org_bufnr,
+      org_pos = ctx.org_pos,
+      file = ctx.file,
+    })
+    :write(ctx)
+end
+
+function EditSpecial:done()
+  local wiped_bufnr = vim.api.nvim_get_current_buf()
+  local ctx = self:get_context(wiped_bufnr)
+
+  vim.api.nvim_buf_del_extmark(ctx.org_bufnr, ctx.extmark_ns, ctx.start_extmark)
+  vim.api.nvim_buf_del_extmark(ctx.org_bufnr, ctx.extmark_ns, ctx.end_extmark)
+
+  local block = self.block_types[ctx.block_type]:new({
+    org_bufnr = ctx.org_bufnr,
+    org_pos = ctx.org_pos,
+    file = ctx.file,
+  })
+
+  local ok, aborted = pcall(vim.api.nvim_buf_get_var, ctx.bufnr, self.aborted_var)
+  if ok and aborted then
+    block:abort()
+    utils.echo_info('Aborting SRC block edits')
+
+    return
+  end
+
+  block:write(ctx)
+
+  vim.schedule(function()
+    local winid = vim.fn.bufwinid(ctx.org_bufnr)
+    if winid == -1 then
+      return
+    end
+
+    if vim.api.nvim_win_get_tabpage(winid) == vim.api.nvim_get_current_tabpage() then
+      vim.api.nvim_set_current_win(winid)
+    end
+  end)
+end
+
+EditSpecial.show_help = function()
+  Help.show_help()
+end
+
+return EditSpecial

--- a/lua/orgmode/objects/edit_special/types/src.lua
+++ b/lua/orgmode/objects/edit_special/types/src.lua
@@ -1,0 +1,154 @@
+local config = require('orgmode.config')
+local es_utils = require('orgmode.objects.edit_special.utils')
+local ts_utils = require('nvim-treesitter.ts_utils')
+local utils = require('orgmode.utils')
+
+local EditSpecialSrc = {
+  extmark_ns = vim.api.nvim_create_namespace('org_edit_special_extmark'),
+  hl_ns = vim.api.nvim_create_namespace('org_edit_special_hl'),
+}
+
+function EditSpecialSrc:new(opts)
+  local o = {}
+
+  o.org_bufnr = opts.org_bufnr
+  o.org_pos = opts.org_pos
+  o.file = opts.file
+  o.src_block = opts.position_info
+
+  setmetatable(o, self)
+  self.__index = self
+
+  return o
+end
+
+function EditSpecialSrc:_update_content(action, block_start_line, content)
+  local block_indent = string.rep(vim.opt.expandtab:get() and ' ' or '\t', config.org_edit_src_content_indentation)
+
+  -- Treesitter doesn't seem to report leading tabs correctly (for example, text offset by a tab character
+  -- will have its column reported as 0)
+  --
+  -- Grab the line itself in order to circumvent this
+  local block_start_line_text = vim.api.nvim_buf_get_lines(
+    self.org_bufnr,
+    block_start_line,
+    block_start_line + 1,
+    false
+  )[1]
+
+  -- Not quite what Emacs does, but assume that the leading space of the entire block is consistent
+  -- and strip that off
+  local whitespace_re = '^[\t%s]+'
+  local block_leading_whitespace = string.match(block_start_line_text, whitespace_re) or ''
+
+  if action == 'remove' then
+    return vim.tbl_map(function(line)
+      local new_line = string.gsub(line, '^' .. block_leading_whitespace, '')
+      if #new_line < #line then
+        new_line = string.gsub(new_line, '^' .. block_indent, '')
+      end
+      return new_line
+    end, content)
+  elseif action == 'add' then
+    return vim.tbl_map(function(line)
+      return line == '' and line or (block_leading_whitespace .. block_indent .. line)
+    end, content)
+  end
+end
+
+function EditSpecialSrc:clear_highlights()
+  vim.api.nvim_buf_clear_namespace(self.org_bufnr, self.hl_ns, 0, -1)
+end
+
+function EditSpecialSrc:_highlight_contents(range)
+  self:clear_highlights()
+  ts_utils.highlight_range(range, self.org_bufnr, self.hl_ns, 'OrgEditSrcHighlight')
+end
+
+function EditSpecialSrc:abort()
+  self:clear_highlights()
+end
+
+function EditSpecialSrc:init()
+  local block_start_line, block_start_col, block_end_line, block_end_col = self.src_block.node:range()
+  local start_extmark = vim.api.nvim_buf_set_extmark(0, self.extmark_ns, block_start_line, block_start_col, {})
+  local end_extmark = vim.api.nvim_buf_set_extmark(0, self.extmark_ns, block_end_line, block_end_col, {})
+
+  -- Only the "content" of the block should change, however we might not have content yet
+  -- so base the range off of the name of the block
+  local ft = self.src_block.children.parameters.text
+
+  local bufnr = es_utils.make_temp_buf()
+  if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+    utils.echo_info('Cancel editing source block, invalid buffer')
+    return
+  end
+
+  vim.cmd('e ' .. vim.fn.tempname())
+
+  local ctx = {
+    block_type = 'SRC',
+    bufnr = bufnr,
+    end_extmark = end_extmark,
+    extmark_ns = self.extmark_ns,
+    filename = self.file.filename,
+    org_bufnr = self.org_bufnr,
+    start_extmark = start_extmark,
+  }
+
+  -- The node content 'text_list' does not include the leading whitespace of the first line of the content,
+  -- grab the entire line instead
+  local content = {}
+  if self.src_block.children.contents then
+    local content_start_line, _, content_end_line = self.src_block.children.contents.node:range()
+    content = vim.api.nvim_buf_get_lines(self.org_bufnr, content_start_line, content_end_line, false)
+  end
+
+  content = self:_update_content('remove', block_start_line, content)
+
+  vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'wipe')
+  vim.api.nvim_buf_set_option(bufnr, 'filetype', ft)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, content)
+  vim.api.nvim_buf_set_option(ctx.bufnr, 'modified', false)
+
+  self:_highlight_contents({
+    block_start_line + 1,
+    block_start_col,
+    block_end_line - 1,
+    block_end_col,
+  })
+
+  return bufnr, ctx
+end
+
+function EditSpecialSrc:write(ctx)
+  local content_start = ctx.start_extmark_pos[1] + 1
+  local content_end = ctx.end_extmark_pos[1] - 1
+
+  if content_start > content_end then
+    -- Handle empty blocks having content written into them
+    content_end = content_start
+  end
+
+  local new_content = vim.api.nvim_buf_get_lines(ctx.bufnr, 0, -1, false)
+  new_content = self:_update_content('add', ctx.start_extmark_pos[1], new_content)
+
+  vim.api.nvim_buf_set_lines(ctx.org_bufnr, content_start, content_end, false, new_content)
+
+  self.file:refresh()
+
+  -- If this is after the special buffer has been closed, our extmarks will have already
+  -- been removed
+  local new_start_extmark = vim.api.nvim_buf_get_extmark_by_id(ctx.org_bufnr, ctx.extmark_ns, ctx.start_extmark, {})
+  local new_end_extmark = vim.api.nvim_buf_get_extmark_by_id(ctx.org_bufnr, ctx.extmark_ns, ctx.end_extmark, {})
+  if #new_start_extmark > 0 and #new_end_extmark > 0 then
+    self:_highlight_contents({
+      new_start_extmark[1] + 1,
+      new_start_extmark[2],
+      new_end_extmark[1] - 1,
+      new_end_extmark[2],
+    })
+  end
+end
+
+return EditSpecialSrc

--- a/lua/orgmode/objects/edit_special/utils.lua
+++ b/lua/orgmode/objects/edit_special/utils.lua
@@ -1,0 +1,19 @@
+local config = require('orgmode.config')
+
+local utils = {}
+
+utils.make_temp_buf = function()
+  local option = config.org_src_window_setup
+  if type(option) == 'string' then
+    vim.cmd(option)
+  elseif type(option) == 'function' then
+    option()
+  else
+    utils.echo_error("Invalid 'org_src_window_setup' setting, value is not a 'string' or 'function'")
+    return false
+  end
+
+  return vim.api.nvim_get_current_buf()
+end
+
+return utils

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -1,13 +1,14 @@
-local ts_utils = require('nvim-treesitter.ts_utils')
 local Calendar = require('orgmode.objects.calendar')
 local Date = require('orgmode.objects.date')
-local TodoState = require('orgmode.objects.todo_state')
-local PriorityState = require('orgmode.objects.priority_state')
-local Hyperlinks = require('orgmode.org.hyperlinks')
-local utils = require('orgmode.utils')
+local EditSpecial = require('orgmode.objects.edit_special')
 local Files = require('orgmode.parser.files')
-local config = require('orgmode.config')
 local Help = require('orgmode.objects.help')
+local Hyperlinks = require('orgmode.org.hyperlinks')
+local PriorityState = require('orgmode.objects.priority_state')
+local TodoState = require('orgmode.objects.todo_state')
+local config = require('orgmode.config')
+local ts_utils = require('nvim-treesitter.ts_utils')
+local utils = require('orgmode.utils')
 
 ---@class OrgMappings
 ---@field capture Capture
@@ -488,6 +489,16 @@ end
 
 function OrgMappings:show_help()
   return Help.show()
+end
+
+function OrgMappings:edit_special()
+  local edit_special = EditSpecial:new()
+  edit_special:init_in_org_buffer()
+  edit_special:init()
+end
+
+function OrgMappings:_edit_special_callback()
+  EditSpecial:new():done()
 end
 
 function OrgMappings:open_at_point()

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -253,8 +253,8 @@ function File:get_opened_unfinished_headlines()
 end
 
 ---@return userdata
-function File:get_node_at_cursor()
-  local cursor = vim.api.nvim_win_get_cursor(0)
+function File:get_node_at_cursor(cursor)
+  cursor = cursor or vim.api.nvim_win_get_cursor(0)
   local cursor_range = { cursor[1] - 1, cursor[2] }
   return self.tree:root():named_descendant_for_range(cursor_range[1], cursor_range[2], cursor_range[1], cursor_range[2])
 end

--- a/tests/plenary/ui/edit_special_src_spec.lua
+++ b/tests/plenary/ui/edit_special_src_spec.lua
@@ -1,0 +1,576 @@
+local config = require('orgmode.config')
+local helpers = require('tests.plenary.ui.helpers')
+
+describe('Edit special operation', function()
+  local start_org_bufnr
+  local expandtab = vim.opt.expandtab
+  local edit_special_indent = config.org_edit_src_content_indentation
+
+  local setup_test = function(o)
+    helpers.load_file_content(o.lines)
+    start_org_bufnr = vim.api.nvim_get_current_buf()
+    vim.fn.cursor(unpack(o.startpos))
+
+    if not o.noenter then
+      vim.cmd([[norm ,o']])
+      assert.are.same(o.ft, vim.api.nvim_buf_get_option(0, 'filetype'))
+      assert.are_not.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+    end
+  end
+
+  after_each(function()
+    pcall(vim.api.nvim_buf_delete, start_org_bufnr, { force = true })
+    vim.opt.expandtab = expandtab
+    config.org_edit_src_content_indentation = edit_special_indent
+  end)
+
+  it('should only pull content from the src block into the edit special buffer', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[norm gg]])
+    assert.are.same('import os', vim.fn.getline('.'))
+    vim.cmd([[norm 2dd]])
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Leading indent configuration is applied
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should add lines from special buffer back to the source org buffer on special buffer wipeout', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    local newline = 'print(os.urandom())'
+    vim.cmd(string.format('norm Go%s', newline))
+    assert.are.same(newline, vim.fn.getline('.'))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Leading indent configuration is applied
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      'print(os.urandom())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should remove lines removed in the special buffer from the source org buffer on wipeout', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd('norm ggdG')
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Leading indent configuration is applied
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      '',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should accept a src block match on the start edge of a src block definiton', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ noenter = true, lines = lines, ft = 'python', startpos = { 2, 1 } })
+    assert.are.same(vim.trim(lines[2]), vim.fn.getline('.'))
+
+    vim.cmd("norm ,o'")
+    assert.are_not.equal(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+  end)
+
+  it('should accept a src block match on the end edge of a src block definiton', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ noenter = true, lines = lines, ft = 'python', startpos = { 6, 9999 } })
+    assert.are.same(vim.trim(lines[6]), vim.fn.getline('.'))
+
+    vim.cmd("norm ,o'")
+    assert.are_not.equal(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+  end)
+
+  it('should not add leading space to empty lines from edit special buffer', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '  #+BEGIN_SRC python',
+      '  import os',
+      '',
+      '  print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    assert.are.same({
+      '* This is my source block',
+      '  #+BEGIN_SRC python',
+      '  import os',
+      '',
+      '  print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should change lines based on extmark as source buffer lines change', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    -- Edit the source buffer
+    vim.cmd('wincmd p')
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    vim.fn.cursor(1, 1)
+    vim.cmd('norm O')
+    vim.cmd('norm O')
+
+    -- Delete all content in the edit special buffer
+    vim.cmd('wincmd p')
+    vim.cmd('norm ggdG')
+    assert.are_not.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Ensure the source buffer content changed correctly
+    --
+    -- Two new lines that we added on top, then all the content from the edit special
+    -- buffer was deleted so that should be applied correctly as well
+    assert.are.same({
+      '',
+      '',
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      '',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should abort despite changes when using abort keymap', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC python',
+      'import os',
+      '',
+      'print(os.uname())',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'python', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    assert.are.same({
+      'import os',
+      '',
+      'print(os.uname())',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    -- Delete all content in the edit special buffer
+    vim.cmd('norm ggdG')
+    vim.cmd('silent! norm ,ok')
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Aborted, lines won't change
+    assert.are.same(lines, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should strip leading spaces from content based on indent of source block no extra indentation', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '  #+BEGIN_SRC sql',
+      '  SELECT *',
+      '  FROM dual;',
+      '  #+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    -- No leading indent on the block content in the edit special buffer
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- No extra indentation when Org buffer is updated
+    assert.are.same({
+      '* This is my source block',
+      '  #+BEGIN_SRC sql',
+      '  SELECT *',
+      '  FROM dual;',
+      '  #+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should strip leading tabs from content based on indent of source block no extra indentation', function()
+    vim.opt.expandtab = false
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\tSELECT *',
+      '\tFROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    -- No leading indent on the block content in the edit special buffer
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- No extra indentation when Org buffer is updated
+    assert.are.same({
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\tSELECT *',
+      '\tFROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should add leading spaces to source block content based on configured indent', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 2
+
+    local lines = {
+      '* This is my source block',
+      '  #+BEGIN_SRC sql',
+      '  SELECT *',
+      '  FROM dual;',
+      '  #+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    -- No leading indent on the block content in the edit special buffer
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Extra spaces are added based on the configured indent value (in this case 2 extra tabs
+    -- beyond the indent of the block itself)
+    assert.are.same({
+      '* This is my source block',
+      '  #+BEGIN_SRC sql',
+      '    SELECT *',
+      '    FROM dual;',
+      '  #+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should add leading tabs to source block content based on configured indent', function()
+    vim.opt.expandtab = false
+    config.org_edit_src_content_indentation = 2
+
+    local lines = {
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\tSELECT *',
+      '\tFROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    -- No leading indent on the block content in the edit special buffer
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Extra tabs are added based on the configured indent value (in this case 2 extra tabs
+    -- beyond the indent of the block itself)
+    assert.are.same({
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\t\t\tSELECT *',
+      '\t\t\tFROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should determine indent character based on expandtab value', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 2
+
+    local lines = {
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\tSELECT *',
+      '\tFROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same(vim.trim(lines[3]), vim.fn.getline('.'))
+
+    -- No leading indent on the block content in the edit special buffer
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Inside of the source block we get spaces instead of tabs, even though the rest
+    -- of the block is indented at a base level with tabs
+    assert.are.same({
+      '* This is my source block',
+      '\t#+BEGIN_SRC sql',
+      '\t  SELECT *',
+      '\t  FROM dual;',
+      '\t#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should properly edit empty blocks', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC sql',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same('', vim.fn.getline('.'))
+
+    -- No content to edit
+    assert.are.same({ '' }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    -- Default is to set content to an empty line
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC sql',
+      '',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+
+  it('should update Org buffer contents when write action occurs in the edit special buffer', function()
+    vim.opt.expandtab = true
+    config.org_edit_src_content_indentation = 0
+
+    local lines = {
+      '* This is my source block',
+      '#+BEGIN_SRC sql',
+      'SELECT *',
+      'FROM dual;',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }
+
+    setup_test({ lines = lines, ft = 'sql', startpos = { 3, 1 } })
+    assert.are.same('SELECT *', vim.fn.getline('.'))
+
+    assert.are.same({
+      'SELECT *',
+      'FROM dual;',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd([[norm gg]])
+    assert.are.same('SELECT *', vim.fn.getline('.'))
+    vim.cmd([[norm dd]])
+
+    -- Lines updated in the original Org buffer after the write action completes
+    vim.cmd([[norm ,ow]])
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC sql',
+      'FROM dual;',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(start_org_bufnr, 0, -1, false))
+
+    vim.cmd([[silent! write | quit]])
+    assert.are.same(start_org_bufnr, vim.api.nvim_get_current_buf())
+
+    assert.are.same({
+      '* This is my source block',
+      '#+BEGIN_SRC sql',
+      'FROM dual;',
+      '#+END_SRC',
+      '* This is unrelated text',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
+end)


### PR DESCRIPTION
This resolves #146.

- [x] Add/fix tests
- [x] Check parity with _Emacs_ functionality
- [x] Investigate using `extmarks`

Right now there's a lot going on in a function that is really only supposed to be handling the mapping, so if you'd rather have this put somewhere else let me know.

The first iteration used an `acwrite` buffer which ends up being a bit cleaner as we aren't creating unecessary files, but most language servers (or at least things in `nvim-lspconfig`) expect a file on disk (e.g. such that a root directory can be found). From this then, I've just gone with `:h tempname()` which solves those problems and is mostly no different.

For now the default is using a simple split as a floating window has some issues with the completion menu (it ends up covering the current cursor position) and I imagine the main use case here is for language servers or similar.

Quick demo:

https://user-images.githubusercontent.com/31262046/141659086-6a954561-cca1-4a4f-bbc8-2a6e9a3f0c6e.mp4

---

Side note, I did some additional edits to have the `utils.echo_*` functions use `:h nvim_echo` only if `:h vim.notify` doesn't exist to follow "standards" but didn't include it in this _PR_ as it is a bit out of scope. I can add that back here if that's something you are alright with changing.