### PR TITLE
Priority sort for same day items

### DIFF
--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -11,11 +11,6 @@ local function sort_by_date_or_priority_or_category(a, b)
   if not a.headline_date:is_same(b.headline_date) then
     return a.headline_date:is_before(b.headline_date)
   end
-  print(a.headline)
-  print(a.headline:get_priority_sort_value())
-  print(b.headline)
-  print(b.headline:get_priority_sort_value())
-  print("\n")
   if a.headline:get_priority_sort_value() ~= b.headline:get_priority_sort_value() then
     return a.headline:get_priority_sort_value() > b.headline:get_priority_sort_value()
   end

--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -7,9 +7,12 @@ local AgendaItem = require('orgmode.agenda.agenda_item')
 local AgendaFilter = require('orgmode.agenda.filter')
 local utils = require('orgmode.utils')
 
-local function sort_by_date_or_category(a, b)
+local function sort_by_date_or_priority_or_category(a, b)
   if not a.headline_date:is_same(b.headline_date) then
     return a.headline_date:is_before(b.headline_date)
+  end
+  if a.headline:get_priority_sort_value() ~= b.headline:get_priority_sort_value() then
+    return a.headline:get_priority_sort_value() > b.headline:get_priority_sort_value()
   end
   return a.index < b.index
 end
@@ -28,7 +31,7 @@ local function sort_agenda_items(agenda_items)
       if not b.headline_date.date_only then
         return false
       end
-      return sort_by_date_or_category(a, b)
+      return sort_by_date_or_priority_or_category(a, b)
     end
 
     if a.is_same_day and not b.is_same_day then
@@ -43,11 +46,7 @@ local function sort_agenda_items(agenda_items)
       end
     end
 
-    if a.headline:get_priority_sort_value() ~= b.headline:get_priority_sort_value() then
-      return a.headline:get_priority_sort_value() > b.headline:get_priority_sort_value()
-    end
-
-    return sort_by_date_or_category(a, b)
+    return sort_by_date_or_priority_or_category(a, b)
   end)
   return agenda_items
 end

--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -11,6 +11,11 @@ local function sort_by_date_or_priority_or_category(a, b)
   if not a.headline_date:is_same(b.headline_date) then
     return a.headline_date:is_before(b.headline_date)
   end
+  print(a.headline)
+  print(a.headline:get_priority_sort_value())
+  print(b.headline)
+  print(b.headline:get_priority_sort_value())
+  print("\n")
   if a.headline:get_priority_sort_value() ~= b.headline:get_priority_sort_value() then
     return a.headline:get_priority_sort_value() > b.headline:get_priority_sort_value()
   end


### PR DESCRIPTION
Moved priority sorting in the `sort_by_date_or_category` function so it gets done for same day items as well. Renamed func to `sort_by_date_or_priority_or_category`, a bit wordy but more adequate :slightly_smiling_face: 

Before:

![image](https://user-images.githubusercontent.com/15214418/160298668-2cbabf7e-5df9-4ea4-bb7a-3b545fa66c21.png)

After:

![image](https://user-images.githubusercontent.com/15214418/160300103-5716b2d6-0d72-4729-bbf8-c1f84442fb62.png)

<details>
  <summary>Contents of test2.org</summary>

  ```org
* TODO [#A] Task 1
  SCHEDULED: <2022-03-27 нед>
* TODO [#B] Task 2
  SCHEDULED: <2022-03-27 нед>
* TODO [#C] Task 3
  SCHEDULED: <2022-03-27 нед>
* TODO [#A] Task 4
  SCHEDULED: <2022-03-27 нед>
* TODO [#B] Task 5
  SCHEDULED: <2022-03-27 нед>
* TODO [#C] Task 6
  SCHEDULED: <2022-03-27 нед>
```
</details>