### PR TITLE
Fix lowercase src highlighting

### DIFF
--- a/lua/orgmode/objects/edit_special/init.lua
+++ b/lua/orgmode/objects/edit_special/init.lua
@@ -7,7 +7,7 @@ local EditSpecial = {
   context_var = '__org_edit_special_ctx',
   aborted_var = '__org_edit_special_aborted',
   block_types = {
-    SRC = require('orgmode.objects.edit_special.types.src'),
+    src = require('orgmode.objects.edit_special.types.src'),
   },
 }
 

--- a/lua/orgmode/objects/edit_special/init.lua
+++ b/lua/orgmode/objects/edit_special/init.lua
@@ -7,6 +7,7 @@ local EditSpecial = {
   context_var = '__org_edit_special_ctx',
   aborted_var = '__org_edit_special_aborted',
   block_types = {
+    SRC = require('orgmode.objects.edit_special.types.src'),
     src = require('orgmode.objects.edit_special.types.src'),
   },
 }
@@ -33,7 +34,7 @@ function EditSpecial:_parse_position()
   self.block_type = nearest_block_node_info.children.name.text:upper()
 
   if not self.block_types[self.block_type] then
-    utils.echo_warning(string.format([[Edit special for block of type '%s' is not supported]]))
+    utils.echo_warning(string.format([[Edit special for block of type '%s' is not supported]], self.block_type))
 
     return
   end

--- a/lua/orgmode/org/autocompletion/omni.lua
+++ b/lua/orgmode/org/autocompletion/omni.lua
@@ -3,8 +3,8 @@ local config = require('orgmode.config')
 local Hyperlinks = require('orgmode.org.hyperlinks')
 
 local data = {
-  directives = { '#+TITLE', '#+AUTHOR', '#+EMAIL', '#+NAME', '#+FILETAGS', '#+ARCHIVE', '#+OPTIONS' },
-  begin_blocks = { '#+BEGIN_SRC', '#+END_SRC', '#+BEGIN_EXAMPLE', '#+END_EXAMPLE' },
+  directives = { '#+title', '#+author', '#+email', '#+name', '#+filetags', '#+archive', '#+options' },
+  begin_blocks = { '#+begin_src', '#+end_src', '#+begin_example', '#+end_example' },
   properties = { ':PROPERTIES:', ':END:', ':LOGBOOK:', ':STYLE:', ':REPEAT_TO_STATE:', ':CUSTOM_ID:', ':CATEGORY:' },
   metadata = { 'DEADLINE:', 'SCHEDULED:', 'CLOSED:' },
 }

--- a/lua/orgmode/org/autocompletion/omni.lua
+++ b/lua/orgmode/org/autocompletion/omni.lua
@@ -51,7 +51,7 @@ local tags = {
 }
 
 local filetags = {
-  line_rgx = vim.regex([[\c^\#+FILETAGS:\s\+]]),
+  line_rgx = vim.regex([[\c^\#+filetags:\s\+]]),
   rgx = vim.regex([[:\([0-9A-Za-z_%@\#]*\)$]]),
   extra_cond = function(line, _)
     return not string.find(line, 'file:.*$')

--- a/lua/orgmode/org/syntax.lua
+++ b/lua/orgmode/org/syntax.lua
@@ -26,7 +26,7 @@ local function load_code_blocks()
   for _, ft in ipairs(loaded_filetypes) do
     vim.cmd(
       string.format(
-        [[syntax region orgmodeBlockSrc%s matchgroup=comment start="^\s*#+BEGIN_SRC\ %s\s*.*$" end="^\s*#+END_SRC\s*$" keepend contains=@orgmodeBlockSrc%s,org_block_delimiter]],
+        [[syntax region orgmodeBlockSrc%s matchgroup=comment start="^\s*#+\(BEGIN_SRC\|begin_src\)\ %s\s*.*$" end="^\s*#+\(END_SRC\|end_src\)\s*$" keepend contains=@orgmodeBlockSrc%s,org_block_delimiter]],
         ft,
         ft,
         ft

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -364,7 +364,9 @@ end
 
 ---@private
 function File:_parse_source_code_filetypes()
-  local blocks = self:get_ts_matches('(block name: (expr) @name parameter: (expr) @parameters (#match? @name "(src|SRC)"))')
+  local blocks = self:get_ts_matches(
+    '(block name: (expr) @name parameter: (expr) @parameters (#match? @name "(src|SRC)"))'
+  )
   local source_code_filetypes = {}
   for _, item in ipairs(blocks) do
     local ft = item.parameters and item.parameters.text

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -364,7 +364,7 @@ end
 
 ---@private
 function File:_parse_source_code_filetypes()
-  local blocks = self:get_ts_matches('(block name: (expr) @name parameter: (expr) @parameters (#eq? @name "SRC"))')
+  local blocks = self:get_ts_matches('(block name: (expr) @name parameter: (expr) @parameters (#match? @name "(src|SRC)"))')
   local source_code_filetypes = {}
   for _, item in ipairs(blocks) do
     local ft = item.parameters and item.parameters.text

--- a/syntax/org.vim
+++ b/syntax/org.vim
@@ -51,8 +51,8 @@ let s:ts_highlight = luaeval('require("orgmode.config"):ts_highlights_enabled()'
 if !s:ts_highlight
   runtime syntax/org_legacy.vim
 else
-  syntax match org_block_delimiter /^\s*#+BEGIN_.*/
-  syntax match org_block_delimiter /^\s*#+END_.*/
+  syntax match org_block_delimiter /^\s*#+\(BEGIN_\|begin_\).*/
+  syntax match org_block_delimiter /^\s*#+\(END_\|end_\).*/
   hi default link org_block_delimiter Comment
 endif
 

--- a/syntax/org_legacy.vim
+++ b/syntax/org_legacy.vim
@@ -70,10 +70,10 @@ syntax match org_list_item /.*$/ contained contains=org_bold,org_italic,org_unde
 
 " Block Delimiters: {{{1
 syntax case ignore
-syntax match  org_block_delimiter /^\s*#+BEGIN_.*/
-syntax match  org_block_delimiter /^\s*#+END_.*/
+syntax match  org_block_delimiter /^\s*#+\(BEGIN_\|begin_\).*/
+syntax match  org_block_delimiter /^\s*#+\(END_\|end_\).*/
 syntax match  org_key_identifier  /^#+[^ ]*:/
-syntax match  org_title           /^#+TITLE:.*/  contains=org_key_identifier
+syntax match  org_title           /^#+\(TITLE\|title\):.*/  contains=org_key_identifier
 hi def link org_block_delimiter Comment
 hi def link org_key_identifier  Comment
 hi def link org_title           Title
@@ -87,9 +87,9 @@ hi def link org_title           Title
 syntax match  org_verbatim /^\s*>.*/
 syntax match  org_code     /^\s*:.*/
 
-syntax region org_verbatim start="^\s*#+BEGIN_.*"      end="^\s*#+END_.*"      keepend contains=org_block_delimiter
-syntax region org_code     start="^\s*#+BEGIN_SRC"     end="^\s*#+END_SRC"     keepend contains=org_block_delimiter
-syntax region org_code     start="^\s*#+BEGIN_EXAMPLE" end="^\s*#+END_EXAMPLE" keepend contains=org_block_delimiter
+syntax region org_verbatim start="^\s*#+\(BEGIN_\|begin_\).*"      end="^\s*#+\(END_\|end\).*"      keepend contains=org_block_delimiter
+syntax region org_code     start="^\s*#+\(BEGIN_SRC\|begin_src\)"     end="^\s*#+\(END_SRC\|end_src\)"     keepend contains=org_block_delimiter
+syntax region org_code     start="^\s*#+\(BEGIN_EXAMPLE\|begin_example\)" end="^\s*#+\(END_EXAMPLE\|end_example\)" keepend contains=org_block_delimiter
 
 " Properties: {{{1
 syn region Error matchgroup=org_properties_delimiter start=/^\s*:PROPERTIES:\s*$/ end=/^\s*:END:\s*$/ contains=org_property keepend

--- a/syntax/org_legacy.vim
+++ b/syntax/org_legacy.vim
@@ -87,7 +87,7 @@ hi def link org_title           Title
 syntax match  org_verbatim /^\s*>.*/
 syntax match  org_code     /^\s*:.*/
 
-syntax region org_verbatim start="^\s*#+\(BEGIN_\|begin_\).*"      end="^\s*#+\(END_\|end\).*"      keepend contains=org_block_delimiter
+syntax region org_verbatim start="^\s*#+\(BEGIN_\|begin_\).*"      end="^\s*#+\(END_\|end_\).*"      keepend contains=org_block_delimiter
 syntax region org_code     start="^\s*#+\(BEGIN_SRC\|begin_src\)"     end="^\s*#+\(END_SRC\|end_src\)"     keepend contains=org_block_delimiter
 syntax region org_code     start="^\s*#+\(BEGIN_EXAMPLE\|begin_example\)" end="^\s*#+\(END_EXAMPLE\|end_example\)" keepend contains=org_block_delimiter
 

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -148,7 +148,7 @@ describe('Autocompletion', function()
     result = OrgmodeOmniCompletion(0, '#+')
     assert.are.same(directives, result)
 
-    result = OrgmodeOmniCompletion(0, '#+B')
+    result = OrgmodeOmniCompletion(0, '#+b')
     assert.are.same({
       { menu = '[Org]', word = '#+begin_src' },
       { menu = '[Org]', word = '#+begin_example' },
@@ -189,11 +189,11 @@ describe('Autocompletion', function()
       { menu = '[Org]', word = ':PRIVATE:' },
     }, result)
 
-    mock_line(api, '#+FILETAGS: ')
+    mock_line(api, '#+filetags: ')
     result = OrgmodeOmniCompletion(0, '')
     assert.are.same({}, result)
 
-    mock_line(api, '#+FILETAGS: :')
+    mock_line(api, '#+filetags: :')
     result = OrgmodeOmniCompletion(0, ':')
     assert.are.same({
       { menu = '[Org]', word = ':OFFICE:' },

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -131,17 +131,17 @@ describe('Autocompletion', function()
     -- Directives
     result = OrgmodeOmniCompletion(0, '#')
     local directives = {
-      { menu = '[Org]', word = '#+TITLE' },
-      { menu = '[Org]', word = '#+AUTHOR' },
-      { menu = '[Org]', word = '#+EMAIL' },
-      { menu = '[Org]', word = '#+NAME' },
-      { menu = '[Org]', word = '#+FILETAGS' },
-      { menu = '[Org]', word = '#+ARCHIVE' },
-      { menu = '[Org]', word = '#+OPTIONS' },
-      { menu = '[Org]', word = '#+BEGIN_SRC' },
-      { menu = '[Org]', word = '#+END_SRC' },
-      { menu = '[Org]', word = '#+BEGIN_EXAMPLE' },
-      { menu = '[Org]', word = '#+END_EXAMPLE' },
+      { menu = '[Org]', word = '#+title' },
+      { menu = '[Org]', word = '#+author' },
+      { menu = '[Org]', word = '#+email' },
+      { menu = '[Org]', word = '#+name' },
+      { menu = '[Org]', word = '#+filetags' },
+      { menu = '[Org]', word = '#+archive' },
+      { menu = '[Org]', word = '#+options' },
+      { menu = '[Org]', word = '#+begin_src' },
+      { menu = '[Org]', word = '#+end_src' },
+      { menu = '[Org]', word = '#+begin_example' },
+      { menu = '[Org]', word = '#+end_example' },
     }
     assert.are.same(directives, result)
 
@@ -150,8 +150,8 @@ describe('Autocompletion', function()
 
     result = OrgmodeOmniCompletion(0, '#+B')
     assert.are.same({
-      { menu = '[Org]', word = '#+BEGIN_SRC' },
-      { menu = '[Org]', word = '#+BEGIN_EXAMPLE' },
+      { menu = '[Org]', word = '#+begin_src' },
+      { menu = '[Org]', word = '#+begin_example' },
     }, result)
 
     -- Headline

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -49,7 +49,7 @@ describe('Autocompletion', function()
     result = OrgmodeOmniCompletion(1, '')
     assert.are.same(0, result)
 
-    mock_line(api, '#+AR')
+    mock_line(api, '#+ar')
     result = OrgmodeOmniCompletion(1, '')
     assert.are.same(0, result)
 


### PR DESCRIPTION
Closes #86 by adding the lowercase `begin_src/end_src` to the syntax match group for language highlighting
