### PR TITLE
feature: add support for cookies

### DIFF
--- a/lua/orgmode/org/checkboxes.lua
+++ b/lua/orgmode/org/checkboxes.lua
@@ -4,6 +4,7 @@ local headline_cookie_query = vim.treesitter.parse_query('org', '(headline (cook
 
 local checkboxes = {}
 
+---@param parent userdata
 local function _get_checked_and_total_checkboxes(parent)
   local checked, total = 0, 0
   for child in parent:iter_children() do
@@ -22,6 +23,10 @@ local function _get_checked_and_total_checkboxes(parent)
   return checked, total
 end
 
+---@param action string [on|off|toggle|children]
+---@param checkbox userdata
+---@param checked_children number
+---@param total_children number
 local function _update_checkbox_text(action, checkbox, checked_children, total_children)
   local checkbox_text
   if action == 'on' then
@@ -49,6 +54,9 @@ local function _update_checkbox_text(action, checkbox, checked_children, total_c
   end
 end
 
+---@param cookie userdata
+---@param checked_children number
+---@param total_children number
 local function _update_cookie_text(cookie, checked_children, total_children)
   local cookie_text = vim.treesitter.get_node_text(cookie, 0)
 

--- a/lua/orgmode/org/checkboxes.lua
+++ b/lua/orgmode/org/checkboxes.lua
@@ -4,7 +4,7 @@ local headline_cookie_query = vim.treesitter.parse_query('org', '(headline (cook
 
 local checkboxes = {}
 
-local function _get_cookie_checked_and_total(parent)
+local function _get_checked_and_total_checkboxes(parent)
   local checked, total = 0, 0
   for child in parent:iter_children() do
     if child:type() == 'listitem' then
@@ -96,14 +96,14 @@ function checkboxes.update_checkbox(node, checked_children, total_children)
   local listitem_parent = utils.get_closest_parent_of_type(node:parent(), 'listitem')
   if listitem_parent then
     local list_parent = utils.get_closest_parent_of_type(node, 'list')
-    local checked, total = _get_cookie_checked_and_total(list_parent)
+    local checked, total = _get_checked_and_total_checkboxes(list_parent)
     return checkboxes.update_checkbox(listitem_parent, checked, total)
   end
 
   local section = utils.get_closest_parent_of_type(node:parent(), 'section')
   if section then
     local list_parent = utils.get_closest_parent_of_type(node, 'list')
-    local checked, total = _get_cookie_checked_and_total(list_parent)
+    local checked, total = _get_checked_and_total_checkboxes(list_parent)
     local start_row, _, end_row, _ = section:range()
     for _, headline_cookie in headline_cookie_query:iter_captures(section, 0, start_row, end_row + 1) do
       _update_cookie_text(headline_cookie, checked, total)

--- a/lua/orgmode/org/checkboxes.lua
+++ b/lua/orgmode/org/checkboxes.lua
@@ -1,0 +1,114 @@
+local utils = require('orgmode.utils')
+local ts_utils = require('nvim-treesitter.ts_utils')
+local headline_cookie_query = vim.treesitter.parse_query('org', '(headline (cookie) @cookie)')
+
+local checkboxes = {}
+
+local function _get_cookie_checked_and_total(parent)
+  local checked, total = 0, 0
+  for child in parent:iter_children() do
+    if child:type() == 'listitem' then
+      for listitem_child in child:iter_children() do
+        if listitem_child:type() == 'checkbox' then
+          local checkbox_text = vim.treesitter.get_node_text(listitem_child, 0)
+          if checkbox_text:match('%[[x|X]%]') then
+            checked = checked + 1
+          end
+          total = total + 1
+        end
+      end
+    end
+  end
+  return checked, total
+end
+
+local function _update_checkbox_text(checkbox, checked_children, total_children)
+  local checkbox_text
+  if total_children == nil then -- if the function is called without child information, we toggle the current value
+    checkbox_text = vim.treesitter.get_node_text(checkbox, 0)
+    if checkbox_text:match('%[[xX]%]') then
+      checkbox_text = '[ ]'
+    else
+      checkbox_text = '[X]'
+    end
+  else
+    checkbox_text = '[ ]'
+    if checked_children == total_children then
+      checkbox_text = '[x]'
+    elseif checked_children > 0 then
+      checkbox_text = '[-]'
+    end
+  end
+
+  utils.update_node_text(checkbox, { checkbox_text })
+end
+
+local function _update_cookie_text(cookie, checked_children, total_children)
+  local cookie_text = vim.treesitter.get_node_text(cookie, 0)
+
+  if total_children == nil then
+    checked_children, total_children = 0, 0
+  end
+
+  local new_cookie
+  if cookie_text:find('/') then
+    new_cookie = string.format('[%d/%d]', checked_children, total_children)
+  else
+    if total_children > 0 then
+      new_cookie = string.format('[%d%%%%]', (100 * checked_children) / total_children)
+    else
+      new_cookie = '[0%%%]'
+    end
+  end
+  cookie_text = cookie_text:gsub('%[.*%]', new_cookie)
+  utils.update_node_text(cookie, { cookie_text })
+end
+
+function checkboxes.update_checkbox(node, checked_children, total_children)
+  if not node then
+    node = utils.get_closest_parent_of_type(ts_utils.get_node_at_cursor(0), 'listitem')
+    if not node then
+      return
+    end
+  end
+
+  local checkbox
+  local cookie
+  for child in node:iter_children() do
+    if child:type() == 'checkbox' then
+      checkbox = child
+    elseif child:type() == 'itemtext' then
+      local c_child = child:named_child(0)
+      if c_child and c_child:type() == 'cookie' then
+        cookie = c_child
+      end
+    end
+  end
+
+  if checkbox then
+    _update_checkbox_text(checkbox, checked_children, total_children)
+  end
+
+  if cookie then
+    _update_cookie_text(cookie, checked_children, total_children)
+  end
+
+  local listitem_parent = utils.get_closest_parent_of_type(node:parent(), 'listitem')
+  if listitem_parent then
+    local list_parent = utils.get_closest_parent_of_type(node, 'list')
+    local checked, total = _get_cookie_checked_and_total(list_parent)
+    return checkboxes.update_checkbox(listitem_parent, checked, total)
+  end
+
+  local section = utils.get_closest_parent_of_type(node:parent(), 'section')
+  if section then
+    local list_parent = utils.get_closest_parent_of_type(node, 'list')
+    local checked, total = _get_cookie_checked_and_total(list_parent)
+    local start_row, _, end_row, _ = section:range()
+    for _, headline_cookie in headline_cookie_query:iter_captures(section, 0, start_row, end_row + 1) do
+      _update_cookie_text(headline_cookie, checked, total)
+    end
+  end
+end
+
+return checkboxes

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -434,7 +434,7 @@ function OrgMappings:handle_return(suffix)
       vim.lsp.util.apply_text_edits(text_edits, 0)
 
       vim.fn.cursor(end_row + 2 + (add_empty_line and 1 or 0), 0) -- +1 for 0 index and +1 for next line
-      syntax.update_checkbox(ts_utils.get_next_node(list_item))
+      checkboxes.update_checkbox(ts_utils.get_next_node(list_item))
       vim.cmd([[startinsert!]])
     end
   end

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -8,7 +8,7 @@ local utils = require('orgmode.utils')
 local Files = require('orgmode.parser.files')
 local config = require('orgmode.config')
 local Help = require('orgmode.objects.help')
-local syntax = require('orgmode.org.syntax')
+local checkboxes = require('orgmode.org.checkboxes')
 
 ---@class OrgMappings
 ---@field capture Capture
@@ -144,7 +144,7 @@ function OrgMappings:global_cycle()
 end
 
 function OrgMappings:toggle_checkbox()
-  syntax.update_checkbox()
+  checkboxes.update_checkbox()
 end
 
 function OrgMappings:timestamp_up_day()

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -144,7 +144,7 @@ function OrgMappings:global_cycle()
 end
 
 function OrgMappings:toggle_checkbox()
-  checkboxes.update_checkbox()
+  checkboxes.update_checkbox('toggle')
 end
 
 function OrgMappings:timestamp_up_day()
@@ -397,8 +397,7 @@ function OrgMappings:handle_return(suffix)
     if checkbox then
       table.insert(text_edits, {
         range = range,
-        -- we initialize the checkbox checked, then use update_checkbox to toggle it off and update the tree
-        newText = checkbox .. ' [X] \n',
+        newText = checkbox .. ' [ ] \n',
       })
     elseif plain_list then
       table.insert(text_edits, {
@@ -434,7 +433,7 @@ function OrgMappings:handle_return(suffix)
       vim.lsp.util.apply_text_edits(text_edits, 0)
 
       vim.fn.cursor(end_row + 2 + (add_empty_line and 1 or 0), 0) -- +1 for 0 index and +1 for next line
-      checkboxes.update_checkbox(ts_utils.get_next_node(list_item))
+      checkboxes.update_checkbox('off', ts_utils.get_next_node(list_item))
       vim.cmd([[startinsert!]])
     end
   end

--- a/lua/orgmode/org/syntax.lua
+++ b/lua/orgmode/org/syntax.lua
@@ -1,5 +1,10 @@
 local Files = require('orgmode.parser.files')
 local config = require('orgmode.config')
+local utils = require('orgmode.utils')
+local ts_utils = require('nvim-treesitter.ts_utils')
+
+local checkbox_query = vim.treesitter.parse_query('org', '(list (listitem (checkbox) @checkbox))')
+local headline_cookie_query = vim.treesitter.parse_query('org', '(headline (cookie) @cookie)')
 
 local function load_code_blocks()
   local file = vim.api.nvim_buf_get_name(0)
@@ -36,7 +41,115 @@ local function add_todo_keywords_to_spellgood()
   end
 end
 
+local function _get_cookie_checked_and_total(parent)
+  local parent_type = parent:type()
+  local start_row, _, end_row, _ = parent:range()
+  local checked, total = 0, 0
+  for _, checkbox in checkbox_query:iter_captures(parent, 0, start_row, end_row + 1) do
+    local closest_parent = utils.get_closest_parent_of_type(checkbox, parent_type)
+    if closest_parent and closest_parent == parent then -- only count direct children
+      local checkbox_text = vim.treesitter.get_node_text(checkbox, 0)
+      if checkbox_text:match('%[[x|X]%]') then
+        checked = checked + 1
+      end
+      total = total + 1
+    end
+  end
+
+  return checked, total
+end
+
+local function _update_checkbox_text(checkbox, checked_children, total_children)
+  local checkbox_text
+  if total_children == nil then -- if the function is called without child information, we toggle the current value
+    checkbox_text = vim.treesitter.get_node_text(checkbox, 0)
+    if checkbox_text:match('%[[xX]%]') then
+      checkbox_text = '[ ]'
+    else
+      checkbox_text = '[X]'
+    end
+  else
+    checkbox_text = '[ ]'
+    if checked_children == total_children then
+      checkbox_text = '[x]'
+    elseif checked_children > 0 then
+      checkbox_text = '[-]'
+    end
+  end
+
+  utils.update_node_text(checkbox, { checkbox_text })
+end
+
+local function _update_cookie_text(cookie, checked_children, total_children)
+  local cookie_text = vim.treesitter.get_node_text(cookie, 0)
+
+  if total_children == nil then
+    checked_children, total_children = 0, 0
+  end
+
+  local new_cookie
+  if cookie_text:find('/') then
+    new_cookie = string.format('[%d/%d]', checked_children, total_children)
+  else
+    if total_children > 0 then
+      new_cookie = string.format('[%d%%%%]', (100 * checked_children) / total_children)
+    else
+      new_cookie = '[0%%%]'
+    end
+  end
+  cookie_text = cookie_text:gsub('%[.*%]', new_cookie)
+  utils.update_node_text(cookie, { cookie_text })
+end
+
+local function update_checkbox(node, checked_children, total_children)
+  if not node then
+    node = utils.get_closest_parent_of_type(ts_utils.get_node_at_cursor(0), 'listitem')
+    if not node then
+      return
+    end
+  end
+
+  local checkbox
+  local cookie
+  for child in node:iter_children() do
+    if child:type() == 'checkbox' then
+      checkbox = child
+    elseif child:type() == 'itemtext' then
+      local c_child = child:named_child(0)
+      if c_child and c_child:type() == 'cookie' then
+        cookie = c_child
+      end
+    end
+  end
+
+  if checkbox then
+    _update_checkbox_text(checkbox, checked_children, total_children)
+  end
+
+  if cookie then
+    _update_cookie_text(cookie, checked_children, total_children)
+  end
+
+  local listitem_parent = utils.get_closest_parent_of_type(node:parent(), 'listitem')
+  if listitem_parent then
+    local list_parent = utils.get_closest_parent_of_type(node, 'list')
+    local checked, total = _get_cookie_checked_and_total(list_parent)
+    return update_checkbox(listitem_parent, checked, total)
+  end
+
+  local section = utils.get_closest_parent_of_type(node:parent(), 'section')
+  if section then
+    local list_parent = utils.get_closest_parent_of_type(node, 'list')
+    local checked, total = _get_cookie_checked_and_total(list_parent)
+    local start_row, _, end_row, _ = section:range()
+    for _, headline_cookie in headline_cookie_query:iter_captures(section, 0, start_row, end_row + 1) do
+      _update_cookie_text(headline_cookie, checked, total)
+    end
+  end
+end
+
 return {
   load_code_blocks = load_code_blocks,
   add_todo_keywords_to_spellgood = add_todo_keywords_to_spellgood,
+  update_checkbox = update_checkbox,
 }

--- a/lua/orgmode/org/syntax.lua
+++ b/lua/orgmode/org/syntax.lua
@@ -1,10 +1,5 @@
 local Files = require('orgmode.parser.files')
 local config = require('orgmode.config')
-local utils = require('orgmode.utils')
-local ts_utils = require('nvim-treesitter.ts_utils')
-
-local checkbox_query = vim.treesitter.parse_query('org', '(list (listitem (checkbox) @checkbox))')
-local headline_cookie_query = vim.treesitter.parse_query('org', '(headline (cookie) @cookie)')
 
 local function load_code_blocks()
   local file = vim.api.nvim_buf_get_name(0)
@@ -41,115 +36,7 @@ local function add_todo_keywords_to_spellgood()
   end
 end
 
-local function _get_cookie_checked_and_total(parent)
-  local parent_type = parent:type()
-  local start_row, _, end_row, _ = parent:range()
-  local checked, total = 0, 0
-  for _, checkbox in checkbox_query:iter_captures(parent, 0, start_row, end_row + 1) do
-    local closest_parent = utils.get_closest_parent_of_type(checkbox, parent_type)
-    if closest_parent and closest_parent == parent then -- only count direct children
-      local checkbox_text = vim.treesitter.get_node_text(checkbox, 0)
-      if checkbox_text:match('%[[x|X]%]') then
-        checked = checked + 1
-      end
-      total = total + 1
-    end
-  end
-
-  return checked, total
-end
-
-local function _update_checkbox_text(checkbox, checked_children, total_children)
-  local checkbox_text
-  if total_children == nil then -- if the function is called without child information, we toggle the current value
-    checkbox_text = vim.treesitter.get_node_text(checkbox, 0)
-    if checkbox_text:match('%[[xX]%]') then
-      checkbox_text = '[ ]'
-    else
-      checkbox_text = '[X]'
-    end
-  else
-    checkbox_text = '[ ]'
-    if checked_children == total_children then
-      checkbox_text = '[x]'
-    elseif checked_children > 0 then
-      checkbox_text = '[-]'
-    end
-  end
-
-  utils.update_node_text(checkbox, { checkbox_text })
-end
-
-local function _update_cookie_text(cookie, checked_children, total_children)
-  local cookie_text = vim.treesitter.get_node_text(cookie, 0)
-
-  if total_children == nil then
-    checked_children, total_children = 0, 0
-  end
-
-  local new_cookie
-  if cookie_text:find('/') then
-    new_cookie = string.format('[%d/%d]', checked_children, total_children)
-  else
-    if total_children > 0 then
-      new_cookie = string.format('[%d%%%%]', (100 * checked_children) / total_children)
-    else
-      new_cookie = '[0%%%]'
-    end
-  end
-  cookie_text = cookie_text:gsub('%[.*%]', new_cookie)
-  utils.update_node_text(cookie, { cookie_text })
-end
-
-local function update_checkbox(node, checked_children, total_children)
-  if not node then
-    node = utils.get_closest_parent_of_type(ts_utils.get_node_at_cursor(0), 'listitem')
-    if not node then
-      return
-    end
-  end
-
-  local checkbox
-  local cookie
-  for child in node:iter_children() do
-    if child:type() == 'checkbox' then
-      checkbox = child
-    elseif child:type() == 'itemtext' then
-      local c_child = child:named_child(0)
-      if c_child and c_child:type() == 'cookie' then
-        cookie = c_child
-      end
-    end
-  end
-
-  if checkbox then
-    _update_checkbox_text(checkbox, checked_children, total_children)
-  end
-
-  if cookie then
-    _update_cookie_text(cookie, checked_children, total_children)
-  end
-
-  local listitem_parent = utils.get_closest_parent_of_type(node:parent(), 'listitem')
-  if listitem_parent then
-    local list_parent = utils.get_closest_parent_of_type(node, 'list')
-    local checked, total = _get_cookie_checked_and_total(list_parent)
-    return update_checkbox(listitem_parent, checked, total)
-  end
-
-  local section = utils.get_closest_parent_of_type(node:parent(), 'section')
-  if section then
-    local list_parent = utils.get_closest_parent_of_type(node, 'list')
-    local checked, total = _get_cookie_checked_and_total(list_parent)
-    local start_row, _, end_row, _ = section:range()
-    for _, headline_cookie in headline_cookie_query:iter_captures(section, 0, start_row, end_row + 1) do
-      _update_cookie_text(headline_cookie, checked, total)
-    end
-  end
-end
-
 return {
   load_code_blocks = load_code_blocks,
   add_todo_keywords_to_spellgood = add_todo_keywords_to_spellgood,
-  update_checkbox = update_checkbox,
 }

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -321,6 +321,13 @@ function utils.get_node_text(node, content)
   end
 end
 
+---@param node userdata
+---@param text string[]
+function utils.update_node_text(node, text)
+  local start_row, start_col, end_row, end_col = node:range()
+  vim.api.nvim_buf_set_text(0, start_row, start_col, end_row, end_col, text)
+end
+
 ---@param node table
 ---@param type string
 ---@return table


### PR DESCRIPTION
Adds support for cookies in headlines and lists

https://orgmode.org/manual/Checkboxes.html

Add `[/]` or `[%]` to a headline or list with sub-items, and it should display the cookie.
It needs this to work https://github.com/milisims/tree-sitter-org/pull/11

fix #81

---

orgmode also supports this for TODO states if the cookie is in the headline. This PR does not cover that.
