### PR TITLE
Add basic `org-insert-link` functionality

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -792,6 +792,9 @@ Toggle current line checkbox state
 #### **org_toggle_heading**
 *mapped to*: `<Leader>o*`<br />
 Toggle current line to headline and vice versa. Checkboxes will turn into TODO headlines.
+#### **org_insert_link**
+*mapped to*: `<Leader>oil`<br />
+Insert a hyperlink at cursor position. When the cursor is on a hyperlink, edit that hyperlink.<br />
 #### **org_open_at_point**
 *mapped to*: `<Leader>oo`<br />
 Open hyperlink or date under cursor. When date is under the cursor, open the agenda for that day.<br />

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -142,6 +142,7 @@ local DefaultConfig = {
       org_schedule = '<prefix>is',
       org_time_stamp = '<prefix>i.',
       org_time_stamp_inactive = '<prefix>i!',
+      org_insert_link = '<prefix>il',
       org_clock_in = '<prefix>xi',
       org_clock_out = '<prefix>xo',
       org_clock_cancel = '<prefix>xq',

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -131,6 +131,7 @@ return {
       'org_mappings.org_time_stamp',
       { args = { true }, opts = { desc = 'org timestamp (inactive)' } }
     ),
+    org_insert_link = m.action('org_mappings.insert_link', { opts = { desc = 'org insert link' } }),
     org_clock_in = m.action('clock.org_clock_in', { opts = { desc = 'org clock in' } }),
     org_clock_out = m.action('clock.org_clock_out', { opts = { desc = 'org clock out' } }),
     org_clock_cancel = m.action('clock.org_clock_cancel', { opts = { desc = 'org clock cancel' } }),

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -693,6 +693,51 @@ function OrgMappings:_insert_heading_from_plain_line(suffix)
   end
 end
 
+-- Inserts a new link at the cursor position or modifies the link the cursor is
+-- currently on
+function OrgMappings:insert_link()
+  local link_location = vim.fn.OrgmodeInput('Links: ', '')
+  if vim.trim(link_location) ~= '' then
+    link_location = '[' .. link_location .. ']'
+  else
+    utils.echo_warning('No Link selected')
+    return
+  end
+  local link_description = vim.trim(vim.fn.OrgmodeInput('Description: ', ''))
+  if link_description ~= '' then
+    link_description = '[' .. link_description .. ']'
+  end
+
+  local insert_from
+  local insert_to
+  local target_col = #link_location + #link_description + 2
+
+  -- check if currently on link
+  local link = self:_get_link_under_cursor()
+  if link then
+    insert_from = link.from - 1
+    insert_to = link.to + 1
+    target_col = target_col + link.from
+  else
+    local colnr = vim.fn.col('.')
+    insert_from = colnr - 1
+    insert_to = colnr
+    target_col = target_col + colnr
+  end
+
+  local linenr = vim.fn.line('.')
+  local curr_line = vim.fn.getline(linenr)
+  local new_line = string.sub(curr_line, 0, insert_from)
+    .. '['
+    .. link_location
+    .. link_description
+    .. ']'
+    .. string.sub(curr_line, insert_to, #curr_line)
+
+  vim.fn.setline(linenr, new_line)
+  vim.fn.cursor(linenr, target_col)
+end
+
 function OrgMappings:move_subtree_up()
   local item = Files.get_closest_headline()
   local prev_headline = item:get_prev_headline_same_level()
@@ -737,7 +782,7 @@ function OrgMappings:open_at_point()
     return
   end
 
-  local parts = vim.split(link, '][', true)
+  local parts = vim.split(link.content, '][', true)
   local url = parts[1]
   local link_ctx = { base = url, skip_add_prefix = true }
   if url:find('^file:') then
@@ -974,6 +1019,7 @@ function OrgMappings:_get_date_under_cursor(col_offset)
     return nil
   end
 
+  -- TODO: this will result in a bug, when more than one date is in the line
   return dates[1]
 end
 
@@ -1008,7 +1054,7 @@ function OrgMappings:_adjust_date(amount, span, fallback)
   return vim.api.nvim_feedkeys(utils.esc(fallback), 'n', true)
 end
 
----@return string|nil
+---@return table|nil
 function OrgMappings:_get_link_under_cursor()
   local found_link = nil
   local links = {}
@@ -1018,10 +1064,10 @@ function OrgMappings:_get_link_under_cursor()
     local start_from = #links > 0 and links[#links].to or nil
     local from, to = line:find('%[%[(.-)%]%]', start_from)
     if col >= from and col <= to then
-      found_link = link
+      found_link = { content = link, from = from, to = to }
       break
     end
-    table.insert(links, { link = link, from = from, to = to })
+    table.insert(links, { content = link, from = from, to = to })
   end
   return found_link
 end


### PR DESCRIPTION
Described [here](https://orgmode.org/manual/Handling-Links.html#index-C_002dc-C_002dl)

There is no completion support for protocols (`http`, etc.) yet.

In light of other GH issues that are concerned with hyperlinks I'd like to discuss whether it makes sense to add a hyperlink object. It would possibly ease development in the future. Also, how about parsing them? Opening hyperlinks from the agenda requires to display all the links of a headline body to the user. There is also [`org-[next|previous]-link`](https://orgmode.org/manual/Handling-Links.html#index-C_002dc-C_002dl), that jumps to the next|previous link in the buffer