### PR TITLE
Advance agenda span with count

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -190,7 +190,7 @@ function Agenda:is_opened()
 end
 
 function Agenda:advance_span(direction)
-  return self:_call_view_and_render('advance_span', direction)
+  return self:_call_view_and_render('advance_span', direction, vim.v.count1)
 end
 
 function Agenda:change_span(span)

--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -214,7 +214,9 @@ function AgendaView:build()
   return self
 end
 
-function AgendaView:advance_span(direction)
+function AgendaView:advance_span(direction, count)
+  count = count or 1
+  direction = direction * count
   local action = { [self.span] = direction }
   if type(self.span) == 'number' then
     action = { day = self.span * direction }


### PR DESCRIPTION
It says [here](https://orgmode.org/manual/Agenda-Commands.html): `Go forward in time to display the span following the current one. [...] With a prefix argument, repeat that many times.`
