### PR TITLE
notifications: show notifications for all active dates

### DIFF
--- a/lua/orgmode/notifications/init.lua
+++ b/lua/orgmode/notifications/init.lua
@@ -91,7 +91,7 @@ function Notifications:get_tasks(time)
   local tasks = {}
   for _, orgfile in ipairs(Files.all()) do
     for _, headline in ipairs(orgfile:get_opened_unfinished_headlines()) do
-      for _, date in ipairs(headline:get_deadline_and_scheduled_dates()) do
+      for _, date in ipairs(headline:get_valid_dates_for_agenda()) do
         local reminders = self:_check_reminders(date, time)
         for _, reminder in ipairs(reminders) do
           table.insert(tasks, {


### PR DESCRIPTION
This seems like an obvious/easy fix, but maybe (probably) there was a reason it wasn't done like this to begin with?
It works for me so far.
Closes https://github.com/nvim-orgmode/orgmode/issues/374