### PR TITLE
Add '%b' as variable for file-basename when parsing archive-location

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -242,6 +242,7 @@ function Config:parse_archive_location(file, archive_loc)
   -- TODO: Support archive to headline
   local parts = vim.split(archive_loc, '::')
   local archive_location = vim.trim(parts[1])
+  archive_location = archive_location:gsub('%%b', vim.fn.fnamemodify(file, ':t'))
   if archive_location:find('%%s') then
     return string.format(archive_location, file)
   end


### PR DESCRIPTION
closes #206

@kristijanhusak let me know what you think of this. I found [this TODO](https://github.com/nvim-orgmode/orgmode/blob/master/lua/orgmode/config/init.lua#L242) about archiving to headlines. Any specific plans on how to implement that, while I'm at it?