### PR TITLE
Fix promisify error in AgendaTodosView when changing todo state

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -422,7 +422,8 @@ function Agenda:_remote_edit(opts)
         self.win_width
       )
     else
-      self.content[line] = AgendaTodosView.generate_todo_item(headline, item.longest_category, item.line, self.win_width)
+      self.content[line] =
+        AgendaTodosView.generate_todo_item(headline, item.longest_category, item.line, self.win_width)
     end
     return self:_render(true)
   end)

--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -422,7 +422,7 @@ function Agenda:_remote_edit(opts)
         self.win_width
       )
     else
-      self.content[line] = AgendaTodosView.generate_todo_item(headline, item.longest_category, item.line)
+      self.content[line] = AgendaTodosView.generate_todo_item(headline, item.longest_category, item.line, self.win_width)
     end
     return self:_render(true)
   end)


### PR DESCRIPTION
I've been having the same issue as described in #490 for a while and finally had a chance to see if I could figure out the cause of it.

The view update fails every time I change the status of a todo item from AgendaTodosView. From what I can tell it seems to be caused by `win_width` not being set when calling `AgendaTodosView.generate_todo_item` from `Agenda:_remote_edit`, which leads to all sorts of weirdness in the TodosView when this call fails.