### PR TITLE
Don't reload orgfile twice

### DIFF
--- a/lua/orgmode/colors/todo_highlighter.lua
+++ b/lua/orgmode/colors/todo_highlighter.lua
@@ -1,5 +1,6 @@
 local config = require('orgmode.config')
 local highlights = require('orgmode.colors.highlights')
+local tree_utils = require('orgmode.utils.treesitter')
 local utils = require('orgmode.utils')
 
 local function add_todo_keyword_highlights()
@@ -52,7 +53,7 @@ local function add_todo_keyword_highlights()
           end
           vim.treesitter.set_query('org', 'highlights', table.concat(all_lines, '\n'))
           if vim.bo.filetype == 'org' then
-            vim.cmd([[filetype detect]])
+            tree_utils.restart_highlights()
           end
         end)
       )

--- a/lua/orgmode/utils/treesitter.lua
+++ b/lua/orgmode/utils/treesitter.lua
@@ -12,6 +12,12 @@ function M.parse(bufnr)
   return vim.treesitter.get_parser(bufnr or 0, 'org', {}):parse()
 end
 
+-- Reload treesitter highlighter without triggering FileType autocommands that include reloading entire file
+function M.restart_highlights(bufnr)
+  bufnr = bufnr or 0
+  require("nvim-treesitter.configs").reattach_module('highlight', bufnr, 'org')
+end
+
 function M.parse_query(query)
   local ts_query = query_cache[query]
   if not ts_query then

--- a/lua/orgmode/utils/treesitter.lua
+++ b/lua/orgmode/utils/treesitter.lua
@@ -15,7 +15,7 @@ end
 -- Reload treesitter highlighter without triggering FileType autocommands that include reloading entire file
 function M.restart_highlights(bufnr)
   bufnr = bufnr or 0
-  require("nvim-treesitter.configs").reattach_module('highlight', bufnr, 'org')
+  require('nvim-treesitter.configs').reattach_module('highlight', bufnr, 'org')
 end
 
 function M.parse_query(query)


### PR DESCRIPTION
Calling `filetype detect` after setting the treesitter TODO highlights was triggering 2 back to back File.reload calls, since setting the `filetype` triggers the FileType autocommand.

Since we check if the filetype is already set, that means We can get away with just restarting the treesitter highlighter after adding new queries

This results in a noticeable perf improvement for me on when opening of an org file.
