### PR TITLE
fix: missing nil check in open_at_point()

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -783,10 +783,13 @@ function OrgMappings:open_at_point()
     return vim.cmd(string.format('edit %s', url))
   end
 
+  local headlines = Hyperlinks.find_matching_links(link_ctx)
   local current_headline = Files.get_closest_headline()
-  local headlines = vim.tbl_filter(function(headline)
-    return headline.line ~= current_headline.line and headline.id ~= current_headline.id
-  end, Hyperlinks.find_matching_links(link_ctx))
+  if current_headline then
+    headlines = vim.tbl_filter(function(headline)
+      return headline.line ~= current_headline.line and headline.id ~= current_headline.id
+    end, headlines)
+  end
   if #headlines == 0 then
     return
   end


### PR DESCRIPTION
Without the check, attempting to open a link like `[[file:./file.org::*Heading]]` outside of any heading would cause a Lua error.

I'm not super proficient in Lua dev, so if there's any unit test I should add for this, I'd need some guidance.

In any case, thank you for working on this great plugin! :slightly_smiling_face: 