### PR TITLE
Enable expansions within lua expression

### DIFF
--- a/lua/orgmode/capture/templates.lua
+++ b/lua/orgmode/capture/templates.lua
@@ -56,13 +56,9 @@ function Templates:compile(template)
     content = table.concat(content, '\n')
   end
   content = self:_compile_dates(content)
-  content = self:_compile_prompts(content)
+  content = self:_compile_expansions(content)
   content = self:_compile_expressions(content)
-  for expansion, compiler in pairs(expansions) do
-    if content:match(vim.pesc(expansion)) then
-      content = content:gsub(vim.pesc(expansion), compiler())
-    end
-  end
+  content = self:_compile_prompts(content)
   return vim.split(content, '\n', true)
 end
 
@@ -78,6 +74,18 @@ function Templates:setup()
       vim.cmd([[startinsert]])
     end
   end
+end
+
+---@param content string
+---@return string
+function Templates:_compile_expansions(content, found_expansions)
+  found_expansions = found_expansions or expansions
+  for expansion, compiler in pairs(found_expansions) do
+    if content:match(vim.pesc(expansion)) then
+      content = content:gsub(vim.pesc(expansion), compiler())
+    end
+  end
+  return content
 end
 
 ---@param content string


### PR DESCRIPTION
It says [here](https://orgmode.org/manual/Template-expansion.html) that `[the expansion of lisp expressions] happens after expanding non-interactive “%-escapes”, those can be used to fill the expression`. Fine, but this messes with Lua expressions, since its escape sequences overlap with those of orgmode templates. 

So, I guess we could do some aliasing for either one of the two sets, when they are within a `%(...)` Lua expression: 

- `%(return string.format("Hello, %s", @x)` aliasing template escapes
- `%(return string.format("Hello, @s", %x)` aliasing lua escapes

The `@` is just for demonstrative purposes, we could use else entirely.

This is the use case that actually prompted me to investigate that: `template = "* TODO [[%x][%(return string.match('%x', '([^/]+)$'))]]"`. I use it when I come across an interesting repo. `C-l`, `C-c`, switch to neovim and start the capture. Before that I had the cursor where the link name goes and typed the repo name in by hand.