### PR TITLE
Revert "Remove checks for loaded ftplugin and indent"

### DIFF
--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -1,3 +1,8 @@
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
 lua require('orgmode.config'):setup_mappings('org')
 lua require('orgmode.config'):setup_mappings('text_objects')
 

--- a/indent/org.vim
+++ b/indent/org.vim
@@ -1,3 +1,8 @@
+if exists('b:did_indent')
+  finish
+endif
+let b:did_indent = 1
+
 function! OrgmodeIndentExpr()
   return luaeval('require("orgmode.org.indent").indentexpr()')
 endfunction


### PR DESCRIPTION
Use `did_ftplugin` for early return is a standard practice in vim. The commit that introduced this change was aiming to solve a treesitter bug which should be outside of orgmode's scope (see #447).

At the time #447 was issued, I was thinking about this is a telescope bug, but indeed this is a treesitter's bug, see https://github.com/nvim-treesitter/nvim-treesitter/issues/4754.

And indeed this commit only solves #447 partially. The first time you opened an org file via telescope, the fold works correctly, but the second time you opened a file via telescope, the fold does not work again.

Based on above description, I think we should revert the changes and follow the standard practice of vim's ftplugin. And let the bugs to be fixed in upstream.