### PR TITLE
feat(ui): virtual indent

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1275,7 +1275,7 @@ In order for the menu to work as expected, the handler must call `action` from `
 
 ### Virtual indent
 
-Virtual indentation is the indentation that the user sees, which does not exist in the file. In other words, white space margins are part of the user interface, not the contents of the file. In emacs org-mode, this feature is called [Org Indent Mode](https://orgmode.org/manual/Org-Indent-Mode.html).
+Virtual indentation is the indentation that the user sees, which does not exist in the file. In other words, white space indents are part of the user interface, not the contents of the file. In emacs org-mode, this feature is called [Org Indent Mode](https://orgmode.org/manual/Org-Indent-Mode.html).
 
 For example, here's what the user sees:
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -1275,6 +1275,29 @@ In order for the menu to work as expected, the handler must call `action` from `
 
 ### Virtual indent
 
+Virtual indentation is the indentation that the user sees, which does not exist in the file. In other words, white space margins are part of the user interface, not the contents of the file. In emacs org-mode, this feature is called [Org Indent Mode](https://orgmode.org/manual/Org-Indent-Mode.html).
+
+For example, here's what the user sees:
+
+```org
+* Heading 1
+  text under heading 1
+  ** Heading 2
+     text under heading 2
+     *** Heading 3
+         text under heading 3
+```
+
+The contents of the file are:
+```org
+* Heading 1
+text under heading 1
+** Heading 2
+text under heading 2
+*** Heading 3
+text under heading 3
+```
+
 In order to activate virtual indent, set the `org_indent_mode` parameter to `'virtual_indent'`:
 
 ```lua
@@ -1285,7 +1308,7 @@ require('orgmode').setup({
 
 You can learn more about the `org_indent_mode` parameter in the [corresponding section](#org_indent_mode). 
 
-The user can customize the virtual indentation. The user can customize the virtual indentation. To do this, you need to pass the handler to the corresponding `handler` parameter:
+To customize the highlighting of the virtual indentation, use the `OrgIndent` highlighting group. Also user can configure the virtual indentation by passing their own handler to the corresponding `handler` parameter:
 ```lua
 require('orgmode').setup({
   ui = {

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -1,5 +1,6 @@
 lua require('orgmode.config'):setup_mappings('org')
 lua require('orgmode.config'):setup_mappings('text_objects')
+lua require('orgmode.org.indent').setup()
 
 function! OrgmodeFoldText()
   return luaeval('require("orgmode.org.indent").foldtext()')
@@ -14,7 +15,7 @@ function! OrgmodeFormatExpr()
 endfunction
 
 setlocal nomodeline
-setlocal fillchars+=fold:\ 
+setlocal fillchars+=fold:\
 setlocal foldmethod=expr
 setlocal foldexpr=nvim_treesitter#foldexpr()
 setlocal foldtext=OrgmodeFoldText()

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -15,7 +15,7 @@ function! OrgmodeFormatExpr()
 endfunction
 
 setlocal nomodeline
-setlocal fillchars+=fold:\
+setlocal fillchars+=fold:\ 
 setlocal foldmethod=expr
 setlocal foldexpr=nvim_treesitter#foldexpr()
 setlocal foldtext=OrgmodeFoldText()

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -175,6 +175,9 @@ local DefaultConfig = {
     menu = {
       handler = nil,
     },
+    virtual_indent = {
+      handler = nil,
+    },
   },
 }
 

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -1,6 +1,7 @@
 local ts = require('orgmode.treesitter.compat')
 local config = require('orgmode.config')
 local ts_utils = require('nvim-treesitter.ts_utils')
+local VirtualIndent = require('orgmode.ui.virtual-indent')
 local query = nil
 
 local get_matches = ts_utils.memoize_by_buf_tick(function(bufnr)
@@ -194,8 +195,15 @@ local function foldtext()
   return line .. config.org_ellipsis
 end
 
+local function setup()
+  if config.org_indent_mode == 'virtual_indent' then
+    VirtualIndent:new(config.ui.virtual_indent):attach()
+  end
+end
+
 return {
   foldexpr = foldexpr,
   indentexpr = indentexpr,
   foldtext = foldtext,
+  setup = setup,
 }

--- a/lua/orgmode/ui/virtual-indent.lua
+++ b/lua/orgmode/ui/virtual-indent.lua
@@ -58,8 +58,6 @@ function VirtualIndent:set_indent(start_line, end_line)
         virt_text = { { string.rep(' ', indent) } },
         virt_text_pos = 'inline',
         right_gravity = false,
-        virt_text_hide = true,
-        priority = 1,
       })
     end
   end

--- a/lua/orgmode/ui/virtual-indent.lua
+++ b/lua/orgmode/ui/virtual-indent.lua
@@ -1,0 +1,86 @@
+local Headline = require('orgmode.treesitter.headline')
+
+local VirtualIndent = {}
+
+function VirtualIndent:new(data)
+  data = data or {}
+
+  local default_name = 'orgmode.ui.indent'
+
+  local opts = {}
+  opts.ns_id = vim.api.nvim_create_namespace(data.namespace or default_name)
+  opts.augroup = vim.api.nvim_create_augroup(data.augroup_name or default_name, {})
+
+  setmetatable(opts, self)
+  self.__index = self
+  return opts
+end
+
+function VirtualIndent:_delete_old_extmarks(start_line, end_line)
+  local old_extmarks = vim.api.nvim_buf_get_extmarks(
+    0,
+    self.ns_id,
+    { start_line, 0 },
+    { end_line, 0 },
+    { type = 'virt_text' }
+  )
+  for _, ext in ipairs(old_extmarks) do
+    vim.api.nvim_buf_del_extmark(0, self.ns_id, ext[1])
+  end
+end
+
+function VirtualIndent:_get_indent_size(line)
+  local headline = Headline.from_cursor({ line + 1, 1 })
+  if headline then
+    local level = headline:level()
+    local headline_line, _, _ = headline.headline:start()
+
+    if headline_line == line then
+      return level - 1
+    else
+      return level * 2
+    end
+  end
+
+  return 0
+end
+
+function VirtualIndent:set_indent(start_line, end_line)
+  end_line = math.min(end_line, vim.fn.line('$') - 1)
+
+  self:_delete_old_extmarks(start_line, end_line)
+
+  for line = start_line, end_line do
+    local indent = self:_get_indent_size(line)
+
+    if indent and indent > 0 then
+      vim.api.nvim_buf_set_extmark(0, self.ns_id, line, 0, {
+        virt_text = { { string.rep(' ', indent) } },
+        virt_text_pos = 'inline',
+        right_gravity = false,
+        virt_text_hide = true,
+        priority = 1,
+      })
+    end
+  end
+end
+
+function VirtualIndent:attach()
+  vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+    pattern = { '*.org' },
+    group = self.augroup,
+    callback = function()
+      self:set_indent(0, vim.fn.line('$') - 1)
+
+      vim.api.nvim_buf_attach(0, true, {
+        on_lines = function(_, _, _, start_line, old_last_line, new_last_line)
+          vim.schedule(function()
+            self:set_indent(start_line, math.max(old_last_line, new_last_line))
+          end)
+        end,
+      })
+    end,
+  })
+end
+
+return VirtualIndent

--- a/lua/orgmode/ui/virtual-indent.lua
+++ b/lua/orgmode/ui/virtual-indent.lua
@@ -1,36 +1,48 @@
 local Headline = require('orgmode.treesitter.headline')
 
+---@alias VirtualIndentHandler fun(buffer:number, start_line: number, end_line: number) function that sets the indentation
+
+---@class VirtualIndent
+---@field private _ns_id number extmarks namespace id
+---@field private _handler VirtualIndentHandler? function that sets the indentation
 local VirtualIndent = {}
 
+---@class VirtualIndentData
+---@field handler VirtualIndentHandler? function that sets the indentation
+
+---@param data VirtualIndentData
 function VirtualIndent:new(data)
   data = data or {}
 
-  local default_name = 'orgmode.ui.indent'
+  vim.validate({
+    handler = { data.handler, 'function', true },
+  })
 
   local opts = {}
-  opts.ns_id = vim.api.nvim_create_namespace(data.namespace or default_name)
-  opts.augroup = vim.api.nvim_create_augroup(data.augroup_name or default_name, {})
+  opts._ns_id = vim.api.nvim_create_namespace('orgmode.ui.indent')
+  opts._handler = data.handler
 
   setmetatable(opts, self)
   self.__index = self
   return opts
 end
 
-function VirtualIndent:_delete_old_extmarks(start_line, end_line)
+function VirtualIndent:_delete_old_extmarks(buffer, start_line, end_line)
   local old_extmarks = vim.api.nvim_buf_get_extmarks(
-    0,
-    self.ns_id,
+    buffer,
+    self._ns_id,
     { start_line, 0 },
     { end_line, 0 },
     { type = 'virt_text' }
   )
   for _, ext in ipairs(old_extmarks) do
-    vim.api.nvim_buf_del_extmark(0, self.ns_id, ext[1])
+    vim.api.nvim_buf_del_extmark(0, self._ns_id, ext[1])
   end
 end
 
 function VirtualIndent:_get_indent_size(line)
   local headline = Headline.from_cursor({ line + 1, 1 })
+
   if headline then
     local level = headline:level()
     local headline_line, _, _ = headline.headline:start()
@@ -45,17 +57,21 @@ function VirtualIndent:_get_indent_size(line)
   return 0
 end
 
-function VirtualIndent:set_indent(start_line, end_line)
-  end_line = math.min(end_line, vim.fn.line('$') - 1)
+---@param buffer number buffer id
+---@param start_line number start line number, 0-based inclusive
+---@param end_line number end line number, 0-based inclusive
+function VirtualIndent:set_indent(buffer, start_line, end_line)
+  if self._handler then
+    return self._handler(buffer, start_line, end_line)
+  end
 
-  self:_delete_old_extmarks(start_line, end_line)
-
+  self:_delete_old_extmarks(buffer, start_line, end_line)
   for line = start_line, end_line do
     local indent = self:_get_indent_size(line)
 
-    if indent and indent > 0 then
-      vim.api.nvim_buf_set_extmark(0, self.ns_id, line, 0, {
-        virt_text = { { string.rep(' ', indent) } },
+    if indent > 0 then
+      vim.api.nvim_buf_set_extmark(buffer, self._ns_id, line, 0, {
+        virt_text = { { string.rep(' ', indent), 'OrgIndent' } },
         virt_text_pos = 'inline',
         right_gravity = false,
       })
@@ -63,20 +79,21 @@ function VirtualIndent:set_indent(start_line, end_line)
   end
 end
 
-function VirtualIndent:attach()
-  vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
-    pattern = { '*.org' },
-    group = self.augroup,
-    callback = function()
-      self:set_indent(0, vim.fn.line('$') - 1)
+---@param buffer number buffer id
+function VirtualIndent:attach(buffer)
+  vim.validate({
+    buffer = { buffer, 'number', true },
+  })
 
-      vim.api.nvim_buf_attach(0, true, {
-        on_lines = function(_, _, _, start_line, old_last_line, new_last_line)
-          vim.schedule(function()
-            self:set_indent(start_line, math.max(old_last_line, new_last_line))
-          end)
-        end,
-      })
+  buffer = buffer or 0
+
+  self:set_indent(buffer, 0, vim.api.nvim_buf_line_count(buffer) - 1)
+
+  vim.api.nvim_buf_attach(buffer, true, {
+    on_lines = function(_, _, _, start_line, _, end_line)
+      vim.schedule(function()
+        self:set_indent(buffer, start_line, end_line)
+      end)
     end,
   })
 end

--- a/lua/orgmode/ui/virtual-indent.lua
+++ b/lua/orgmode/ui/virtual-indent.lua
@@ -36,7 +36,7 @@ function VirtualIndent:_delete_old_extmarks(buffer, start_line, end_line)
     { type = 'virt_text' }
   )
   for _, ext in ipairs(old_extmarks) do
-    vim.api.nvim_buf_del_extmark(0, self._ns_id, ext[1])
+    vim.api.nvim_buf_del_extmark(buffer, self._ns_id, ext[1])
   end
 end
 
@@ -58,8 +58,8 @@ function VirtualIndent:_get_indent_size(line)
 end
 
 ---@param buffer number buffer id
----@param start_line number start line number, 0-based inclusive
----@param end_line number end line number, 0-based inclusive
+---@param start_line number start line number to set the indentation, 0-based inclusive
+---@param end_line number end line number to set the indentation, 0-based inclusive
 function VirtualIndent:set_indent(buffer, start_line, end_line)
   if self._handler then
     return self._handler(buffer, start_line, end_line)

--- a/lua/orgmode/utils/treesitter.lua
+++ b/lua/orgmode/utils/treesitter.lua
@@ -92,7 +92,10 @@ end
 -- returns the nearest headline
 function M.closest_headline(cursor)
   vim.treesitter.get_parser(0, 'org', {}):parse()
-  return M.find_headline(M.get_node_at_cursor(cursor))
+  local node = M.get_node_at_cursor(cursor)
+  if node then
+    return M.find_headline(node)
+  end
 end
 
 function M.find_parent_type(node, type)


### PR DESCRIPTION
### Preview

https://github.com/nvim-orgmode/orgmode/assets/57654917/b8429fba-bf52-4cfc-8d04-7243418e8099

### How to try it

1. Install neovim with neovim/neovim#23426

2. Add the following code to your `orgmode` configuration:
```lua
local VirtualIndent = require("orgmode.ui.virtual-indent"):new()
VirtualIndent:attach()
```

### TODO

- [x] Customizable indentation size (hidden or visible stars, possibly custom indentation)
- [x] Documentation