### PR TITLE
tests/minimial_init.vim: set language such that tests pass on non en_US systems

### DIFF
--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -3,6 +3,7 @@ set rtp+=./plenary.nvim
 set rtp+=./nvim-treesitter
 set termguicolors
 set noswapfile
+language en_US.utf-8
 runtime plugin/plenary.vim
 runtime plugin/nvim-treesitter.lua
 let mapleader = ','


### PR DESCRIPTION
My system's locale isn't en_US and therefore I had test failures on doing `make test`.