### PR TITLE
Fix for setting to DONE with no plan.

### DIFF
--- a/lua/orgmode/treesitter/headline.lua
+++ b/lua/orgmode/treesitter/headline.lua
@@ -82,6 +82,9 @@ end
 
 function Headline:dates()
   local plan = self:plan()
+  if plan == nil then
+    return {}
+  end
   local dates = {}
   for _, node in ipairs(ts_utils.get_named_children(plan)) do
     local name = vim.treesitter.query.get_node_text(node:named_child(0), 0)


### PR DESCRIPTION
I am seeing the following error when using `cit` to change a task to "DONE".

```
[orgmode] ...plugged/nvim-treesitter/lua/nvim-treesitter/ts_utils.lua:148: attempt to index local 'node' (a nil value)
```

Note, this change only fixes the immediate issue (the nil reference). I think there is still a disconnect with what is in the docs. If a schedule or deadline does not already exist on the headline, even when `org_log_done == 'time'`, a "CLOSED:" entry will not be added. 