### PR TITLE
Fix todo-keywords containing hyphens in agenda views

### DIFF
--- a/lua/orgmode/parser/section.lua
+++ b/lua/orgmode/parser/section.lua
@@ -625,7 +625,7 @@ function Section:_parse_todo_keyword()
   end
 
   local keyword_info = todo_keywords.KEYS[keyword]
-  self.title = self.title:gsub('^' .. keyword .. '%s*', '')
+  self.title = self.title:gsub('^' .. vim.pesc(keyword) .. '%s*', '')
   self.todo_keyword = {
     value = keyword,
     type = keyword_info.type,


### PR DESCRIPTION
fixes #246 

Turns out hyphens are special in Lua 'regex' patterns: [stackoverflow](https://stackoverflow.com/a/29379912/5356183)
And a hyphen is not the only special character. I suggest we also add a pattern-validation function to `orgmode.utils` like suggested in the answer.