### PR TITLE
Added Enter as a multipurpose action

### DIFF
--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -120,7 +120,7 @@ return {
       org_promote_subtree = '<s',
       org_demote_subtree = '>s',
       org_meta_return = '<Leader><CR>', -- Add heading, item or row
-      org_return = '<CR>',
+      -- org_return = '<CR>',
       org_insert_heading_respect_content = '<prefix>ih', -- Add new headling after current heading block with same level
       org_insert_todo_heading = '<prefix>iT', -- Add new todo headling right after current heading with same level
       org_insert_todo_heading_respect_content = '<prefix>it', -- Add new todo headling after current heading block on same level
@@ -142,6 +142,7 @@ return {
       org_clock_goto = '<prefix>xj',
       org_set_effort = '<prefix>xe',
       org_show_help = 'g?',
+      org_multipurpose_action = '<CR>',
     },
     edit_src = {
       org_edit_src_abort = '<prefix>k',

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -132,6 +132,7 @@ return {
     org_clock_goto = m.action('clock.org_clock_goto', { opts = { desc = 'org clock goto' } }),
     org_set_effort = m.action('clock.org_set_effort', { opts = { desc = 'org set effort' } }),
     org_show_help = m.action('org_mappings.show_help', { opts = { desc = 'org show help' } }),
+    org_multipurpose_action = m.action('org_mappings.multipurpose_action', { opts = { desc = 'org multipurpose action' } }),
   },
   edit_src = {
     org_edit_src_abort = m.custom(

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -132,7 +132,10 @@ return {
     org_clock_goto = m.action('clock.org_clock_goto', { opts = { desc = 'org clock goto' } }),
     org_set_effort = m.action('clock.org_set_effort', { opts = { desc = 'org set effort' } }),
     org_show_help = m.action('org_mappings.show_help', { opts = { desc = 'org show help' } }),
-    org_multipurpose_action = m.action('org_mappings.multipurpose_action', { opts = { desc = 'org multipurpose action' } }),
+    org_multipurpose_action = m.action(
+      'org_mappings.multipurpose_action',
+      { opts = { desc = 'org multipurpose action' } }
+    ),
   },
   edit_src = {
     org_edit_src_abort = m.custom(

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -954,8 +954,7 @@ function OrgMappings:_get_link_under_cursor()
 end
 
 function OrgMappings:multipurpose_action()
-
-  local is_link = function ()
+  local is_link = function()
     return self:_get_link_under_cursor() ~= nil
   end
 
@@ -965,23 +964,22 @@ function OrgMappings:multipurpose_action()
     headline = OrgMappings.todo_next_state,
     listitem = OrgMappings.toggle_checkbox,
     list = OrgMappings.toggle_checkbox,
-    _default = OrgMappings.org_return
+    _default = OrgMappings.org_return,
   }
 
   local function get_action_from_type()
     local cur_node = ts_utils.get_node_at_cursor()
     local cur_row = cur_node:range()
 
-
     while cur_node ~= nil do
       local nodetype = cur_node:type()
 
       for identifier, action in pairs(type_to_action) do
-        if type(identifier) == "function" then
+        if type(identifier) == 'function' then
           if identifier() then
             return action
           end
-        elseif nodetype == identifier and identifier ~= "_default" then
+        elseif nodetype == identifier and identifier ~= '_default' then
           return action
         end
       end


### PR DESCRIPTION
This PR makes the Enter key a multipurpose key. It will do a different action based on the context.
It currently overrides the "org_return" action and checks for these situations (in this specific order):
- open links
- open dates in calendar
- change headline status
- toggle a list item

Otherwise, it will do the "org_return" action as a default.

I've made this PR as a way to discuss this, as proposed in #301 

Some things I'd like to discuss are:
- Should we be using this as the default action for the Enter key? It seems to be like this on Emacs, but honestly, I had only tried it in Doom Emacs, not the vanilla one, if I recall correctly.
- The order in which the actions are checked is ok? It seemed sensible to me.
- What to do about the "org_return" / "use original return" actions? Should we keep these as is?

Thank you for your time, as always, I'm open to suggestions, have a nice day