### PR TITLE
Fixed time stamp based sorting

### DIFF
--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -28,6 +28,9 @@ local function sort_agenda_items(agenda_items)
       if not b.headline_date.date_only and a.headline_date.date_only then
         return false
       end
+      if not a.headline_date.date_only and not b.headline_date.date_only then
+        return a.headline_date:is_before(b.headline_date)
+      end
       return sort_by_date_or_priority_or_category(a, b)
     end
 


### PR DESCRIPTION
For some reason time stamp based sorting was failing (some merge broke it?):

![Screenshot_20220607_102617](https://user-images.githubusercontent.com/15214418/172333803-b66fa866-af19-4b89-a226-1d229365a3de.png)

I've fixed this adding a precedence sort if both items are on the same day and have a time stamp.