### PR TITLE
fix(mappings): properly get old mapping

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -260,9 +260,13 @@ function Config:get_todo_keywords()
   return types
 end
 
-function Config:setup_mappings(category, bufnr)
+function Config:setup_mappings(category, buffer)
   if not self.old_cr_mapping then
-    self.old_cr_mapping = vim.fn.maparg('<CR>', 'i', false, true)
+    self.old_cr_mapping = utils.get_keymap({
+      mode = 'i',
+      lhs = '<CR>',
+      buffer = buffer,
+    })
   end
   if self.opts.mappings.disable_all then
     return
@@ -272,8 +276,8 @@ function Config:setup_mappings(category, bufnr)
   local default_mappings = defaults.mappings[category] or {}
   local user_mappings = vim.tbl_get(self.opts.mappings, category) or {}
   local opts = {}
-  if bufnr then
-    opts.buffer = bufnr
+  if buffer then
+    opts.buffer = buffer
   end
 
   if self.opts.mappings.prefix then

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -260,6 +260,10 @@ function Config:get_todo_keywords()
   return types
 end
 
+--- Setup mappings for a given category and buffer
+---@param category string Mapping category name (e.g. `agenda`, `capture`, `node`)
+---@param buffer number? Buffer id
+---@see orgmode.config.mappings
 function Config:setup_mappings(category, buffer)
   if not self.old_cr_mapping then
     self.old_cr_mapping = utils.get_keymap({

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -167,6 +167,27 @@ function utils.menu(title, items, prompt)
   return entry.action()
 end
 
+---@class KeymapData
+---@field mode string|table
+---@field lhs string
+---@field buffer integer?
+
+---@param data KeymapData
+function utils.get_keymap(data)
+  local keymaps
+  if data.buffer then
+    keymaps = vim.api.nvim_buf_get_keymap(data.mode)
+  else
+    keymaps = vim.api.nvim_get_keymap(data.mode)
+  end
+
+  for _, map in ipairs(keymaps) do
+    if map.lhs == data.lhs then
+      return map
+    end
+  end
+end
+
 function utils.esc(cmd)
   return vim.api.nvim_replace_termcodes(cmd, true, false, true)
 end

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -176,7 +176,7 @@ end
 function utils.get_keymap(data)
   local keymaps
   if data.buffer then
-    keymaps = vim.api.nvim_buf_get_keymap(data.mode)
+    keymaps = vim.api.nvim_buf_get_keymap(data.buffer, data.mode)
   else
     keymaps = vim.api.nvim_get_keymap(data.mode)
   end

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -173,6 +173,7 @@ end
 ---@field buffer integer?
 
 ---@param data KeymapData
+---@return table? map Mapping definition
 function utils.get_keymap(data)
   local keymaps
   if data.buffer then


### PR DESCRIPTION
I played around a bit with the problem described in #553. It seems to me that the point is that we are calling the wrong `old_cr_mapping`. I replaced `vim.fn.maparg` with `vim.api.nvim_get_keymap` and the problem went away.

