### PR TITLE
refactor(export): flexible exporters generation

### DIFF
--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -4,172 +4,205 @@ local config = require('orgmode.config')
 ---@class Export
 local Export = {}
 
-function Export.prompt()
-  local submenu = function(key, label, org_cmd, extension, additional_opts)
-    return {
-      label = label,
-      key = key,
-      action = function()
-        local opts = {
-          {
-            label = string.format('emacs (%s)', org_cmd),
-            key = 'e',
-            action = function()
-              return Export.emacs(org_cmd, extension)
-            end,
-          },
-        }
-        if additional_opts then
-          opts = utils.concat(opts, additional_opts)
-        end
-        table.insert(opts, {
-          label = 'pandoc',
-          key = 'p',
-          action = function()
-            return Export.pandoc(extension)
-          end,
-        })
-        table.insert(opts, { label = 'Quit', key = 'q' })
-
-        return utils.menu(label .. ' via', opts, label .. ' via')
-      end,
-    }
-  end
-
-  local opts = {
-    submenu('h', 'Export to HTML file (emacs/pandoc)', 'org-html-export-to-html', 'html'),
-    submenu('l', 'Export to LaTex file (emacs/pandoc)', 'org-latex-export-to-latex', 'tex', {
-      {
-        label = 'emacs beamer (org-beamer-export-to-latex)',
-        key = 'b',
-        action = function()
-          return Export.emacs('org-beamer-export-to-latex', 'tex')
-        end,
-      },
-    }),
-    submenu('p', 'Export to PDF file (emacs/pandoc)', 'org-latex-export-to-pdf', 'pdf', {
-      {
-        label = 'emacs beamer (org-beamer-export-to-pdf)',
-        key = 'b',
-        action = function()
-          return Export.emacs('org-beamer-export-to-pdf', 'pdf')
-        end,
-      },
-    }),
-    {
-      label = 'Export to Markdown file (emacs)',
-      key = 'm',
-      action = function()
-        return Export.emacs('org-md-export-to-markdown', 'md')
-      end,
-    },
-    {
-      label = 'Export to iCalendar file (emacs)',
-      key = 'i',
-      action = function()
-        return Export.emacs('org-icalendar-export-to-ics', 'ics')
-      end,
-    },
-  }
-
-  if not vim.tbl_isempty(config.org_custom_exports) then
-    for key, data in pairs(config.org_custom_exports) do
-      table.insert(opts, {
-        key = key,
-        label = data.label,
-        action = function()
-          return data.action(Export._exporter)
-        end,
-      })
-    end
-  end
-
-  table.insert(opts, { label = 'Quit', key = 'q' })
-  table.insert(opts, { label = '', separator = ' ', length = 1 })
-
-  return utils.menu('Export options', opts, 'Export command')
-end
-
----@param extension string
-function Export.pandoc(extension)
-  local file = utils.current_file_path()
-  local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. extension
-  if vim.fn.executable('pandoc') ~= 1 then
-    return utils.echo_error('pandoc executable not found. Make sure pandoc is in $PATH.')
-  end
-
-  return Export._exporter({ 'pandoc', file, '-o', target }, target)
-end
-
----@param format string
----@param extension string
-function Export.emacs(format, extension)
-  local file = utils.current_file_path()
-  local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. extension
-  local emacs = config.emacs_config.executable_path
-  local emacs_config_path = config.emacs_config.config_path
-  if vim.fn.executable(emacs) ~= 1 then
-    return utils.echo_error('emacs executable not found. Make sure emacs is in $PATH.')
-  end
-
-  local cmd = {
-    emacs,
-    '-nw',
-    '--batch',
-    '--load',
-    emacs_config_path,
-    string.format('--visit=%s', file),
-    string.format('--funcall=%s', format),
-  }
-
-  return Export._exporter(cmd, target, nil, function(err)
-    table.insert(err, '')
-    table.insert(err, 'NOTE: Emacs export issues are most likely caused by bad or missing emacs configuration.')
-    return utils.echo_error(string.format('Export error:\n%s', table.concat(err, '\n')))
-  end)
-end
-
 ---@param cmd table
 ---@param on_success? function
 ---@param on_error? function
 function Export._exporter(cmd, target, on_success, on_error)
-  utils.echo_info('Exporting...')
-  local output = {}
-  local read_data = function(_, data, _)
-    for _, i in ipairs(data) do
-      if i and i ~= '' then
-        table.insert(output, i)
-      end
-    end
-  end
-  vim.fn.jobstart(cmd, {
-    on_stdout = read_data,
-    on_stderr = read_data,
-    on_exit = function(_, code, _)
-      if code ~= 0 then
-        if on_error then
-          return on_error(output)
+    utils.echo_info('Exporting...')
+    local output = {}
+    local read_data = function(_, data, _)
+        for _, i in ipairs(data) do
+            if i and i ~= '' then
+                table.insert(output, i)
+            end
         end
-        return utils.echo_error(string.format('Export error:\n%s', table.concat(output, '\n')))
-      end
+    end
+    vim.fn.jobstart(cmd, {
+        on_stdout = read_data,
+        on_stderr = read_data,
+        on_exit = function(_, code, _)
+            if code ~= 0 then
+                if on_error then
+                    return on_error(output)
+                end
+                return utils.echo_error(string.format('Export error:\n%s', table.concat(output, '\n')))
+            end
 
-      if on_success then
-        return on_success(output)
-      end
+            if on_success then
+                return on_success(output)
+            end
 
-      return utils.menu(string.format('Exported to %s', target), {
-        { label = '', separator = '-', length = 34 },
-        {
-          label = 'Yes',
-          key = 'y',
-          action = function()
-            return utils.open(target)
-          end,
-        },
-        { label = 'No', key = 'n' },
-      }, 'Open')
-    end,
-  })
+            return utils.menu(string.format('Exported to %s', target), {
+                { label = '', separator = '-', length = 34 },
+                {
+                    label = 'Yes',
+                    key = 'y',
+                    action = function()
+                        return utils.open(target)
+                    end,
+                },
+                { label = 'No', key = 'n' },
+            }, 'Open')
+        end,
+    })
+end
+
+---@param opts table
+function Export.pandoc(opts)
+    local file = utils.current_file_path()
+    local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
+    if vim.fn.executable('pandoc') ~= 1 then
+        return utils.echo_error('pandoc executable not found. Make sure pandoc is in $PATH.')
+    end
+
+    local cmd = { 'pandoc', file, '-o', target }
+    if opts.format then
+        table.insert(cmd, "-t")
+        table.insert(cmd, opts.format)
+    end
+
+    return Export._exporter(cmd, target)
+end
+
+---@param opts table
+function Export.emacs(opts)
+    local file = utils.current_file_path()
+    local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
+    local emacs = config.emacs_config.executable_path
+    local emacs_config_path = config.emacs_config.config_path
+    if vim.fn.executable(emacs) ~= 1 then
+        return utils.echo_error('emacs executable not found. Make sure emacs is in $PATH.')
+    end
+
+    local cmd = {
+        emacs,
+        '-nw',
+        '--batch',
+        '--load',
+        emacs_config_path,
+        string.format('--visit=%s', file),
+        string.format('--funcall=%s', opts.command),
+    }
+
+    return Export._exporter(cmd, target, nil, function(err)
+        table.insert(err, '')
+        table.insert(err, 'NOTE: Emacs export issues are most likely caused by bad or missing emacs configuration.')
+        return utils.echo_error(string.format('Export error:\n%s', table.concat(err, '\n')))
+    end)
+end
+
+Export.emacs_beamer = Export.emacs
+
+function Export.prompt()
+    local keys = {
+        emacs = "e",
+        emacs_beamer = "b",
+        pandoc = "p",
+    }
+
+    local submenu = function(key, label, extension, exporters)
+        local commands = {
+            {
+                label = 'quit', key = 'q',
+            }
+        }
+
+        local exporters_names = {}
+
+        for name, opts in pairs(exporters) do
+            table.insert(exporters_names, name)
+
+            opts.extension = extension
+
+            local exporter_label = name
+            if opts.command then
+                exporter_label = string.format("%s (%s)", name, opts.command)
+            else
+                exporter_label = name
+            end
+
+            table.insert(commands, {
+                label = exporter_label,
+                key = keys[name],
+                action = function()
+                    return Export[name](opts)
+                end
+            })
+        end
+
+        table.sort(commands, function(lhs, rhs)
+            return lhs.label < rhs.label
+        end)
+
+        table.sort(exporters_names, function(lhs, rhs)
+            return lhs < rhs
+        end)
+
+        return {
+            label = string.format("%s (%s)", label, table.concat(exporters_names, "/")),
+            key = key,
+            action = function()
+                return utils.menu(label .. ' via', commands, label .. ' via')
+            end,
+        }
+    end
+
+    local opts = {
+        submenu('h', 'Export to HTML file', 'html', {
+            emacs = {
+                command = 'org-html-export-to-html',
+            },
+            pandoc = {},
+        }),
+        submenu('l', 'Export to LaTex file', 'tex', {
+            emacs = {
+                command = 'org-latex-export-to-latex'
+            },
+            emacs_beamer = {
+                command = 'org-beamer-export-to-latex'
+            },
+            pandoc = {},
+        }),
+        submenu('p', 'Export to PDF file', 'pdf', {
+            emacs = {
+                command = 'org-latex-export-to-pdf'
+            },
+            emacs_beamer = {
+                command = 'org-beamer-export-to-pdf',
+            },
+            pandoc = {},
+        }),
+        submenu('m', 'Export to Markdown file', 'md', {
+            emacs = {
+                command = 'org-md-export-to-markdown'
+            },
+            pandoc = {
+                format = "gfm"
+            }
+        }),
+        submenu('i', 'Export to iCalendar file', 'ics', {
+            emacs = {
+                command = 'org-icalendar-export-to-ics'
+            }
+        })
+    }
+
+    if not vim.tbl_isempty(config.org_custom_exports) then
+        for key, data in pairs(config.org_custom_exports) do
+            table.insert(opts, {
+                key = key,
+                label = data.label,
+                action = function()
+                    return data.action(Export._exporter)
+                end,
+            })
+        end
+    end
+
+    table.insert(opts, { label = 'quit', key = 'q' })
+    table.insert(opts, { label = '', separator = ' ', length = 1 })
+
+    return utils.menu('Export options', opts, 'Export command')
 end
 
 return Export

--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -8,201 +8,202 @@ local Export = {}
 ---@param on_success? function
 ---@param on_error? function
 function Export._exporter(cmd, target, on_success, on_error)
-    utils.echo_info('Exporting...')
-    local output = {}
-    local read_data = function(_, data, _)
-        for _, i in ipairs(data) do
-            if i and i ~= '' then
-                table.insert(output, i)
-            end
-        end
+  utils.echo_info('Exporting...')
+  local output = {}
+  local read_data = function(_, data, _)
+    for _, i in ipairs(data) do
+      if i and i ~= '' then
+        table.insert(output, i)
+      end
     end
-    vim.fn.jobstart(cmd, {
-        on_stdout = read_data,
-        on_stderr = read_data,
-        on_exit = function(_, code, _)
-            if code ~= 0 then
-                if on_error then
-                    return on_error(output)
-                end
-                return utils.echo_error(string.format('Export error:\n%s', table.concat(output, '\n')))
-            end
+  end
+  vim.fn.jobstart(cmd, {
+    on_stdout = read_data,
+    on_stderr = read_data,
+    on_exit = function(_, code, _)
+      if code ~= 0 then
+        if on_error then
+          return on_error(output)
+        end
+        return utils.echo_error(string.format('Export error:\n%s', table.concat(output, '\n')))
+      end
 
-            if on_success then
-                return on_success(output)
-            end
+      if on_success then
+        return on_success(output)
+      end
 
-            return utils.menu(string.format('Exported to %s', target), {
-                { label = '', separator = '-', length = 34 },
-                {
-                    label = 'Yes',
-                    key = 'y',
-                    action = function()
-                        return utils.open(target)
-                    end,
-                },
-                { label = 'No', key = 'n' },
-            }, 'Open')
-        end,
-    })
+      return utils.menu(string.format('Exported to %s', target), {
+        { label = '', separator = '-', length = 34 },
+        {
+          label = 'Yes',
+          key = 'y',
+          action = function()
+            return utils.open(target)
+          end,
+        },
+        { label = 'No', key = 'n' },
+      }, 'Open')
+    end,
+  })
 end
 
 ---@param opts table
 function Export.pandoc(opts)
-    local file = utils.current_file_path()
-    local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
-    if vim.fn.executable('pandoc') ~= 1 then
-        return utils.echo_error('pandoc executable not found. Make sure pandoc is in $PATH.')
-    end
+  local file = utils.current_file_path()
+  local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
+  if vim.fn.executable('pandoc') ~= 1 then
+    return utils.echo_error('pandoc executable not found. Make sure pandoc is in $PATH.')
+  end
 
-    local cmd = { 'pandoc', file, '-o', target }
-    if opts.format then
-        table.insert(cmd, "-t")
-        table.insert(cmd, opts.format)
-    end
+  local cmd = { 'pandoc', file, '-o', target }
+  if opts.format then
+    table.insert(cmd, '-t')
+    table.insert(cmd, opts.format)
+  end
 
-    return Export._exporter(cmd, target)
+  return Export._exporter(cmd, target)
 end
 
 ---@param opts table
 function Export.emacs(opts)
-    local file = utils.current_file_path()
-    local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
-    local emacs = config.emacs_config.executable_path
-    local emacs_config_path = config.emacs_config.config_path
-    if vim.fn.executable(emacs) ~= 1 then
-        return utils.echo_error('emacs executable not found. Make sure emacs is in $PATH.')
-    end
+  local file = utils.current_file_path()
+  local target = vim.fn.fnamemodify(file, ':p:r') .. '.' .. opts.extension
+  local emacs = config.emacs_config.executable_path
+  local emacs_config_path = config.emacs_config.config_path
+  if vim.fn.executable(emacs) ~= 1 then
+    return utils.echo_error('emacs executable not found. Make sure emacs is in $PATH.')
+  end
 
-    local cmd = {
-        emacs,
-        '-nw',
-        '--batch',
-        '--load',
-        emacs_config_path,
-        string.format('--visit=%s', file),
-        string.format('--funcall=%s', opts.command),
-    }
+  local cmd = {
+    emacs,
+    '-nw',
+    '--batch',
+    '--load',
+    emacs_config_path,
+    string.format('--visit=%s', file),
+    string.format('--funcall=%s', opts.command),
+  }
 
-    return Export._exporter(cmd, target, nil, function(err)
-        table.insert(err, '')
-        table.insert(err, 'NOTE: Emacs export issues are most likely caused by bad or missing emacs configuration.')
-        return utils.echo_error(string.format('Export error:\n%s', table.concat(err, '\n')))
-    end)
+  return Export._exporter(cmd, target, nil, function(err)
+    table.insert(err, '')
+    table.insert(err, 'NOTE: Emacs export issues are most likely caused by bad or missing emacs configuration.')
+    return utils.echo_error(string.format('Export error:\n%s', table.concat(err, '\n')))
+  end)
 end
 
 Export.emacs_beamer = Export.emacs
 
 function Export.prompt()
-    local keys = {
-        emacs = "e",
-        emacs_beamer = "b",
-        pandoc = "p",
+  local keys = {
+    emacs = 'e',
+    emacs_beamer = 'b',
+    pandoc = 'p',
+  }
+
+  local submenu = function(key, label, extension, exporters)
+    local commands = {
+      {
+        label = 'quit',
+        key = 'q',
+      },
     }
 
-    local submenu = function(key, label, extension, exporters)
-        local commands = {
-            {
-                label = 'quit', key = 'q',
-            }
-        }
+    local exporters_names = {}
 
-        local exporters_names = {}
+    for name, opts in pairs(exporters) do
+      table.insert(exporters_names, name)
 
-        for name, opts in pairs(exporters) do
-            table.insert(exporters_names, name)
+      opts.extension = extension
 
-            opts.extension = extension
+      local exporter_label = name
+      if opts.command then
+        exporter_label = string.format('%s (%s)', name, opts.command)
+      else
+        exporter_label = name
+      end
 
-            local exporter_label = name
-            if opts.command then
-                exporter_label = string.format("%s (%s)", name, opts.command)
-            else
-                exporter_label = name
-            end
-
-            table.insert(commands, {
-                label = exporter_label,
-                key = keys[name],
-                action = function()
-                    return Export[name](opts)
-                end
-            })
-        end
-
-        table.sort(commands, function(lhs, rhs)
-            return lhs.label < rhs.label
-        end)
-
-        table.sort(exporters_names, function(lhs, rhs)
-            return lhs < rhs
-        end)
-
-        return {
-            label = string.format("%s (%s)", label, table.concat(exporters_names, "/")),
-            key = key,
-            action = function()
-                return utils.menu(label .. ' via', commands, label .. ' via')
-            end,
-        }
+      table.insert(commands, {
+        label = exporter_label,
+        key = keys[name],
+        action = function()
+          return Export[name](opts)
+        end,
+      })
     end
 
-    local opts = {
-        submenu('h', 'Export to HTML file', 'html', {
-            emacs = {
-                command = 'org-html-export-to-html',
-            },
-            pandoc = {},
-        }),
-        submenu('l', 'Export to LaTex file', 'tex', {
-            emacs = {
-                command = 'org-latex-export-to-latex'
-            },
-            emacs_beamer = {
-                command = 'org-beamer-export-to-latex'
-            },
-            pandoc = {},
-        }),
-        submenu('p', 'Export to PDF file', 'pdf', {
-            emacs = {
-                command = 'org-latex-export-to-pdf'
-            },
-            emacs_beamer = {
-                command = 'org-beamer-export-to-pdf',
-            },
-            pandoc = {},
-        }),
-        submenu('m', 'Export to Markdown file', 'md', {
-            emacs = {
-                command = 'org-md-export-to-markdown'
-            },
-            pandoc = {
-                format = "gfm"
-            }
-        }),
-        submenu('i', 'Export to iCalendar file', 'ics', {
-            emacs = {
-                command = 'org-icalendar-export-to-ics'
-            }
-        })
+    table.sort(commands, function(lhs, rhs)
+      return lhs.label < rhs.label
+    end)
+
+    table.sort(exporters_names, function(lhs, rhs)
+      return lhs < rhs
+    end)
+
+    return {
+      label = string.format('%s (%s)', label, table.concat(exporters_names, '/')),
+      key = key,
+      action = function()
+        return utils.menu(label .. ' via', commands, label .. ' via')
+      end,
     }
+  end
 
-    if not vim.tbl_isempty(config.org_custom_exports) then
-        for key, data in pairs(config.org_custom_exports) do
-            table.insert(opts, {
-                key = key,
-                label = data.label,
-                action = function()
-                    return data.action(Export._exporter)
-                end,
-            })
-        end
+  local opts = {
+    submenu('h', 'Export to HTML file', 'html', {
+      emacs = {
+        command = 'org-html-export-to-html',
+      },
+      pandoc = {},
+    }),
+    submenu('l', 'Export to LaTex file', 'tex', {
+      emacs = {
+        command = 'org-latex-export-to-latex',
+      },
+      emacs_beamer = {
+        command = 'org-beamer-export-to-latex',
+      },
+      pandoc = {},
+    }),
+    submenu('p', 'Export to PDF file', 'pdf', {
+      emacs = {
+        command = 'org-latex-export-to-pdf',
+      },
+      emacs_beamer = {
+        command = 'org-beamer-export-to-pdf',
+      },
+      pandoc = {},
+    }),
+    submenu('m', 'Export to Markdown file', 'md', {
+      emacs = {
+        command = 'org-md-export-to-markdown',
+      },
+      pandoc = {
+        format = 'gfm',
+      },
+    }),
+    submenu('i', 'Export to iCalendar file', 'ics', {
+      emacs = {
+        command = 'org-icalendar-export-to-ics',
+      },
+    }),
+  }
+
+  if not vim.tbl_isempty(config.org_custom_exports) then
+    for key, data in pairs(config.org_custom_exports) do
+      table.insert(opts, {
+        key = key,
+        label = data.label,
+        action = function()
+          return data.action(Export._exporter)
+        end,
+      })
     end
+  end
 
-    table.insert(opts, { label = 'quit', key = 'q' })
-    table.insert(opts, { label = '', separator = ' ', length = 1 })
+  table.insert(opts, { label = 'quit', key = 'q' })
+  table.insert(opts, { label = '', separator = ' ', length = 1 })
 
-    return utils.menu('Export options', opts, 'Export command')
+  return utils.menu('Export options', opts, 'Export command')
 end
 
 return Export

--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -101,12 +101,7 @@ function Export.prompt()
   }
 
   local submenu = function(key, label, extension, exporters)
-    local commands = {
-      {
-        label = 'quit',
-        key = 'q',
-      },
-    }
+    local commands = {}
 
     local exporters_names = {}
 
@@ -139,12 +134,24 @@ function Export.prompt()
       return lhs < rhs
     end)
 
+    local action
+    if #commands > 1 then
+      action = function()
+        utils.menu(label .. ' via', commands, label .. ' via')
+      end
+
+      table.insert(commands, {
+        label = 'quit',
+        key = 'q',
+      })
+    else
+      action = commands[1].action
+    end
+
     return {
       label = string.format('%s (%s)', label, table.concat(exporters_names, '/')),
       key = key,
-      action = function()
-        return utils.menu(label .. ' via', commands, label .. ' via')
-      end,
+      action = action,
     }
   end
 


### PR DESCRIPTION
Hi! Thank you for this awesome plugin!

I found that the interface of default exporters is not very flexible, so I decided to improve it

- It's easy to add a new exporter. For example, I added the `pandoc` exporter for markdown:

```lua
submenu('m', 'Export to Markdown file', 'md', {
    emacs = {
        command = 'org-md-export-to-markdown'
    },
    pandoc = {
        format = "gfm"
    }
}),
```
- The labels of the exporters is generated automatically. For example, `My awesome exporter` becomes `My awesome exporter (emacs/pandoc)`:

```lua
submenu('d', 'My awesome exporter', 'docx', {
    emacs = {
        -- ...
    },
    pandoc = {
        -- ...
    }
}),
```

- The arguments for the exporters were separated
