### PR TITLE
Add 'win_border' config option

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -132,6 +132,32 @@ Always open horizontally with specific height of 20 lines:
 win_split_mode = '20split'
 ```
 
+#### **win_border**
+*type*: `string|string[]`<br />
+*default value*: `single`<br />
+Border style of floating windows.<br />
+Available options:
+* `none` - No border (default)
+* `single` - A single line box
+* `double` - A double line box
+* `rounded` - Like "single", but with rounded corners ("╭" etc.)
+* `solid` - Adds padding by a single whitespace cell
+* `shadow` - A drop shadow effect by blending with the background
+* `{'╔', '═' ,'╗', '║', '╝', '═', '╚', '║' }` - Specify border characters in a clock-wise fashion
+* `{'/', '-', '\\', '|' }` - If less than eight chars the chars will start repeating
+
+See `:help nvim_open_win()`
+
+Applies to:
+    always
+        - calendar pop-up
+        - help pop-up
+        - notification pop-up
+    `win_split_mode` is set to `float`
+        - agenda window
+        - capture window
+
+
 #### **org_todo_keyword_faces**
 *type*: `table<string, string>`<br />
 *default value*: `{}`<br />
@@ -139,7 +165,7 @@ Custom colors for todo keywords.<br />
 Available options:
 * foreground - `:foreground hex/colorname`. Examples: `:foreground #FF0000`, `:foreground blue`
 * background - `:background hex/colorname`. Examples: `:background #FF0000`, `:background blue`
-* weight - `:weight bold`.
+* weight - `:weight bold`
 * underline - `:underline on`
 * italic - `:slant italic`
 
@@ -1290,7 +1316,7 @@ In order to trigger notifications via cron, job needs to be added to the crontab
 This is currently possible only on Linux and MacOS, since I don't know how would this be done on Windows. Any help on this topic is appreciated. <br />
 This works by starting the headless Neovim instance, running one off function inside orgmode, and quitting the Neovim.
 
-Here's maximum simplified **Linux** example (Tested on Manjaro/Arch), but least optimized:
+Here's maximum simplified **Linux** example (Tested on Manjaro/Arch/Ubuntu), but least optimized:
 
 Run this to open crontab:
 ```

--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -77,7 +77,7 @@ function Agenda:open_window()
     end
   end
 
-  utils.open_window('orgagenda', math.max(34, config.org_agenda_min_height), config.win_split_mode)
+  utils.open_window('orgagenda', math.max(34, config.org_agenda_min_height), config.win_split_mode, config.win_border)
 
   vim.cmd([[setf orgagenda]])
   vim.cmd([[setlocal buftype=nofile bufhidden=wipe nobuflisted nolist noswapfile nowrap nospell]])

--- a/lua/orgmode/capture/closing_note.lua
+++ b/lua/orgmode/capture/closing_note.lua
@@ -14,7 +14,7 @@ end
 
 function ClosingNote:open()
   self._resolve_fn = nil
-  self._close_tmp = utils.open_tmp_org_window(16, config.win_split_mode)
+  self._close_tmp = utils.open_tmp_org_window(16, config.win_split_mode, config.win_border)
   config:setup_mappings('note')
   vim.api.nvim_buf_set_var(0, 'org_note', true)
   vim.api.nvim_buf_set_lines(0, 0, -1, false, { '# Insert note for closed todo item', '', '' })

--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -72,7 +72,7 @@ function Capture:open_template(template)
   local on_close = function()
     require('orgmode').action('capture.refile', true)
   end
-  self._close_tmp = utils.open_tmp_org_window(16, config.win_split_mode, on_close)
+  self._close_tmp = utils.open_tmp_org_window(16, config.win_split_mode, config.win_border, on_close)
   vim.api.nvim_buf_set_lines(0, 0, -1, true, content)
   self.templates:setup()
   vim.api.nvim_buf_set_var(0, 'org_template', template)

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -42,6 +42,7 @@ local DefaultConfig = {
   org_edit_src_content_indentation = 0,
   diagnostics = true,
   win_split_mode = 'horizontal',
+  win_border = 'single',
   notifications = {
     enabled = false,
     cron_enabled = true,

--- a/lua/orgmode/notifications/init.lua
+++ b/lua/orgmode/notifications/init.lua
@@ -55,7 +55,7 @@ function Notifications:notify(time)
   end
 
   if not vim.tbl_isempty(result) then
-    NotificationPopup:new({ content = result })
+    NotificationPopup:new({ content = result, border = config.win_border })
   end
 end
 

--- a/lua/orgmode/notifications/notification_popup.lua
+++ b/lua/orgmode/notifications/notification_popup.lua
@@ -6,6 +6,7 @@ function NotificationPopup:new(opts)
     hide_after = opts.hide_after or 15000,
     buf = nil,
     win = nil,
+    border = opts.border,
   }
   setmetatable(data, self)
   self.__index = self
@@ -22,7 +23,7 @@ function NotificationPopup:show()
     width = 50,
     height = #self.content,
     style = 'minimal',
-    border = 'single',
+    border = self.border,
     anchor = 'NE',
     row = 0,
     col = vim.o.columns - 1,

--- a/lua/orgmode/objects/calendar.lua
+++ b/lua/orgmode/objects/calendar.lua
@@ -43,7 +43,7 @@ function Calendar.open()
     width = width,
     height = Calendar.clearable and height + 1 or height,
     style = 'minimal',
-    border = 'single',
+    border = config.win_border,
     row = vim.o.lines / 2 - (y_offset + height) / 2,
     col = vim.o.columns / 2 - (x_offset + width) / 2,
   }

--- a/lua/orgmode/objects/help.lua
+++ b/lua/orgmode/objects/help.lua
@@ -322,7 +322,7 @@ function Help.show(opts)
     height = math.min(#content + 1, vim.o.lines - 2),
     anchor = 'NW',
     style = 'minimal',
-    border = 'single',
+    border = config.win_border,
     row = 5,
     col = vim.o.columns / 4,
   }

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -495,7 +495,8 @@ end
 ---@param name string
 ---@param height number
 ---@param split_mode string|function|table
-function utils.open_window(name, height, split_mode)
+---@param border string|table
+function utils.open_window(name, height, split_mode, border)
   local cmd_by_split_mode = {
     horizontal = string.format('%dsplit %s', height, name),
     vertical = string.format('vsplit %s', name),
@@ -524,19 +525,19 @@ function utils.open_window(name, height, split_mode)
   end
 
   if split_mode == 'float' then
-    return utils.open_float(name)
+    return utils.open_float(name, { border = border })
   end
 
   if type(split_mode) == 'table' and split_mode[1] == 'float' then
-    return utils.open_float(name, split_mode[2])
+    return utils.open_float(name, { scale = split_mode[2], border = border })
   end
 
   return vim.cmd(string.format('%s %s', split_mode, name))
 end
 
-function utils.open_tmp_org_window(height, split_mode, on_close)
+function utils.open_tmp_org_window(height, split_mode, border, on_close)
   local winnr = vim.api.nvim_get_current_win()
-  utils.open_window(vim.fn.tempname(), height or 16, split_mode)
+  utils.open_window(vim.fn.tempname(), height or 16, split_mode, border)
   vim.cmd([[setf org]])
   vim.cmd([[setlocal bufhidden=wipe nobuflisted nolist noswapfile nofoldenable]])
   vim.api.nvim_buf_set_var(0, 'org_prev_window', winnr)
@@ -567,11 +568,13 @@ function utils.open_tmp_org_window(height, split_mode, on_close)
 end
 
 ---@param name string
----@param scale? number
-function utils.open_float(name, scale)
-  scale = scale or 0.7
+---@param opts? table
+function utils.open_float(name, opts)
+  opts = opts or { scale = nil, border = nil }
+  opts.scale = opts.scale or 0.7
+  opts.border = opts.border or 'single'
   -- Make sure number is between 0 and 1
-  scale = math.min(math.max(0, scale), 1)
+  local scale = math.min(math.max(0, opts.scale), 1)
   local bufnr = vim.api.nvim_create_buf(false, true)
   vim.api.nvim_buf_set_name(bufnr, name)
 
@@ -587,7 +590,7 @@ function utils.open_float(name, scale)
     row = row,
     col = col,
     style = 'minimal',
-    border = 'rounded',
+    border = opts.border,
   })
 end
 


### PR DESCRIPTION
closes #507 

@akinsho could you please have a look at this. It adds a new config option `win_border` that just passes the border options that can be passed to `nvim_open_win()` through.