### PR TITLE
fix(mappings): Default offset encoding when handling <CR> press

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -7,6 +7,7 @@ local Hyperlinks = require('orgmode.org.hyperlinks')
 local PriorityState = require('orgmode.objects.priority_state')
 local TodoState = require('orgmode.objects.todo_state')
 local config = require('orgmode.config')
+local constants = require('orgmode.utils.constants')
 local ts_utils = require('nvim-treesitter.ts_utils')
 local utils = require('orgmode.utils')
 
@@ -440,7 +441,7 @@ function OrgMappings:handle_return(suffix)
     end
 
     if #text_edits > 0 then
-      vim.lsp.util.apply_text_edits(text_edits, 0)
+      vim.lsp.util.apply_text_edits(text_edits, 0, constants.default_offset_encoding)
 
       vim.fn.cursor(end_row + 2 + (add_empty_line and 1 or 0), 0) -- +1 for 0 index and +1 for next line
       vim.cmd([[startinsert!]])

--- a/lua/orgmode/utils/constants.lua
+++ b/lua/orgmode/utils/constants.lua
@@ -1,0 +1,3 @@
+return {
+  default_offset_encoding = 'utf-16',
+}


### PR DESCRIPTION
Per [here](https://github.com/neovim/neovim/issues/14090) there are a number of functions that now require specifying an `offset_encoding`. Some examples of other updates to things like [nvim-cmp](https://github.com/hrsh7th/nvim-cmp/commit/614e00de2424d1c19a3f653120b63d5b2d10b21a) and [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim/commit/e5f71b759618f0c9613d0f7cda86d2124ce1361e).

Looking at all of those functions, this is the only one that I found that gets used in this plugin. As we do not have any attached clients, I do not see this being a huge issue (although I am also pretty naive in terms of the usage and impact) to follow the "norm" and use `utf-16` as a default.