### PR TITLE
Added tangle functionality to org files

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -954,9 +954,9 @@ function OrgMappings:_get_link_under_cursor()
 end
 
 function OrgMappings:tangle_file()
-    local file = Files.get_current_file()
+  local file = Files.get_current_file()
 
-    file:tangle()
+  file:tangle()
 end
 
 return OrgMappings

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -953,4 +953,10 @@ function OrgMappings:_get_link_under_cursor()
   return found_link
 end
 
+function OrgMappings:tangle_file()
+    local file = Files.get_current_file()
+
+    file:tangle()
+end
+
 return OrgMappings

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -410,8 +410,7 @@ function File:_parse_directives()
 end
 
 function File:tangle()
-    tangle.tangle_file(self)
+  tangle.tangle_file(self)
 end
-
 
 return File

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -4,6 +4,7 @@ local Section = require('orgmode.parser.section')
 local LanguageTree = require('vim.treesitter.languagetree')
 local config = require('orgmode.config')
 local utils = require('orgmode.utils')
+local tangle = require('orgmode.tangle')
 
 ---@class File
 ---@field tree table
@@ -407,5 +408,10 @@ function File:_parse_directives()
   end
   self.tags = tags
 end
+
+function File:tangle()
+    tangle.tangle_file(self)
+end
+
 
 return File

--- a/lua/orgmode/tangle/init.lua
+++ b/lua/orgmode/tangle/init.lua
@@ -1,0 +1,134 @@
+-- Expand a relative path given an origin file (took from the one found in Hyperlinks module)
+---@param relative_path string The relative path to expand
+---@param origin string The file which path is the relative to our
+---@private
+local function _expand_relative_path(relative_path, origin)
+  local path = relative_path
+  if path:match('^/') then
+    return path
+  end
+  path = path:gsub('^./', '')
+  return vim.fn.fnamemodify(origin, ':p:h') .. '/' .. path
+end
+
+-- Setup abbreviation
+local query = vim.treesitter.query
+
+-- Fix indentation in code blocks (remove unnecessary whitespaces)
+---@param str string The string that need to be fixed (usually, a code block content)
+---@param to_trim number The number of whitespaces (spaces or tabs) to remove at the start of the line
+---@private
+local fix_indentation = function (str, to_trim)
+    if to_trim == nil then
+        -- Arbitrarily large number
+        to_trim = 1000
+    end
+
+    -- Understand the minimum numbers of whitespaces in the code in order to remove ORG indentation from the code
+    for spaces in string.gmatch(str, "\n([ \t]+)") do
+        if to_trim > #spaces then
+            to_trim = #spaces
+        end
+    end
+
+    local pattern = "\n"
+    pattern = pattern .. string.rep("[ \t]", to_trim)
+
+    local indented = string.gsub(str, pattern, "\n")
+    return indented
+end
+
+-- Save the loaded blocks into a file
+---@param files table<string, table<string>> A table that correlates file names to a list of code blocks
+---@private
+local save_into_files = function (files)
+
+    if next(files) == nil then
+        print("Nothing to tangle.")
+        return
+    end
+
+    local out = "Tangled files: "
+    for filename, code_blocks in pairs(files) do
+        -- Without expanding the file will be nil
+        local file = io.open(vim.fn.expand(filename), "w+")
+        io.output(file)
+        for _, block in ipairs(code_blocks) do
+            io.write(block .. "\n\n")
+        end
+        io.close(file)
+        out = out .. filename .. " "
+    end
+    print(out)
+end
+
+-- necessary for recursion in this case
+local process_node = nil
+-- Main function that recursively check for code blocks to be tangled
+---@param node any The current node to inspect
+---@param cur_file string The name of the file as stated in the :TANGLE: property in the enclosing headline
+---@param files table<string, table<string>> The map between filenames and codeblocks to tangle
+process_node = function (node, cur_file, files, file)
+    if node == nil then
+        return
+    end
+
+    for subnode in node:iter_children() do
+        local t = subnode:type()
+        -- If the node is a block, add it to the blocks that need to be tangled if necessary
+        if t == "block" then
+            if cur_file ~= nil then
+                if files[cur_file] == nil then
+                    files[cur_file] = {}
+                end
+
+                for block_prop in subnode:iter_children() do
+                    if block_prop:type() == "contents" then
+                        local _, col = block_prop:range()
+                        table.insert(files[cur_file], fix_indentation(query.get_node_text(block_prop, 0), col))
+                    end
+                end
+            end
+        -- It was necessary to start from property_drawer, in order to
+        -- pass "cur_file" to the node inside the section body
+        elseif t == "property_drawer" then
+            for drawer_child in subnode:iter_children() do
+                if drawer_child:type() == "property" then
+                    local is_tangle = false
+                    -- Look for the property name and value
+                    for prop_part in drawer_child:iter_children() do
+                        local prop_type = prop_part:type()
+                        local prop_text = query.get_node_text(prop_part, 0)
+                        if prop_type == "expr" and prop_text == "TANGLE" then
+                            is_tangle = true
+                        elseif prop_type == "value" and is_tangle then
+                            cur_file = _expand_relative_path(prop_text, file.filename)
+                            is_tangle = false
+                        end
+                    end
+
+                    if is_tangle == true then
+                        -- TODO: What to do if the filename is not defined?
+                        is_tangle = false
+                    end
+                end
+            end
+        else
+            process_node(subnode, cur_file, files, file)
+        end
+    end
+end
+
+---@param file File the file to be tangled
+local tangle_file = function (file)
+    local files_to_blocks = {}
+
+    local root = file.tree:root()
+
+    process_node(root, nil, files_to_blocks, file)
+    save_into_files(files_to_blocks)
+end
+
+return {
+    tangle_file = tangle_file
+}

--- a/lua/orgmode/tangle/init.lua
+++ b/lua/orgmode/tangle/init.lua
@@ -18,48 +18,47 @@ local query = vim.treesitter.query
 ---@param str string The string that need to be fixed (usually, a code block content)
 ---@param to_trim number The number of whitespaces (spaces or tabs) to remove at the start of the line
 ---@private
-local fix_indentation = function (str, to_trim)
-    if to_trim == nil then
-        -- Arbitrarily large number
-        to_trim = 1000
+local fix_indentation = function(str, to_trim)
+  if to_trim == nil then
+    -- Arbitrarily large number
+    to_trim = 1000
+  end
+
+  -- Understand the minimum numbers of whitespaces in the code in order to remove ORG indentation from the code
+  for spaces in string.gmatch(str, '\n([ \t]+)') do
+    if to_trim > #spaces then
+      to_trim = #spaces
     end
+  end
 
-    -- Understand the minimum numbers of whitespaces in the code in order to remove ORG indentation from the code
-    for spaces in string.gmatch(str, "\n([ \t]+)") do
-        if to_trim > #spaces then
-            to_trim = #spaces
-        end
-    end
+  local pattern = '\n'
+  pattern = pattern .. string.rep('[ \t]', to_trim)
 
-    local pattern = "\n"
-    pattern = pattern .. string.rep("[ \t]", to_trim)
-
-    local indented = string.gsub(str, pattern, "\n")
-    return indented
+  local indented = string.gsub(str, pattern, '\n')
+  return indented
 end
 
 -- Save the loaded blocks into a file
 ---@param files table<string, table<string>> A table that correlates file names to a list of code blocks
 ---@private
-local save_into_files = function (files)
+local save_into_files = function(files)
+  if next(files) == nil then
+    print('Nothing to tangle.')
+    return
+  end
 
-    if next(files) == nil then
-        print("Nothing to tangle.")
-        return
+  local out = 'Tangled files: '
+  for filename, code_blocks in pairs(files) do
+    -- Without expanding the file will be nil
+    local file = io.open(vim.fn.expand(filename), 'w+')
+    io.output(file)
+    for _, block in ipairs(code_blocks) do
+      io.write(block .. '\n\n')
     end
-
-    local out = "Tangled files: "
-    for filename, code_blocks in pairs(files) do
-        -- Without expanding the file will be nil
-        local file = io.open(vim.fn.expand(filename), "w+")
-        io.output(file)
-        for _, block in ipairs(code_blocks) do
-            io.write(block .. "\n\n")
-        end
-        io.close(file)
-        out = out .. filename .. " "
-    end
-    print(out)
+    io.close(file)
+    out = out .. filename .. ' '
+  end
+  print(out)
 end
 
 -- necessary for recursion in this case
@@ -68,67 +67,67 @@ local process_node = nil
 ---@param node any The current node to inspect
 ---@param cur_file string The name of the file as stated in the :TANGLE: property in the enclosing headline
 ---@param files table<string, table<string>> The map between filenames and codeblocks to tangle
-process_node = function (node, cur_file, files, file)
-    if node == nil then
-        return
-    end
+process_node = function(node, cur_file, files, file)
+  if node == nil then
+    return
+  end
 
-    for subnode in node:iter_children() do
-        local t = subnode:type()
-        -- If the node is a block, add it to the blocks that need to be tangled if necessary
-        if t == "block" then
-            if cur_file ~= nil then
-                if files[cur_file] == nil then
-                    files[cur_file] = {}
-                end
-
-                for block_prop in subnode:iter_children() do
-                    if block_prop:type() == "contents" then
-                        local _, col = block_prop:range()
-                        table.insert(files[cur_file], fix_indentation(query.get_node_text(block_prop, 0), col))
-                    end
-                end
-            end
-        -- It was necessary to start from property_drawer, in order to
-        -- pass "cur_file" to the node inside the section body
-        elseif t == "property_drawer" then
-            for drawer_child in subnode:iter_children() do
-                if drawer_child:type() == "property" then
-                    local is_tangle = false
-                    -- Look for the property name and value
-                    for prop_part in drawer_child:iter_children() do
-                        local prop_type = prop_part:type()
-                        local prop_text = query.get_node_text(prop_part, 0)
-                        if prop_type == "expr" and prop_text == "TANGLE" then
-                            is_tangle = true
-                        elseif prop_type == "value" and is_tangle then
-                            cur_file = _expand_relative_path(prop_text, file.filename)
-                            is_tangle = false
-                        end
-                    end
-
-                    if is_tangle == true then
-                        -- TODO: What to do if the filename is not defined?
-                        is_tangle = false
-                    end
-                end
-            end
-        else
-            process_node(subnode, cur_file, files, file)
+  for subnode in node:iter_children() do
+    local t = subnode:type()
+    -- If the node is a block, add it to the blocks that need to be tangled if necessary
+    if t == 'block' then
+      if cur_file ~= nil then
+        if files[cur_file] == nil then
+          files[cur_file] = {}
         end
+
+        for block_prop in subnode:iter_children() do
+          if block_prop:type() == 'contents' then
+            local _, col = block_prop:range()
+            table.insert(files[cur_file], fix_indentation(query.get_node_text(block_prop, 0), col))
+          end
+        end
+      end
+      -- It was necessary to start from property_drawer, in order to
+      -- pass "cur_file" to the node inside the section body
+    elseif t == 'property_drawer' then
+      for drawer_child in subnode:iter_children() do
+        if drawer_child:type() == 'property' then
+          local is_tangle = false
+          -- Look for the property name and value
+          for prop_part in drawer_child:iter_children() do
+            local prop_type = prop_part:type()
+            local prop_text = query.get_node_text(prop_part, 0)
+            if prop_type == 'expr' and prop_text == 'TANGLE' then
+              is_tangle = true
+            elseif prop_type == 'value' and is_tangle then
+              cur_file = _expand_relative_path(prop_text, file.filename)
+              is_tangle = false
+            end
+          end
+
+          if is_tangle == true then
+            -- TODO: What to do if the filename is not defined?
+            is_tangle = false
+          end
+        end
+      end
+    else
+      process_node(subnode, cur_file, files, file)
     end
+  end
 end
 
 ---@param file File the file to be tangled
-local tangle_file = function (file)
-    local files_to_blocks = {}
+local tangle_file = function(file)
+  local files_to_blocks = {}
 
-    local root = file.tree:root()
+  local root = file.tree:root()
 
-    process_node(root, nil, files_to_blocks, file)
-    save_into_files(files_to_blocks)
+  process_node(root, nil, files_to_blocks, file)
+  save_into_files(files_to_blocks)
 end
 
 return {
-    tangle_file = tangle_file
+  tangle_file = tangle_file,
 }


### PR DESCRIPTION
This PR has been created to propose a way to implement the tangling functionality existing in ORG Mode (following Discussion #275 ). 
The current code will add a `tangle` function as a method of an Org File, since this seemed the most flexible way to implement this.

With this PR, you can write the following in order to tangle block files found under specific headings:
```org
* Heading 1
  :PROPERTY:
  :TANGLE: ./filename.lua
  :END:
  
  #+begin_src lua
  print("Test")
  #+end_src
```

Since this is a stub, I've not yet thought if the action should be triggered by a keymap or by a command.
Currently, you can tangle the file from lua using this code:
```lua
local file = require("orgmode.parse.files").get_current_file()
file:tangle()
```

This is not a 1:1 copy of the syntax that is implemented in the original Org Mode, since it seems like treesitter isn't able to comprehend the original one.

Things that I'd like to discuss about this implementations are:
- The currently used syntax is different from what Org Mode does. It was meant to be more easily parsed by treesitter, but other options are welcome
- How to handle when the filename isn't defined (the original uses the filename + an extension based on the code block language)
- How to expose this functionality to the user
- I've added a function that changes a relative path to an absolute one. This has been done elsewere in the code, but I think it could need some improment, maybe we can create a function in `utils.lua`?

Of course, if there are other questions or suggestions, don't hold back! Hope this can be of some help 🙂