### PR TITLE
Add event dispatcher

### DIFF
--- a/lua/orgmode/events/init.lua
+++ b/lua/orgmode/events/init.lua
@@ -1,0 +1,44 @@
+local Events = require('orgmode.events.types')
+local Listeners = require('orgmode.events.listeners')
+
+---@class EventManager
+local EventManager = {
+  initialized = false,
+  _listeners = {},
+  event = Events,
+}
+
+---@param event Event
+function EventManager.dispatch(event)
+  if EventManager._listeners[event.type] then
+    for _, listener in ipairs(EventManager._listeners[event.type]) do
+      listener(event)
+    end
+  end
+end
+
+---@param event Event
+---@param listener fun(...)
+function EventManager.listen(event, listener)
+  if not EventManager._listeners[event.type] then
+    EventManager._listeners[event.type] = {}
+  end
+  if not vim.tbl_contains(EventManager._listeners[event.type], listener) then
+    table.insert(EventManager._listeners[event.type], listener)
+  end
+end
+
+function EventManager.init()
+  if EventManager.initialized then
+    return
+  end
+  for event, listeners in pairs(Listeners) do
+    for _, listener in ipairs(listeners) do
+      EventManager.listen(event, listener)
+    end
+  end
+  EventManager.initialized = true
+  return EventManager
+end
+
+return EventManager

--- a/lua/orgmode/events/listeners/align_tags.lua
+++ b/lua/orgmode/events/listeners/align_tags.lua
@@ -1,0 +1,4 @@
+---@param event TodoChangedEvent | HeadlineDemotedEvent | HeadlinePromotedEvent
+return function(event)
+  event.headline:align_tags()
+end

--- a/lua/orgmode/events/listeners/init.lua
+++ b/lua/orgmode/events/listeners/init.lua
@@ -1,0 +1,14 @@
+local Events = require('orgmode.events.types')
+local AlignTags = require('orgmode.events.listeners.align_tags')
+
+return {
+  [Events.TodoChanged] = {
+    AlignTags,
+  },
+  [Events.HeadlineDemoted] = {
+    AlignTags,
+  },
+  [Events.HeadlinePromoted] = {
+    AlignTags,
+  },
+}

--- a/lua/orgmode/events/types/headline_demoted_event.lua
+++ b/lua/orgmode/events/types/headline_demoted_event.lua
@@ -1,0 +1,23 @@
+---@class HeadlineDemotedEvent: Event
+---@field type string
+---@field section Section
+---@field headline Headline
+---@field old_headline? string
+
+local HeadlineDemotedEvent = {
+  type = 'orgmode.headline_demoted',
+}
+
+---@param section Section
+---@param headline Headline
+---@param old_level number
+function HeadlineDemotedEvent:new(section, headline, old_level)
+  local obj = setmetatable({}, self)
+  self.__index = self
+  obj.section = section
+  obj.headline = headline
+  obj.old_level = old_level
+  return obj
+end
+
+return HeadlineDemotedEvent

--- a/lua/orgmode/events/types/headline_promoted_event.lua
+++ b/lua/orgmode/events/types/headline_promoted_event.lua
@@ -1,0 +1,23 @@
+---@class HeadlinePromotedEvent: Event
+---@field type string
+---@field section Section
+---@field headline Headline
+---@field old_headline? string
+
+local HeadlinePromotedEvent = {
+  type = 'orgmode.headline_promoted',
+}
+
+---@param section Section
+---@param headline Headline
+---@param old_level number
+function HeadlinePromotedEvent:new(section, headline, old_level)
+  local obj = setmetatable({}, self)
+  self.__index = self
+  obj.section = section
+  obj.headline = headline
+  obj.old_level = old_level
+  return obj
+end
+
+return HeadlinePromotedEvent

--- a/lua/orgmode/events/types/init.lua
+++ b/lua/orgmode/events/types/init.lua
@@ -1,0 +1,8 @@
+---@class Event
+---@field type string
+
+return {
+  TodoChanged = require('orgmode.events.types.todo_changed_event'),
+  HeadlinePromoted = require('orgmode.events.types.headline_promoted_event'),
+  HeadlineDemoted = require('orgmode.events.types.headline_demoted_event'),
+}

--- a/lua/orgmode/events/types/todo_changed_event.lua
+++ b/lua/orgmode/events/types/todo_changed_event.lua
@@ -1,0 +1,25 @@
+---@class TodoChangedEvent: Event
+---@field type string
+---@field section Section
+---@field headline Headline
+---@field old_todo_state? string
+---@field is_done? boolean
+local TodoChangedEvent = {
+  type = 'orgmode.todo_changed',
+}
+
+---@param section Section
+---@param headline Headline
+---@param old_todo_state? string
+---@param is_done? string
+function TodoChangedEvent:new(section, headline, old_todo_state, is_done)
+  local obj = setmetatable({}, self)
+  self.__index = self
+  obj.section = section
+  obj.headline = headline
+  obj.old_todo_state = old_todo_state
+  obj.is_done = is_done
+  return obj
+end
+
+return TodoChangedEvent

--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -25,6 +25,7 @@ function Org:init()
     return
   end
   require('orgmode.colors.custom_highlighter').setup()
+  require('orgmode.events').init()
   self.files = require('orgmode.parser.files').new()
   self.agenda = require('orgmode.agenda'):new()
   self.capture = require('orgmode.capture'):new()

--- a/tests/plenary/ui/mappings_spec.lua
+++ b/tests/plenary/ui/mappings_spec.lua
@@ -353,7 +353,10 @@ describe('Mappings', function()
     vim.fn.cursor(5, 1)
     assert.are.same('** TODO [#A] Test orgmode level 2 :PRIVATE:', vim.fn.getline('.'))
     vim.cmd([[norm <<]])
-    assert.are.same('* TODO [#A] Test orgmode level 2 :PRIVATE:', vim.fn.getline('.'))
+    assert.are.same(
+      '* TODO [#A] Test orgmode level 2                                       :PRIVATE:',
+      vim.fn.getline('.')
+    )
   end)
 
   it('should promote the heading and its subtree (org_promote_subtree)', function()
@@ -383,7 +386,7 @@ describe('Mappings', function()
     assert.are.same({
       '* TODO Test orgmode',
       '  DEADLINE: <2021-07-21 Wed 22:02>',
-      '* TODO [#A] Test orgmode level 2 :PRIVATE:',
+      '* TODO [#A] Test orgmode level 2                                       :PRIVATE:',
       'Some content for level 2',
       '** NEXT [#1] Level 3',
       'Content Level 3',


### PR DESCRIPTION
@jgollenz this is the result of https://github.com/nvim-orgmode/orgmode/pull/410/files. I thought about it a little bit, and figured out we might need to do more things when something changes, not only this one. That's why I introduced an event dispatcher and few events that are fired, and tags are aligned through them.

This will also allow us to expose listener through the api, and allow people to hook into it if they want to do something.
Let me know what you think.