### PR TITLE
fix: allow multiple key mappings to global

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -175,12 +175,14 @@ function Config:setup_mappings(category)
     return
   end
   if not category then
-    if type(self.opts.mappings.global.org_agenda) == "table" then
-        for _, k in ipairs(self.opts.mappings.global.org_agenda) do
-        utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
-        end
+    if type(self.opts.mappings.global.org_agenda) == "string" then
+        keys = { self.opts.mappings.global.org_agenda }
     else
-        utils.keymap('n', self.opts.mappings.global.org_agenda, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
+        keys = self.opts.mappings.global.org_agenda
+    end
+
+    for _, k in ipairs(keys) do
+        utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
     end
 
     utils.keymap('n', self.opts.mappings.global.org_capture, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -175,8 +175,16 @@ function Config:setup_mappings(category)
     return
   end
   if not category then
-    utils.keymap('n', self.opts.mappings.global.org_agenda, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
+    if type(self.opts.mappings.global.org_agenda) == "table" then
+        for _, k in ipairs(self.opts.mappings.global.org_agenda) do
+        utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
+        end
+    else
+        utils.keymap('n', self.opts.mappings.global.org_agenda, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
+    end
+
     utils.keymap('n', self.opts.mappings.global.org_capture, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
+
     return
   end
   if not self.opts.mappings[category] then

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -175,25 +175,21 @@ function Config:setup_mappings(category)
     return
   end
   if not category then
-    agenda_key = self.opts.mappings.global.org_agenda
-    if type(agenda_key) == 'string' then
-      keys = { agenda_key }
-    else
-      keys = agenda_key
+    local agenda_keys = self.opts.mappings.global.org_agenda
+    if type(agenda_keys) == 'string' then
+      agenda_keys = { agenda_keys }
     end
 
-    for _, k in ipairs(keys) do
+    for _, k in ipairs(agenda_keys) do
       utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
     end
 
-    capture_key = self.opts.mappings.global.org_capture
-    if type(capture_key) == 'string' then
-      keys = { capture_key }
-    else
-      keys = capture_key
+    local capture_keys = self.opts.mappings.global.org_capture
+    if type(capture_keys) == 'string' then
+      capture_keys = { capture_keys }
     end
 
-    for _, k in ipairs(keys) do
+    for _, k in ipairs(capture_keys) do
       utils.keymap('n', k, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
     end
 

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -175,17 +175,29 @@ function Config:setup_mappings(category)
     return
   end
   if not category then
-    if type(self.opts.mappings.global.org_agenda) == "string" then
-        keys = { self.opts.mappings.global.org_agenda }
+
+    agenda_key = self.opts.mappings.global.org_agenda
+    if type(agenda_key) == "string" then
+        keys = { agenda_key }
     else
-        keys = self.opts.mappings.global.org_agenda
+        keys = agenda_key
     end
 
     for _, k in ipairs(keys) do
         utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
     end
 
-    utils.keymap('n', self.opts.mappings.global.org_capture, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
+    capture_key = self.opts.mappings.global.org_capture
+    if type(capture_key) == "string" then
+        keys = { capture_key }
+    else
+        keys = capture_key
+    end
+
+    for _, k in ipairs(keys) do
+        utils.keymap('n', k, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
+    end
+
 
     return
   end

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -175,29 +175,27 @@ function Config:setup_mappings(category)
     return
   end
   if not category then
-
     agenda_key = self.opts.mappings.global.org_agenda
-    if type(agenda_key) == "string" then
-        keys = { agenda_key }
+    if type(agenda_key) == 'string' then
+      keys = { agenda_key }
     else
-        keys = agenda_key
+      keys = agenda_key
     end
 
     for _, k in ipairs(keys) do
-        utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
+      utils.keymap('n', k, '<cmd>lua require("orgmode").action("agenda.prompt")<CR>')
     end
 
     capture_key = self.opts.mappings.global.org_capture
-    if type(capture_key) == "string" then
-        keys = { capture_key }
+    if type(capture_key) == 'string' then
+      keys = { capture_key }
     else
-        keys = capture_key
+      keys = capture_key
     end
 
     for _, k in ipairs(keys) do
-        utils.keymap('n', k, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
+      utils.keymap('n', k, '<cmd>lua require("orgmode").action("capture.prompt")<CR>')
     end
-
 
     return
   end


### PR DESCRIPTION
Hello! thank you for this amazing plugin. 
I've encountered one issue while using thils.

The manual says it supports multiple key mappings, so I tried this
```lua
        global = {
            org_agenda = {'gA', '<C-c>a'},
            org_capture = 'gC'
        },
```
However, this gives following error message:

![Screen Shot 2021-11-19 at 12 46 31 PM](https://user-images.githubusercontent.com/3666080/142689801-21ce047b-b8ef-45b3-8aab-74fda1418986.png)

This PR is an attempt to fix this. Thanks!