### PR TITLE
README refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,44 +3,82 @@
 <div align="center">
   <img alt="[org-neovim-blend" src="https://user-images.githubusercontent.com/1782860/124820564-eddc5000-df6d-11eb-9016-d0c073a9575c.png" width="250" />
 
-  # Orgmode.nvim
+# nvim-orgmode
+
+  <a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a><a> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
 
 
-  <a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a>
+  Orgmode clone written in Lua for Neovim 0.7+
 
-  Orgmode clone written in Lua for Neovim 0.7.
+  [Setup](#setup) • [Docs](/DOCS.md) • [Showcase](#showcase) • [Treesitter](#treesitter-info) • [Troubleshoot](#troubleshoot) • [Plugins](#plugins) • [Development](#development) • [Kudos](#thanks-to)
 
-  [Installation](#installation) | [Setup](#setup) | [Troubleshoot](#troubleshoot) |  [Gifs](#gifs) | [Docs](/DOCS.md) | [Tree-sitter info](#tree-sitter-info) | [Plugins](#plugins) | [Development](#development) | [Kudos](#thanks-to)
 
 </div>
 
-## Installation
+## Quickstart
+
+### Requirements
+
+* Neovim 0.7.0 or later
+* [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+
+### Installation
 
 Use your favourite package manager:
 
-* [vim-packager](https://github.com/kristijanhusak/vim-packager):
+<details>
+  <summary><a href="https://github.com/kristijanhusak/vim-packager"><b>vim-packager</b></a></summary>
+  </br>
 
 ```lua
 packager.add('nvim-treesitter/nvim-treesitter')
 packager.add('nvim-orgmode/orgmode')
 ```
 
-- [packer.nvim](https://github.com/wbthomason/packer.nvim)
+</details>
 
-**Recommended**
+<details open>
+  <summary><b><a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a> (recommended)</b></summary>
+  </br>
 
 ```lua
 use {'nvim-treesitter/nvim-treesitter'}
 use {'nvim-orgmode/orgmode', config = function()
-        require('orgmode').setup{}
+  require('orgmode').setup{}
 end
 }
 ```
 
-**Lazy loading (Not recommended)**
+</details>
+
+<details>
+  <summary><a href="https://github.com/junegunn/vim-plug"><b>vim-plug</b></a></summary>
+  </br>
+
+```vim
+Plug 'nvim-treesitter/nvim-treesitter'
+Plug 'nvim-orgmode/orgmode'
+```
+
+</details>
+
+<details>
+  <summary><a href="https://github.com/Shougo/dein.vim"><b>dein.vim</b></a></summary>
+  </br>
+
+```vim
+call dein#add('nvim-treesitter/nvim-treesitter')
+call dein#add('nvim-orgmode/orgmode')
+```
+
+</details>
+
+<details>
+  <summary><b>Lazy loading (not recommended)</b></summary>
+  </br>
 
 Lazy loading via `ft` option works, but not completely. Global mappings are not set because plugin is not initialized on startup.
-Above setup has startup time of somewhere between 1 and 3 ms, so there are no many benefits in lazy loading.
+Above setup has a startup time of somewhere between 1 and 3 ms, so there are not many benefits in lazy loading.
 If you want to do it anyway, here's the lazy load setup:
 ```lua
 use {'nvim-treesitter/nvim-treesitter'}
@@ -52,34 +90,25 @@ use {'nvim-orgmode/orgmode',
     }
 ```
 
-- [vim-plug](https://github.com/junegunn/vim-plug)
+</details>
 
-```vim
-Plug 'nvim-treesitter/nvim-treesitter'
-Plug 'nvim-orgmode/orgmode'
-```
-
-- [dein](https://github.com/Shougo/dein.vim)
-
-```vim
-call dein#add('nvim-treesitter/nvim-treesitter')
-call dein#add('nvim-orgmode/orgmode')
-```
-
-## Setup
+### Setup
 
 ```lua
 -- init.lua
 
--- Load custom tree-sitter grammar for org filetype
+-- Load custom treesitter grammar for org filetype
 require('orgmode').setup_ts_grammar()
 
--- Tree-sitter configuration
-require'nvim-treesitter.configs'.setup {
-  -- If TS highlights are not enabled at all, or disabled via `disable` prop, highlighting will fallback to default Vim syntax highlighting
+-- Treesitter configuration
+require('nvim-treesitter.configs').setup {
+  -- If TS highlights are not enabled at all, or disabled via `disable` prop,
+  -- highlighting will fallback to default Vim syntax highlighting
   highlight = {
     enable = true,
-    additional_vim_regex_highlighting = {'org'}, -- Required for spellcheck, some LaTex highlights and code block highlights that do not have ts grammar
+    -- Required for spellcheck, some LaTex highlights and
+    -- code block highlights that do not have ts grammar
+    additional_vim_regex_highlighting = {'org'},
   },
   ensure_installed = {'org'}, -- Or run :TSUpdate org
 }
@@ -90,115 +119,120 @@ require('orgmode').setup({
 })
 ```
 
-Or if you are using `init.vim`:
+Or if you are using `init.vim`, wrap the above snippet like so:
 ```vim
 " init.vim
 lua << EOF
 
--- Load custom tree-sitter grammar for org filetype
-require('orgmode').setup_ts_grammar()
+require('orgmode').setup_ts_grammar() ...
 
--- Tree-sitter configuration
-require'nvim-treesitter.configs'.setup {
-  -- If TS highlights are not enabled at all, or disabled via `disable` prop, highlighting will fallback to default Vim syntax highlighting
-  highlight = {
-    enable = true,
-    additional_vim_regex_highlighting = {'org'}, -- Required for spellcheck, some LaTex highlights and code block highlights that do not have ts grammar
-  },
-  ensure_installed = {'org'}, -- Or run :TSUpdate org
-}
-
-require('orgmode').setup({
-  org_agenda_files = {'~/Dropbox/org/*', '~/my-orgs/**/*'},
-  org_default_notes_file = '~/Dropbox/org/refile.org',
-})
 EOF
 ```
+#### Completion
 
-* **Open agenda prompt**: <kbd>\<Leader\>oa</kbd>
-* **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
-* In any orgmode buffer press <kbd>g?</kbd> for help
-
-If you are new to Orgmode, see [Getting started](/DOCS.md#getting-started-with-orgmode) section in Docs.
-
-### Completion
-If you use [nvim-compe](https://github.com/hrsh7th/nvim-compe) and want
-to enable autocompletion, add this to your compe config:
+<details>
+  <summary><a href="https://github.com/hrsh7th/nvim-compe"><b>nvim-compe</b></a></summary>
+  </br>
 
 ```lua
-require'compe'.setup({
+require('compe').setup({
   source = {
     orgmode = true
   }
 })
 ```
 
-For [nvim-cmp](https://github.com/hrsh7th/nvim-cmp), add `orgmode` to list of sources:
+</details>
+
+<details>
+  <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary>
+  </br>
+
 ```lua
-require'cmp'.setup({
+require('cmp').setup({
   sources = {
     { name = 'orgmode' }
   }
 })
 ```
 
-For [completion.nvim](https://github.com/nvim-lua/completion-nvim), just add `omni` mode to chain complete list and add additional keyword chars:
+</details>
+
+<details>
+  <summary><a href="https://github.com/nvim-lua/completion-nvim"><b>completion-nvim</b></a></summary>
+  </br>
+
 ```lua
 vim.g.completion_chain_complete_list = {
   org = {
     { mode = 'omni'},
   },
 }
+-- add additional keyword chars
 vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 ```
 
+</details>
+
 Or just use `omnifunc` via <kbd>\<C-x\>\<C-o\></kbd>
 
-### Gifs
-#### Agenda
+
+### Usage
+
+
+* **Open agenda prompt**: <kbd>\<Leader\>oa</kbd>
+* **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
+* In any orgmode buffer press <kbd>g?</kbd> for help
+
+If you are new to Orgmode, see [Getting started](/DOCS.md#getting-started-with-orgmode) section in the Docs
+or a hands-on [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][tutorial]] in our wiki.
+
+
+## Showcase
+### Agenda
   ![agenda](https://user-images.githubusercontent.com/1782860/123549968-8521f600-d76b-11eb-9a93-02bad08b37ce.gif)
 
-#### Org file
+### Org file
   ![orgfile](https://user-images.githubusercontent.com/1782860/123549982-90752180-d76b-11eb-8828-9edf9f76af08.gif)
 
-#### Capturing and refiling
+### Capturing and refiling
   ![capture](https://user-images.githubusercontent.com/1782860/123549993-9a972000-d76b-11eb-814b-b348a93df08a.gif)
 
-#### Autocompletion
+### Autocompletion
   ![autocomplete](https://user-images.githubusercontent.com/1782860/123550227-e8605800-d76c-11eb-96f6-c0a677d562d4.gif)
 
-### Tree-sitter info
-Built in tree-sitter parser is used for parsing the org files.
+## Treesitter Info
+The built-in treesitter parser is used for parsing the org files.
 Highlights are experimental and partially supported.
 
-#### Advantages of tree-sitter over built in parsing/syntax:
-* More reliable, since parsing is done with proper parsing tool
+### Advantages of treesitter over built in parsing/syntax:
+* More reliable, since parsing is done with a proper parsing tool
 * Better highlighting (Experimental, still requires improvements)
-* Future features will be easier to implement because grammar already parses some things that were not parsed before (tables, latex, etc.)
+* Future features will be easier to implement because the grammar already parses some things that were not parsed before (tables, latex, etc.)
 * Allows for easier hacking (custom motions that can work with TS nodes, etc.)
 
-#### Known highlighting issues and limitations
+### Known highlighting issues and limitations
 * Performance issues. This is generally an issue in Neovim that should be resolved before 0.6 release (https://github.com/neovim/neovim/issues/14762, https://github.com/neovim/neovim/issues/14762)
 * Anything that requires concealing ([org_hide_emphasis_markers](/DOCS.md#org_hide_emphasis_markers), links concealing) is not (yet) supported in TS highlighter
 * LaTex is still highlighted through syntax file
 
-#### Improvements over Vim's syntax highlighting
+### Improvements over Vim's syntax highlighting
 * Better highlighting of certain parts (tags, deadline/schedule/closed dates)
-* [Tree-sitter highlight injections](https://github.com/nvim-treesitter/nvim-treesitter/blob/4f2265632becabcd2c5b1791fa31ef278f1e496c/CONTRIBUTING.md#injections) through `#BEGIN_SRC filetype` blocks
+* [Treesitter highlight injections](https://github.com/nvim-treesitter/nvim-treesitter/blob/4f2265632becabcd2c5b1791fa31ef278f1e496c/CONTRIBUTING.md#injections) through `#BEGIN_SRC filetype` blocks
 * Headline markup highlighting (https://github.com/nvim-orgmode/orgmode/issues/67)
 
-#### Troubleshoot
-##### Folding is not working
+## Troubleshoot
+### Folding is not working
 Make sure you are not overriding foldexpr in Org buffers with [nvim-treesitter folding](https://github.com/nvim-treesitter/nvim-treesitter#folding)
 
-##### Indentation is not working
+### Indentation is not working
 Make sure you are not overriding indentexpr in Org buffers with [nvim-treesitter indentation](https://github.com/nvim-treesitter/nvim-treesitter#indentation)
 
-##### I get `treesitter/query.lua` errors when opening agenda/capture prompt or org files
+### I get `treesitter/query.lua` errors when opening agenda/capture prompt or org files
 Make sure you are using latest changes from [tree-sitter-org](https://github.com/milisims/tree-sitter-org) grammar.<br />
 by running `:TSUpdate org` and restarting the editor.
 
-##### Dates are not in English
+### Dates are not in English
 Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
 To use different locale you can add this to your `init.lua`:
 ```lua
@@ -211,7 +245,7 @@ language en_US.utf8
 Just make sure you have `en_US` locale installed on your system. To see what you have available on the system you can
 start the command `:language ` and press `<TAB>` to autocomplete possible options.
 
-##### Links are not concealed
+### Links are not concealed
 Links are concealed with Vim's conceal feature (see `:help conceal`). To enable concealing, add this to your `init.lua`:
 ```lua
 vim.opt.conceallevel = 2
@@ -225,7 +259,7 @@ set conceallevel=2
 set concealcursor=nc
 ```
 
-##### Jumping to file path is not working for paths with forward slash
+### Jumping to file path is not working for paths with forward slash
 If you are using Windows, paths are by default written with backslashes.
 To use forward slashes, you must enable `shellslash` option (see `:help 'shellslash'`).
 
@@ -241,7 +275,8 @@ set shellslash
 
 More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775)
 
-### Features (TL;DR):
+## Features
+### TL;DR
 * Agenda view
 * Search by tags/keyword
 * Clocking time
@@ -262,7 +297,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
 * Remote editing from agenda view
 * Repeatable mapping via [vim-repeat](https://github.com/tpope/vim-repeat)
 
-### Features (Detailed breakdown):
+### Detailed breakdown
 * Agenda prompt:
   * Agenda view (<kbd>a</kbd>):
     * Ability to show daily(<kbd>vd</kbd>)/weekly(<kbd>vw</kbd>)/monthly(<kbd>vm</kbd>)/yearly(<kbd>vy</kbd>) agenda
@@ -329,9 +364,9 @@ See all available plugins on [orgmode-nvim](https://github.com/topics/orgmode-nv
 
 **If you built a plugin please add "orgmode-nvim" topic to it.**
 
-**NOTE**: None of the Emacs Orgmode plugins will be built into orgmode.nvim.
+**NOTE**: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.
-Point of this plugin is to provide functionality that's built into Emacs Orgmode core,
+The point of this plugin is to provide functionality that's built into Emacs Orgmode core,
 and a good foundation for external plugins.<br />
 If you want to build a plugin, post suggestions and improvements on [Plugins infrastructure](https://github.com/nvim-orgmode/orgmode/issues/26)
 issue.
@@ -358,9 +393,9 @@ make format
 ```
 
 ### Parser
-Parsing is done via builtin tree-sitter parser and [tree-sitter-org](https://github.com/milisims/tree-sitter-org) grammar.
+Parsing is done via builtin treesitter parser and [tree-sitter-org](https://github.com/milisims/tree-sitter-org) grammar.
 
-## Plans
+## Roadmap
 * [X] Support searching by properties
 * [ ] Improve checkbox hierarchy
 * [X] Support todo keyword faces
@@ -368,12 +403,12 @@ Parsing is done via builtin tree-sitter parser and [tree-sitter-org](https://git
 * [X] Improve folding
 * [X] Support exporting (via existing emacs tools)
 * [ ] Support archiving to specific headline
-* [ ] Support tables
+* [X] Support tables
 * [ ] Support diary format dates
 * [ ] Support evaluating code blocks
 
 ## Thanks to
 * [@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo](https://github.com/dhruvasagar/vim-dotoo) plugin
   that got me started using orgmode. Without him this plugin would not happen.
-* [@milisims](https://github.com/milisims) for writing a tree-sitter parser for org
+* [@milisims](https://github.com/milisims) for writing a treesitter parser for org
 * [vim-orgmode](https://github.com/jceb/vim-orgmode) for some parts of the code (mostly syntax)


### PR DESCRIPTION
I'll open this so we can discuss how we could improve the current state of the README. Things I'd like to push for are: 

- Conciseness
- Showing > Describing
- Consistency

Changes I made so far ([have a look](https://github.com/jgollenz/orgmode/tree/refactor/readme)):

- Improved consistency for the code snippets
- Elevated some headlines so the structure closer resembles the top-level links
- Added 'Requirements' section
- Put 'Requirements', 'Installation', 'Setup' and 'Usage' under a 'Quickstart' section
- Renamed 'Gifs' to 'Showcase'
- Made the logo smaller
- Put the package managers and completion plugins into collapsible sections

Changes I propose:

- [ ] Combine the 'Features' and 'Showcase/Gifs' section. Have some strong gifs that show the main features of the port. A (semi-)full list of features can only grow in the future and blow up the README further. I think it's better to link to the docs. And IF we stay with such a list (exhaustive or not) in the README, we should link to the dedicated part of the documentation.
- [ ] I am a huge fan of plugins that just give me a display of their features first thing in the README. I only care about installation and setup when I think that the plugin does what I want.
- [x] Mention the Matrix channel
- [x] There is an inconsistency about the actual name of the repo. On one hand we have the organization `nvim-orgmode`, on the other the title of the repo in the README: `orgmode.nvim`. The repo itself is named `orgmode`. We should clarify this. 