### PR TITLE
org_time_stamp append date after cursor instead of inserting before it

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -862,7 +862,7 @@ function OrgMappings:org_time_stamp(inactive)
     if date_start then
       date_string = '--' .. date_string
     end
-    vim.cmd(string.format('norm!i%s', date_string))
+    vim.cmd(string.format('norm!a%s', date_string))
   end)
 end
 


### PR DESCRIPTION
I think it would be a much better default to append a date after the cursor instead of inserting it before the cursor.