### PR TITLE
Date Searching

### DIFF
--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -25,7 +25,28 @@ local time_format = '%H:%M'
 ---@field related_date_range Date
 ---@field dayname string
 ---@field adjustments string[]
-local Date = {}
+local Date = {
+  ---@type fun(this: Date, other: Date): boolean
+  __eq = function(this, other)
+    return this.timestamp == other.timestamp
+  end,
+  ---@type fun(this: Date, other: Date): boolean
+  __lt = function(this, other)
+    return this.timestamp < other.timestamp
+  end,
+  ---@type fun(this: Date, other: Date): boolean
+  __le = function(this, other)
+    return this.timestamp <= other.timestamp
+  end,
+  ---@type fun(this: Date, other: Date): boolean
+  __gt = function(this, other)
+    return this.timestamp > other.timestamp
+  end,
+  ---@type fun(this: Date, other: Date): boolean
+  __ge = function(this, other)
+    return this.timestamp >= other.timestamp
+  end,
+}
 
 ---@param source table
 ---@param target? table

--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -187,6 +187,12 @@ local function today(data)
   return Date:new(opts)
 end
 
+---@return Date
+local function tomorrow()
+  local today_date = today()
+  return today_date:adjust('+1d')
+end
+
 ---@param data? table
 ---@return Date
 local function now(data)
@@ -930,6 +936,7 @@ return {
   from_string = from_string,
   now = now,
   today = today,
+  tomorrow = tomorrow,
   parse_all_from_line = parse_all_from_line,
   is_valid_date = is_valid_date,
   is_date_instance = is_date_instance,

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -205,9 +205,17 @@ function File:apply_search(search, todo_only)
     if item:is_archived() or (todo_only and not item:is_todo()) then
       return false
     end
+
+    local deadline = item:get_deadline_date()
+    local scheduled = item:get_scheduled_date()
+    local closed = item:get_closed_date()
+
     return search:check({
       props = vim.tbl_extend('keep', {}, item.properties.items, {
         category = item.category,
+        deadline = deadline and deadline:to_wrapped_string(true),
+        scheduled = scheduled and scheduled:to_wrapped_string(true),
+        closed = closed and closed:to_wrapped_string(false),
       }),
       tags = item.tags,
       todo = item.todo_keyword.value,

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -127,13 +127,15 @@ local function parse_delimited_sequence(input, item_parser, delimiter_pattern)
 
   -- Continue parsing items while there's a trailing delimiter
   delimiter, input = parse_pattern(input, delimiter_pattern)
-  while delimiter and input:len() do
+  while delimiter do
     item, input = item_parser(input)
     if not item then
       return nil, original_input
     end
 
     table.insert(sequence, item)
+
+    delimiter, input = parse_pattern(input, delimiter_pattern)
   end
 
   return sequence, input

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -4,9 +4,18 @@
 ---@class Search
 ---@field term string
 ---@field expressions table
----@field logic table
+---@field logic SearchLogicClause[]
 ---@field todo_search table
 local Search = {}
+
+---@class SearchLogicClause
+---@field contains string[]
+---@field excludes string[]
+
+---@class Searchable
+---@field props table<string, string>
+---@field tags string[]
+---@field todo string
 
 ---@param term string
 function Search:new(term)
@@ -22,6 +31,8 @@ function Search:new(term)
   return data
 end
 
+---@param item Searchable
+---@return boolean
 function Search:check(item)
   for _, or_item in ipairs(self.logic) do
     local passes = self:_check_or(or_item, item)
@@ -32,6 +43,9 @@ function Search:check(item)
   return false
 end
 
+---@param or_item SearchLogicClause
+---@param item Searchable
+---@return boolean
 function Search:_check_or(or_item, item)
   for _, val in ipairs(or_item.contains) do
     if not self:_matches(val, item) then
@@ -52,6 +66,9 @@ function Search:_check_or(or_item, item)
   return true
 end
 
+---@param val string
+---@param item Searchable
+---@return boolean
 function Search:_matches(val, item)
   local prop_name, operator, prop_val = val:match('([^=<>]*)([=<>]+)([^=<>]*)')
   if not prop_name then
@@ -111,7 +128,7 @@ function Search:_matches(val, item)
 end
 
 ---@private
----@return string
+---@return nil
 function Search:_parse()
   local term = self.term
   local todo_search = term:match('/([^/]*)$')

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -401,9 +401,10 @@ function PropertyMatch:parse(input)
       date_value = Date.tomorrow()
     else
       -- Parse relative formats (e.g. <+1d>) as well as absolute
-      date_content = date_str:match('^<([%+%-]%d+[dm])>$')
+      date_content = date_str:match('^<([%+%-]%d+[dmyhwM])>$')
       if date_content then
-        date_value = Date.from_string(date_str)
+        date_value = Date.now()
+        date_value = date_value:adjust(date_content)
       else
         date_content = date_str:match('^<([^>]+)>$')
         if date_content then

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -586,11 +586,9 @@ end
 ---@param item Searchable
 ---@return boolean
 function TodoMatch:match(item)
-  print(('TodoMatch:match(%s)'):format(vim.inspect(item)))
   local item_todo = item.todo
 
   if #self.anyOf > 0 then
-    print('Checking for anyof')
     for _, todo_value in ipairs(self.anyOf) do
       if item_todo == todo_value then
         return true
@@ -599,9 +597,7 @@ function TodoMatch:match(item)
 
     return false
   elseif #self.noneOf > 0 then
-    print('Checking for noneOf')
     for _, todo_value in ipairs(self.noneOf) do
-      print(('%s can not be %s'):format(item_todo, todo_value))
       if item_todo == todo_value then
         return false
       end

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -183,7 +183,6 @@ function Search:check(item)
     todos_match = true
   end
 
-  print(vim.inspect({ todos_match = todos_match, ors_match = ors_match }))
   return ors_match and todos_match
 end
 

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -393,8 +393,26 @@ function PropertyMatch:parse(input)
   -- Date property
   date_str, input = parse_pattern(input, '"(<[^>]+>)"')
   if date_str then
+    ---@type string?, Date?
+    local date_content, date_value
+    if date_str == '<today>' then
+      date_value = Date.today()
+    elseif date_str == '<tomorrow>' then
+      date_value = Date.tomorrow()
+    else
+      -- Parse relative formats (e.g. <+1d>) as well as absolute
+      date_content = date_str:match('^<([%+%-]%d+[dm])>$')
+      if date_content then
+        date_value = Date.from_string(date_str)
+      else
+        date_content = date_str:match('^<([^>]+)>$')
+        if date_content then
+          date_value = Date.from_string(date_str)
+        end
+      end
+    end
+
     ---@type Date?
-    local date_value = Date.from_string(date_str)
     if date_value then
       return PropertyDateMatch:new(name, operator, date_value), input
     else

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -11,7 +11,7 @@ local Search = {}
 
 ---@class Searchable
 ---@field props table<string, string>
----@field tags string[]
+---@field tags string|string[]
 ---@field todo string
 
 ---@class OrItem
@@ -331,7 +331,12 @@ end
 ---@param item Searchable
 ---@return boolean
 function TagMatch:match(item)
-  for _, tag in ipairs(item.tags) do
+  local item_tags = item.tags
+  if type(item_tags) == 'string' then
+    return item_tags == self.value
+  end
+
+  for _, tag in ipairs(item_tags) do
     if tag == self.value then
       return true
     end

--- a/lua/orgmode/parser/search.lua
+++ b/lua/orgmode/parser/search.lua
@@ -201,8 +201,8 @@ function OrItem:parse(input)
   local and_items
   local original_input = input
 
-  and_items, input = parse_delimited_sequence(input, function()
-    return AndItem:parse(input)
+  and_items, input = parse_delimited_sequence(input, function(i)
+    return AndItem:parse(i)
   end, '%&')
 
   if not and_items then

--- a/lua/orgmode/parser/section.lua
+++ b/lua/orgmode/parser/section.lua
@@ -137,6 +137,7 @@ function Section.from_node(section_node, file, parent)
               type = first_node_text
             end
             local timestamp = file:get_node_text(entry:named_child(1))
+            data.properties.items[first_node_text:lower()] = timestamp
             utils.concat(
               data.dates,
               Date.from_org_date(timestamp, {

--- a/lua/orgmode/parser/section.lua
+++ b/lua/orgmode/parser/section.lua
@@ -27,12 +27,15 @@ local config = require('orgmode.config')
 ---@field file string
 ---@field content string[]
 ---@field dates Date[]
----@field properties table
+---@field properties SectionProperties
 ---@field tags string[]
 ---@field own_tags string[]
 ---@field logbook Logbook
 ---@field clocked_in boolean
 local Section = {}
+
+---@class SectionProperties
+---@field items table<string, string>
 
 ---@class SectionTodoKeyword
 ---@field node unknown

--- a/lua/orgmode/parser/section.lua
+++ b/lua/orgmode/parser/section.lua
@@ -137,7 +137,6 @@ function Section.from_node(section_node, file, parent)
               type = first_node_text
             end
             local timestamp = file:get_node_text(entry:named_child(1))
-            data.properties.items[first_node_text:lower()] = timestamp
             utils.concat(
               data.dates,
               Date.from_org_date(timestamp, {

--- a/tests/plenary/parser/parser_spec.lua
+++ b/tests/plenary/parser/parser_spec.lua
@@ -245,6 +245,11 @@ describe('Parser', function()
           end_col = 6,
         }),
       },
+      properties_items = {
+        deadline = '<2021-05-20 Thu>',
+        scheduled = '<2021-05-18>',
+        closed = '[2021-05-21 Fri]',
+      },
       tags = { 'WORK' },
       own_tags = { 'WORK' },
       category = 'work',
@@ -378,6 +383,7 @@ describe('Parser', function()
       own_tags = { 'WORK' },
       category = 'work',
       properties_items = {
+        deadline = '<2021-05-10 11:00>',
         some_prop = 'some value',
       },
       properties_range = Range:new({
@@ -417,7 +423,7 @@ describe('Parser', function()
     }
     local parsed = File.from_content(lines, 'work')
     local section = parsed:get_section(1)
-    assert.are.same({ items = {} }, section.properties)
+    assert.are.same({ items = { deadline = '<2021-05-10 11:00>' } }, section.properties)
   end)
 
   it('should parse properties only if its positioned after headline or planning date', function()
@@ -433,7 +439,7 @@ describe('Parser', function()
 
     local parsed = File.from_content(lines, 'work')
     local headline = parsed:get_section(1)
-    assert.are.same({}, headline.properties.items)
+    assert.are.same({ deadline = '<2021-05-10 11:00>' }, headline.properties.items)
 
     lines = {
       '* TODO Test orgmode :WORK:',
@@ -471,7 +477,7 @@ describe('Parser', function()
 
     parsed = File.from_content(lines, 'work')
     headline = parsed:get_section(1)
-    assert.are.same({ some_prop = 'some value' }, headline.properties.items)
+    assert.are.same({ deadline = '<2021-05-10 11:00>', some_prop = 'some value' }, headline.properties.items)
   end)
 
   it('should override headline category from property', function()
@@ -635,6 +641,7 @@ describe('Parser', function()
       own_tags = { 'WORK' },
       category = 'work',
       properties_items = {
+        deadline = '<2021-05-10 11:00>',
         some_prop = 'some value',
       },
       properties_range = Range:new({

--- a/tests/plenary/parser/parser_spec.lua
+++ b/tests/plenary/parser/parser_spec.lua
@@ -245,11 +245,6 @@ describe('Parser', function()
           end_col = 6,
         }),
       },
-      properties_items = {
-        deadline = '<2021-05-20 Thu>',
-        scheduled = '<2021-05-18>',
-        closed = '[2021-05-21 Fri]',
-      },
       tags = { 'WORK' },
       own_tags = { 'WORK' },
       category = 'work',
@@ -383,7 +378,6 @@ describe('Parser', function()
       own_tags = { 'WORK' },
       category = 'work',
       properties_items = {
-        deadline = '<2021-05-10 11:00>',
         some_prop = 'some value',
       },
       properties_range = Range:new({
@@ -423,7 +417,7 @@ describe('Parser', function()
     }
     local parsed = File.from_content(lines, 'work')
     local section = parsed:get_section(1)
-    assert.are.same({ items = { deadline = '<2021-05-10 11:00>' } }, section.properties)
+    assert.are.same({ items = {} }, section.properties)
   end)
 
   it('should parse properties only if its positioned after headline or planning date', function()
@@ -439,7 +433,7 @@ describe('Parser', function()
 
     local parsed = File.from_content(lines, 'work')
     local headline = parsed:get_section(1)
-    assert.are.same({ deadline = '<2021-05-10 11:00>' }, headline.properties.items)
+    assert.are.same({}, headline.properties.items)
 
     lines = {
       '* TODO Test orgmode :WORK:',
@@ -477,7 +471,7 @@ describe('Parser', function()
 
     parsed = File.from_content(lines, 'work')
     headline = parsed:get_section(1)
-    assert.are.same({ deadline = '<2021-05-10 11:00>', some_prop = 'some value' }, headline.properties.items)
+    assert.are.same({ some_prop = 'some value' }, headline.properties.items)
   end)
 
   it('should override headline category from property', function()
@@ -641,7 +635,6 @@ describe('Parser', function()
       own_tags = { 'WORK' },
       category = 'work',
       properties_items = {
-        deadline = '<2021-05-10 11:00>',
         some_prop = 'some value',
       },
       properties_range = Range:new({

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -67,7 +67,7 @@ describe('Search parser', function()
   end)
 
   it('should parse search term and match string properties and value', function()
-    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK')
+    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
@@ -128,7 +128,7 @@ describe('Search parser', function()
   end)
 
   it('should search props, tags and todo keywords', function()
-    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK/TODO|NEXT')
+    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK/TODO|NEXT')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -54,11 +54,10 @@ describe('Search parser', function()
     assert.Is.False(result:check({ tags = 'OTHER' }))
 
     result = Search:new('TAGS|TWO+THREE-FOUR&FIVE')
-    assert.are.equal(result.or_items[1].and_items[1].contains[1].value, 'TAGS')
-    assert.are.equal(result.or_items[2].and_items[1].contains[1].value, 'TWO')
-    assert.are.equal(result.or_items[2].and_items[1].contains[2].value, 'THREE')
-    assert.are.equal(result.or_items[2].and_items[1].excludes[1].value, 'FOUR')
-    assert.are.equal(result.or_items[2].and_items[2].contains[1].value, 'FIVE')
+    assert.are.same({
+      { contains = { 'TAGS' }, excludes = {} },
+      { contains = { 'TWO', 'THREE', 'FIVE' }, excludes = { 'FOUR' } },
+    }, result.logic)
 
     assert.Is.True(result:check({ tags = { 'TAGS', 'THREE' } }))
     assert.Is.True(result:check({ tags = { 'TWO', 'THREE', 'FIVE' } }))
@@ -67,7 +66,7 @@ describe('Search parser', function()
   end)
 
   it('should parse search term and match string properties and value', function()
-    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK')
+    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
@@ -128,11 +127,11 @@ describe('Search parser', function()
   end)
 
   it('should search props, tags and todo keywords', function()
-    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK/TODO|NEXT')
+    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK/TODO|NEXT')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = 'TODO',
+      todo = { 'TODO' },
     }))
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
@@ -142,38 +141,38 @@ describe('Search parser', function()
     assert.Is.False(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = 'DONE',
+      todo = { 'DONE' },
     }))
 
     result = Search:new('CATEGORY="test"+WORK/-WAITING')
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = 'TODO',
+      todo = { 'TODO' },
     }))
 
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = 'DONE',
+      todo = { 'DONE' },
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = 'WAITING',
+      todo = { 'WAITING' },
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test_bad' },
       tags = { 'WORK' },
-      todo = 'DONE',
+      todo = { 'DONE' },
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'OFFICE' },
-      todo = 'DONE',
+      todo = { 'DONE' },
     }))
   end)
 end)

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -55,9 +55,36 @@ describe('Search parser', function()
 
     result = Search:new('TAGS|TWO+THREE-FOUR&FIVE')
     assert.are.same({
-      { contains = { 'TAGS' }, excludes = {} },
-      { contains = { 'TWO', 'THREE', 'FIVE' }, excludes = { 'FOUR' } },
-    }, result.logic)
+      {
+        and_items = {
+          {
+            contains = {
+              { value = 'TAGS' },
+            },
+            excludes = {},
+          },
+        },
+      },
+      {
+        and_items = {
+          {
+            contains = {
+              { value = 'TWO' },
+              { value = 'THREE' },
+            },
+            excludes = {
+              { value = 'FOUR' },
+            },
+          },
+          {
+            contains = {
+              { value = 'FIVE' },
+            },
+            excludes = {},
+          },
+        },
+      },
+    }, result.or_items)
 
     assert.Is.True(result:check({ tags = { 'TAGS', 'THREE' } }))
     assert.Is.True(result:check({ tags = { 'TWO', 'THREE', 'FIVE' } }))

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -93,7 +93,7 @@ describe('Search parser', function()
   end)
 
   it('should parse search term and match string properties and value', function()
-    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK')
+    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
@@ -154,7 +154,7 @@ describe('Search parser', function()
   end)
 
   it('should search props, tags and todo keywords', function()
-    local result = Search:new('CATEGORY="test"&MYPROP=myval+WORK/TODO|NEXT')
+    local result = Search:new('CATEGORY="test"&MYPROP="myval"+WORK/TODO|NEXT')
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -132,7 +132,7 @@ describe('Search parser', function()
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = { 'TODO' },
+      todo = 'TODO',
     }))
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
@@ -142,38 +142,38 @@ describe('Search parser', function()
     assert.Is.False(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     result = Search:new('CATEGORY="test"+WORK/-WAITING')
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'TODO' },
+      todo = 'TODO',
     }))
 
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'WAITING' },
+      todo = 'WAITING',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test_bad' },
       tags = { 'WORK' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'OFFICE' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
   end)
 end)

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -158,7 +158,7 @@ describe('Search parser', function()
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = { 'TODO' },
+      todo = 'TODO',
     }))
     assert.Is.True(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
@@ -168,38 +168,38 @@ describe('Search parser', function()
     assert.Is.False(result:check({
       props = { category = 'test', myprop = 'myval', age = 10 },
       tags = { 'WORK', 'OFFICE' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     result = Search:new('CATEGORY="test"+WORK/-WAITING')
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'TODO' },
+      todo = 'TODO',
     }))
 
     assert.Is.True(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'WORK' },
-      todo = { 'WAITING' },
+      todo = 'WAITING',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test_bad' },
       tags = { 'WORK' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
 
     assert.Is.False(result:check({
       props = { category = 'test' },
       tags = { 'OFFICE' },
-      todo = { 'DONE' },
+      todo = 'DONE',
     }))
   end)
 end)

--- a/tests/plenary/parser/search_spec.lua
+++ b/tests/plenary/parser/search_spec.lua
@@ -54,10 +54,11 @@ describe('Search parser', function()
     assert.Is.False(result:check({ tags = 'OTHER' }))
 
     result = Search:new('TAGS|TWO+THREE-FOUR&FIVE')
-    assert.are.same({
-      { contains = { 'TAGS' }, excludes = {} },
-      { contains = { 'TWO', 'THREE', 'FIVE' }, excludes = { 'FOUR' } },
-    }, result.logic)
+    assert.are.equal(result.or_items[1].and_items[1].contains[1].value, 'TAGS')
+    assert.are.equal(result.or_items[2].and_items[1].contains[1].value, 'TWO')
+    assert.are.equal(result.or_items[2].and_items[1].contains[2].value, 'THREE')
+    assert.are.equal(result.or_items[2].and_items[1].excludes[1].value, 'FOUR')
+    assert.are.equal(result.or_items[2].and_items[2].contains[1].value, 'FIVE')
 
     assert.Is.True(result:check({ tags = { 'TAGS', 'THREE' } }))
     assert.Is.True(result:check({ tags = { 'TWO', 'THREE', 'FIVE' } }))


### PR DESCRIPTION
An initial implementation of searching for headlines using date properties. This
PR requried a rewrite of the `Search` type to use a more traditional parsing
strategy internally. This allows for parsing more complicated queries more
easily, and also potential performance improvements since the query string is
parsed one time instead of every time the query is tested against a headline.
