### PR TITLE
Resolve path for `default_notes_file` to support symlinks.

### DIFF
--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -134,7 +134,7 @@ end
 ---@private
 function Capture:_get_refile_vars()
   local template = vim.api.nvim_buf_get_var(0, 'org_template') or {}
-  local file = vim.fn.fnamemodify(template.target or config.org_default_notes_file, ':p')
+  local file = vim.fn.resolve(vim.fn.fnamemodify(template.target or config.org_default_notes_file, ':p'))
   local lines = vim.api.nvim_buf_get_lines(0, 0, -1, true)
   local org_file = File.from_content(lines, 'capture', utils.current_file_path())
   local item = nil

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -69,7 +69,7 @@ end
 function Config:get_all_files()
   local all_filenames = {}
   if self.opts.org_default_notes_file and self.opts.org_default_notes_file ~= '' then
-    local default_full_path = vim.fn.expand(self.opts.org_default_notes_file, ':p')
+    local default_full_path = vim.fn.resolve(vim.fn.expand(self.opts.org_default_notes_file, ':p'))
     table.insert(all_filenames, default_full_path)
   end
   local files = self.opts.org_agenda_files


### PR DESCRIPTION
This fixes an issue where you would end up with two references to the default file when using symlinks, since all other files had their symlinks resolved but not this.
This led to having one reference to the full path of the file, and one reference to the symlink, giving symptoms such as duplicate entries in the agenda.

This fix is very similar to [this](https://github.com/nvim-orgmode/orgmode/commit/60a101616bbf9b0dec11e44a46e8395509fc373e) one.
