### PR TITLE
Match by category

### DIFF
--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -206,7 +206,7 @@ function File:apply_search(search, todo_only)
       return false
     end
     return search:check({
-      props = vim.tbl_extend('force', {}, item.properties.items, {
+      props = vim.tbl_extend('keep', {}, item.properties.items, {
         category = item.category,
       }),
       tags = item.tags,

--- a/lua/orgmode/parser/file.lua
+++ b/lua/orgmode/parser/file.lua
@@ -201,11 +201,14 @@ function File:apply_search(search, todo_only)
   end
 
   return vim.tbl_filter(function(item)
+    ---@cast item Section
     if item:is_archived() or (todo_only and not item:is_todo()) then
       return false
     end
     return search:check({
-      props = item.properties.items,
+      props = vim.tbl_extend('force', {}, item.properties.items, {
+        category = item.category,
+      }),
       tags = item.tags,
       todo = item.todo_keyword.value,
     })


### PR DESCRIPTION
Allows a user to match using the implicit `CATEGORY` property as mentioned in org's
documentation [here](https://orgmode.org/manual/Categories.html)
