### PR TITLE
fix: Fix executable check in `utils.open`

### DIFF
--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -40,15 +40,15 @@ function utils.readfile(file, callback, as_string)
 end
 
 function utils.open(target)
-  if vim.fn.executable('xdg-open') then
+  if vim.fn.executable('xdg-open') == 1 then
     return vim.fn.system(string.format('xdg-open %s', target))
   end
 
-  if vim.fn.executable('open') then
+  if vim.fn.executable('open') == 1 then
     return vim.fn.system(string.format('open %s', target))
   end
 
-  if vim.fn.has('win32') then
+  if vim.fn.has('win32') == 1 then
     return vim.fn.system(string.format('start "%s"', target))
   end
 end


### PR DESCRIPTION
The previous implementation of `utils.open` did not properly check if the necessary executables were present. In Lua, `0` is treated as `true`, so it always tried to run `xdg-open` even when the executable was not found, preventing the proper command from being executed. This pr updates the check to correctly use the return values of `vim.fn.executable` and `vim.fn.has` functions.
