### PR TITLE
No shada during tests

### DIFF
--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -7,6 +7,7 @@ language en_US.utf-8
 runtime plugin/plenary.vim
 runtime plugin/nvim-treesitter.lua
 let mapleader = ','
+set shada="NONE"
 
 lua << EOF
 require('orgmode').setup_ts_grammar()


### PR DESCRIPTION
Having shada enabled sometimes breaks when running the tests from within a neovim session. Also, shada would get clobbered with synthetic test files. Therefore, disable it during testing.