### PR TITLE
[WIP][RFC] Open tmp window: handle case where tmp window is prev window

### DIFF
--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -536,10 +536,12 @@ end
 
 function utils.open_tmp_org_window(height, split_mode, on_close)
   local winnr = vim.api.nvim_get_current_win()
+  local bufnr = vim.api.nvim_get_current_buf()
   utils.open_window(vim.fn.tempname(), height or 16, split_mode)
   vim.cmd([[setf org]])
   vim.cmd([[setlocal bufhidden=wipe nobuflisted nolist noswapfile nofoldenable]])
   vim.api.nvim_buf_set_var(0, 'org_prev_window', winnr)
+  vim.api.nvim_buf_set_var(0, 'org_prev_buffer', bufnr)
 
   if on_close then
     vim.api.nvim_create_autocmd('BufWipeout', {
@@ -559,9 +561,16 @@ function utils.open_tmp_org_window(height, split_mode, on_close)
   return function()
     vim.api.nvim_create_augroup('OrgTmpWindow', { clear = true })
     local prev_winnr = vim.api.nvim_buf_get_var(0, 'org_prev_window')
-    vim.api.nvim_win_close(0, true)
-    if prev_winnr and vim.api.nvim_win_is_valid(prev_winnr) then
-      vim.api.nvim_set_current_win(prev_winnr)
+    if prev_winnr ~= vim.api.nvim_get_current_win() then
+      vim.api.nvim_win_close(0, true)
+      if prev_winnr and vim.api.nvim_win_is_valid(prev_winnr) then
+        vim.api.nvim_set_current_win(prev_winnr)
+      end
+    else
+      local prev_bufnr = vim.api.nvim_buf_get_var(0, 'org_prev_buffer')
+      if prev_bufnr and vim.api.nvim_buf_is_valid(prev_bufnr) then
+        vim.api.nvim_set_current_buf(prev_bufnr)
+      end
     end
   end
 end


### PR DESCRIPTION
This is my first ever contribution to an nvim plugin, so take everything with a grain of salt.

This PR fixes an issue when the `win_split_mode` is set such that no new window is opened, but instead the agenda/capture buffer are opened in the current window. See the following excerpt of my org config:

```lua
  win_split_mode = function(bufname) -- open agenda buffer in same window
    local bufnr = vim.api.nvim_create_buf(false, true)
    -- Setting buffer name is required
    vim.api.nvim_buf_set_name(bufnr, bufname)
    local current_window_nr = vim.api.nvim_tabpage_get_win(0)
    vim.api.nvim_win_set_buf(current_window_nr, bufnr)
  end,

```
There is a problem when "finalizing" the capture (with `<C-c>` by default), namely that it tries to close the temporary window. But a temporary window had never been opened.

I wonder if this PR is at all going in the right direction. I haven't run the test suite yet as I haven't yet learned how that works. I'll hopefully get to it in the next days unless you tell me now that this PR doesn't make sense.