### PR TITLE
fix(calendar): remove key waiting

### DIFF
--- a/lua/orgmode/objects/calendar.lua
+++ b/lua/orgmode/objects/calendar.lua
@@ -71,7 +71,7 @@ function Calendar.open()
   vim.api.nvim_buf_set_var(Calendar.buf, 'indent_blankline_enabled', false)
   vim.api.nvim_buf_set_option(Calendar.buf, 'bufhidden', 'wipe')
 
-  local map_opts = { buffer = Calendar.buf, silent = true }
+  local map_opts = { buffer = Calendar.buf, silent = true, nowait = true }
 
   vim.keymap.set('n', 'j', '<cmd>lua require("orgmode.objects.calendar").cursor_down()<cr>', map_opts)
   vim.keymap.set('n', 'k', '<cmd>lua require("orgmode.objects.calendar").cursor_up()<cr>', map_opts)


### PR DESCRIPTION
This patch removes the input lag when the `<` or `>` key is pressed.

#### Before

https://user-images.githubusercontent.com/57654917/228636125-b7a70556-da2d-4297-a64f-0d924100af7f.mov

#### After

https://user-images.githubusercontent.com/57654917/228636148-145de163-562b-4ae4-a3d6-91d46d4ccf2f.mov

