### PR TITLE
Reveal headline when jumping from agenda

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -220,6 +220,7 @@ function Agenda:switch_to_item()
   end
   vim.cmd('edit ' .. vim.fn.fnameescape(item.file))
   vim.fn.cursor(item.file_position, 0)
+  vim.cmd([[normal! zv]])
 end
 
 function Agenda:change_todo_state()
@@ -349,6 +350,7 @@ function Agenda:goto_item()
 
   vim.cmd('edit ' .. vim.fn.fnameescape(item.file))
   vim.fn.cursor(item.file_position, 0)
+  vim.cmd([[normal! zv]])
 end
 
 function Agenda:filter()


### PR DESCRIPTION
When jumping to a headline from the agenda with `<CR>` or `<Tab>` and if the file
is folded, just setting the cursor doesn't reveal the folds.

By calling `zv` after positioning the cursor we reveal up to the cursor
