### PR TITLE
Open file hyperlinks starting with ~

### DIFF
--- a/lua/orgmode/org/hyperlinks.lua
+++ b/lua/orgmode/org/hyperlinks.lua
@@ -148,6 +148,9 @@ end
 function Hyperlinks.get_file_real_path(url_path)
   local path = url_path
   path = path:gsub('^file:', '')
+  if path:match('^~/') then
+    path = path:gsub('^~', os.getenv('HOME'))
+  end
   if path:match('^/') then
     return path
   end


### PR DESCRIPTION
Added a small check for hyperlinks that start with tildes to substitute them with `$HOME` on `<Leader>oo`.