### PR TITLE
Fix wrong tag_column indentation

### DIFF
--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -21,7 +21,7 @@ return {
   org_priority_default = 'B',
   org_priority_lowest = 'C',
   org_archive_location = '%s_archive::',
-  org_tags_column = 80,
+  org_tags_column = -80,
   org_use_tag_inheritance = true,
   org_tags_exclude_from_inheritance = {},
   org_hide_leading_stars = false,

--- a/lua/orgmode/treesitter/headline.lua
+++ b/lua/orgmode/treesitter/headline.lua
@@ -68,7 +68,7 @@ function Headline:set_tags(tags)
       to_col = math.abs(to_col) - tags_width
     end
 
-    local spaces = math.max(to_col - (vim.api.nvim_strwidth(txt) + stars:len()) - tags_width, 1)
+    local spaces = math.max(to_col - (vim.api.nvim_strwidth(txt) + stars:len()), 1)
     text = string.rep(' ', spaces) .. tags
   end
 

--- a/tests/plenary/ui/mappings_spec.lua
+++ b/tests/plenary/ui/mappings_spec.lua
@@ -1604,7 +1604,7 @@ describe('Mappings', function()
     }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
   end)
 
-  it('should update headline cookies when updaing checkboxes', function()
+  it('should update headline cookies when updating checkboxes', function()
     helpers.load_file_content({
       '* Test orgmode [/]',
       '- [ ] checkbox item',


### PR DESCRIPTION
The `tags_width` was being subtracted in any case, which resulted in flushright alignment per default. When a negative `tag_column` value was given, the `tags_width` was subtracted twice, resulting in a broken alignment.
