### PR TITLE
fix org_hide_leading_stars on folded lines

### DIFF
--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -93,7 +93,8 @@ end
 local function foldtext()
   local line = vim.fn.getline(vim.v.foldstart)
   if config.org_hide_leading_stars then
-    return vim.fn.substitute(line, '\\(^\\*+\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '') .. config.org_ellipsis
+    return vim.fn.substitute(line, '\\(^\\*\\+\\)', '\\=repeat(" ", len(submatch(0))-1) . "*"', '')
+      .. config.org_ellipsis
   end
   return line .. config.org_ellipsis
 end


### PR DESCRIPTION
I'm not sure what changed, but hiding leading stars on folded lines stopped working for me. This commit escapes the regex string more explicitly and seems to fix the issue.