### PR TITLE
Handle org_return correctly in face of Lua keymaps

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -507,10 +507,17 @@ function OrgMappings:org_return()
 
   local old_mapping = config.old_cr_mapping
 
+  -- No other mapping for <CR>, just reproduce it.
   if not old_mapping or vim.tbl_isempty(old_mapping) then
     return vim.api.nvim_feedkeys(utils.esc('<CR>'), 'n', true)
   end
 
+  -- Lua mapping that installed a Lua function to call.
+  if old_mapping.callback then
+    return old_mapping.callback()
+  end
+
+  -- Classic, string-based mapping. Reconstruct it as faithfully as possible.
   local rhs = utils.esc(old_mapping.rhs)
 
   if old_mapping.expr > 0 then


### PR DESCRIPTION
Classically, keymaps map one string of characters to another. Neovim also allows users to install a Lua function as a callback, like this:

```lua
vim.api.nvim_set_keymap('n', 'asdf', '', {callback = function()...end})
vim.keymap.set('n', 'asdf', function()...end, {})
```

In these cases, `vim.fn.maparg()` in dict-mode returns a table that does *not* contain a key `'rhs'`, but instead a key `'callback'` that points to this function. This is not documented; this bug is being tracked at <https://github.com/neovim/neovim/issues/22399>.

The function `OrgMappings.org_return()` was not prepared to handle this case. It would not call the callback function, and with `rhs==nil`, it would not even insert a line break. To the user, it appears as if the return key stopped doing anything in insert mode.

This commit adds a simple check whether `'callback'` exists in the table returned by `maparg()`. If it does, we *assume* that `rhs` is nil and immediately return by calling the designated callback function. If `'callback'` does not exist, we proceed as usual.

As always, thank you for working on this wonderful plugin! :slightly_smiling_face: 