### PR TITLE
Fix overriding of global fillchars

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -22,7 +22,7 @@ function OrgmodeFormatExpr()
   return luaeval('require("orgmode.org.format")()')
 endfunction
 
-setlocal fillchars=fold:\ 
+setlocal fillchars+=fold:\ 
 setlocal foldmethod=expr
 setlocal foldexpr=OrgmodeFoldExpr()
 setlocal foldtext=OrgmodeFoldText()


### PR DESCRIPTION
currently the plugin will override the user's `fillchars` when setting `fold:c`, this unintentionally set's everything else beck to their defaults (such as `horiz:c` or `vert:c` for example)