### PR TITLE
Prepare for 0.7 release to use default ftplugin

### DIFF
--- a/ftdetect/filetype.lua
+++ b/ftdetect/filetype.lua
@@ -1,8 +1,10 @@
-if vim.filetype then
-  vim.filetype.add({
-    extension = {
-      org = 'org',
-      org_archive = 'org',
-    },
-  })
+if vim.fn.has('nvim-0.7') ~= 1 then
+  if vim.filetype then
+    vim.filetype.add({
+      extension = {
+        org = 'org',
+        org_archive = 'org',
+      },
+    })
+  end
 end

--- a/ftdetect/org.vim
+++ b/ftdetect/org.vim
@@ -1,1 +1,3 @@
-autocmd BufRead,BufNewFile *.org set filetype=org
+if !has('nvim-0.7')
+  autocmd BufRead,BufNewFile *.org set filetype=org
+endif

--- a/ftdetect/org_archive.vim
+++ b/ftdetect/org_archive.vim
@@ -1,1 +1,3 @@
-autocmd BufRead,BufNewFile *.org_archive set filetype=org
+if !has('nvim-0.7')
+  autocmd BufRead,BufNewFile *.org_archive set filetype=org
+endif


### PR DESCRIPTION
Neovim 0.7 can detect org filetypes by [default](https://github.com/neovim/neovim/pull/17939). Once 0.7 is officially released, the ftdetect directory in the plugin is redundant 