### PR TITLE
Bug Fix: emacs html export

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -245,6 +245,11 @@ Determine if blank line should be prepended when:
 * Adding heading via `org_meta_return` and `org_insert_*` mappings
 * Adding a list item via `org_meta_return`
 
+#### **emacs_config**
+*type*: `table`<br />
+*default value*: `{ executable_path = 'emacs', configure_path='$HOME/.emacs.d/init.el' }`<br />
+Set configuration for your emacs. This is useful for having the emacs export properly pickup your emacs config and plugins.
+
 ### Agenda settings
 
 #### **org_deadline_warning_days**

--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -26,6 +26,7 @@ CONTENTS                                                        *orgmode-content
             1.2.1.15. org_custom_exports..............|orgmode-org_custom_exports|
             1.2.1.16. org_time_stamp_rounding_minutes.|orgmode-org_time_stamp_rounding_minutes|
             1.2.1.17. org_blank_before_new_entry.|orgmode-org_blank_before_new_entry|
+            1.2.1.18. emacs_config..........................|orgmode-emacs_config|
         1.2.2. Agenda settings...........................|orgmode-agenda_settings|
             1.2.2.1. org_deadline_warning_days.|orgmode-org_deadline_warning_days|
             1.2.2.2. org_agenda_span.....................|orgmode-org_agenda_span|
@@ -429,6 +430,12 @@ default value: `{ heading = true, plain_list_item = false }`
 Determine if blank line should be prepended when:
 * Adding heading via `org_meta_return` and `org_insert_*` mappings
 * Adding a list item via `org_meta_return`
+
+EMACS_CONFIG                                                *orgmode-emacs_config*
+
+type: `table`
+default value: `{ executable_path = 'emacs', configure_path='$HOME/.emacs.d/init.el' }`
+Set configuration for your emacs. This is useful for having the emacs export properly pickup your emacs config and plugins.
 
 AGENDA SETTINGS                                          *orgmode-agenda_settings*
 

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -152,4 +152,8 @@ return {
       around_subtree_from_root = 'OR',
     },
   },
+  emacs_config = {
+    executable_path = 'emacs',
+    config_path = '$HOME/.emacs.d/init.el',
+  },
 }

--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -108,14 +108,18 @@ end
 function Export.emacs(format, extension)
   local file = vim.api.nvim_buf_get_name(0)
   local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. extension
-  if vim.fn.executable('emacs') ~= 1 then
+  local emacs = config.emacs_config.executable_path
+  local emacs_config_path = config.emacs_config.config_path
+  if vim.fn.executable(emacs) ~= 1 then
     return utils.echo_error('emacs executable not found. Make sure emacs is in $PATH.')
   end
 
   local cmd = {
-    'emacs',
+    emacs,
     '-nw',
     '--batch',
+    '--load',
+    emacs_config_path,
     string.format('--visit=%s', file),
     string.format('--funcall=%s', format),
   }


### PR DESCRIPTION
emacs html export requires the htmlize package which is no longer included in the latest orgmode for emacs (I'm using emacs 26.3). If you export to html -> emacs with a code block it breaks since it uses htmlize to syntax highlight. (btw, get the same error in emacs when trying to export)

That being said, when I install the htmlize package in emacs, exporting from emacs works, but still fails from orgmode.nvim. The reason is because the `--batch` flag doesn't source your emacs configuration and any packages you have. This PR adds a `--load` switch to the export command that points at your emacs config. This tells emacs running in batch mode to load a specific startup file, in this case the main emacs config.

> **NOTE** Changes beyond this. We may want to have a config option for specifying the location of an emacs config to use, since its not standard on all systems.

I know its failing tests/formatting. Just want to make sure this is an acceptable fix before polishing this PR. (See NOTE above for one outstanding issue)