### PR TITLE
Make menu prompts more uniformly

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -65,7 +65,6 @@ end
 function Agenda:prompt()
   self.filters:reset()
   return utils.menu('Press key for an agenda command', {
-    { label = '', separator = '-', length = 34 },
     {
       label = 'Agenda for current week or day',
       key = 'a',

--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -56,6 +56,7 @@ function Capture:_create_prompt(templates)
   local menu_items = self:_create_menu_items(templates)
   table.insert(menu_items, { label = '', key = '', separator = '-' })
   table.insert(menu_items, { label = 'Quit', key = 'q' })
+  table.insert(menu_items, { label = '', separator = ' ', length = 1 })
 
   return utils.menu('Select a capture template', menu_items, 'Template key')
 end

--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -11,7 +11,6 @@ function Export.prompt()
       key = key,
       action = function()
         local opts = {
-          { label = '', separator = '-', length = 34 },
           {
             label = string.format('emacs (%s)', org_cmd),
             key = 'e',
@@ -38,7 +37,6 @@ function Export.prompt()
   end
 
   local opts = {
-    { label = '', separator = '-', length = 34 },
     submenu('h', 'Export to HTML file (emacs/pandoc)', 'org-html-export-to-html', 'html'),
     submenu('l', 'Export to LaTex file (emacs/pandoc)', 'org-latex-export-to-latex', 'tex', {
       {

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -144,7 +144,7 @@ function utils.concat(first, second, unique)
 end
 
 function utils.menu(title, items, prompt)
-  local content = { title .. ':' }
+  local content = { title .. '\\n' .. string.rep('-', #title) }
   local valid_keys = {}
   for _, item in ipairs(items) do
     if item.separator then


### PR DESCRIPTION
The separator char for the capture prompt in Emacs appears to be `=` ([here](https://youtu.be/qCdScs4YO8k?t=98)) but I think we can get by making them all `-` instead. As every menu should use a separator after the title, we can also get rid of some magic numbers.