### PR TITLE
feat: Opening hyperlinks externally

### DIFF
--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -52,6 +52,7 @@ local DefaultConfig = {
     deadline_reminder = true,
     scheduled_reminder = true,
   },
+  org_nontext_hyperlinks = false,
   org_external_opener = 'xdg-open',
   mappings = {
     disable_all = false,

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -52,6 +52,7 @@ local DefaultConfig = {
     deadline_reminder = true,
     scheduled_reminder = true,
   },
+  org_external_opener = 'xdg-open',
   mappings = {
     disable_all = false,
     prefix = '<Leader>o',

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -54,6 +54,15 @@ local DefaultConfig = {
   },
   org_nontext_hyperlinks = false,
   org_external_opener = 'xdg-open',
+  org_link_types = {
+    shell = {
+      handler = function(url)
+        url = string.gsub(url, '^shell:', '')
+        vim.fn.jobstart(url, { detach = true })
+        return
+      end,
+    },
+  },
   mappings = {
     disable_all = false,
     prefix = '<Leader>o',

--- a/lua/orgmode/org/hyperlinks.lua
+++ b/lua/orgmode/org/hyperlinks.lua
@@ -148,6 +148,9 @@ end
 function Hyperlinks.get_file_real_path(url_path)
   local path = url_path
   path = path:gsub('^file:', '')
+  if path:match('^~/') then
+    path = path:gsub('^~', os.getenv('HOME'))
+  end
   if path:match('^/') then
     return path
   end

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -754,7 +754,6 @@ function OrgMappings:open_at_point()
   local parts = vim.split(link, '][', true)
   local url = parts[1]
   local link_ctx = { base = url, skip_add_prefix = true }
-  local ext_opener = 'xdg-open'
 
   if url:find('^file:') then
     if url:find(' +', 1, true) then
@@ -770,7 +769,7 @@ function OrgMappings:open_at_point()
       link_ctx.line = url
     elseif vim.filetype.match({ filename = url }) == nil then
       local filepath = Hyperlinks.get_file_real_path(url)
-      vim.fn.jobstart(ext_opener .. ' ' .. vim.fn.shellescape(filepath), { detach = true })
+      vim.fn.jobstart(config.org_external_opener .. ' ' .. vim.fn.shellescape(filepath), { detach = true })
     else
       vim.cmd(string.format('edit %s', Hyperlinks.get_file_real_path(url)))
       vim.cmd([[normal! zv]])

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -789,8 +789,6 @@ function OrgMappings:open_at_point()
 
   if url:find('^shell:') then
     url = string.gsub(url, '^shell:', '')
-    url = vim.fn.shellescape(url)
-    print(url)
     vim.fn.jobstart(url, { detach = true })
     return
   end

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -787,12 +787,6 @@ function OrgMappings:open_at_point()
     return vim.cmd(string.format('edit %s', url))
   end
 
-  if url:find('^shell:') then
-    url = string.gsub(url, '^shell:', '')
-    vim.fn.jobstart(url, { detach = true })
-    return
-  end
-
   pref = string.gsub(url, '^(.-):.*', '%1')
   if config.org_link_types[pref] ~= nil then
     config.org_link_types[pref].handler(url)

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -787,11 +787,12 @@ function OrgMappings:open_at_point()
     return vim.cmd(string.format('edit %s', url))
   end
 
-  if url:find('^custom:') then
-    url = string.gsub(url, '^custom:', '')
-    local opener = string.gsub(url, '^(.-):.*', '%1')
-    local target = string.gsub(url, '^.-:', '')
-    vim.fn.jobstart(opener .. ' ' .. vim.fn.shellescape(target), { detach = true })
+  if url:find('^shell:') then
+    url = string.gsub(url, '^shell:', '')
+    url = vim.fn.shellescape(url)
+    print(url)
+    vim.fn.jobstart(url, { detach = true })
+    return
   end
 
   local headlines = Hyperlinks.find_matching_links(link_ctx)

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -793,6 +793,12 @@ function OrgMappings:open_at_point()
     return
   end
 
+  pref = string.gsub(url, '^(.-):.*', '%1')
+  if config.org_link_types[pref] ~= nil then
+    config.org_link_types[pref].handler(url)
+    return
+  end
+
   local headlines = Hyperlinks.find_matching_links(link_ctx)
   local current_headline = Files.get_closest_headline()
   if current_headline then

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -767,7 +767,7 @@ function OrgMappings:open_at_point()
 
     if url:find('^file:(.-)::') then
       link_ctx.line = url
-    elseif vim.filetype.match({ filename = url }) == nil then
+    elseif config.org_nontext_hyperlinks and vim.filetype.match({ filename = url }) == nil then
       local filepath = Hyperlinks.get_file_real_path(url)
       vim.fn.jobstart(config.org_external_opener .. ' ' .. vim.fn.shellescape(filepath), { detach = true })
     else


### PR DESCRIPTION
This is a stab at https://github.com/nvim-orgmode/orgmode/issues/563 and https://github.com/nvim-orgmode/orgmode/issues/506. `<Leader>oo` now opens linked files with `xdg-open`.
There is also an option to specify `custom:` links, which I would like to read your thoughts on:
```
[[custom:nsxiv:~/some-gif.gif][]] - This link opens a GIF file in nsxiv
[[file:~/some-gif.gif][]] - This link opens a GIF file with the specified default opener
[[file:~/org/notes.org]] - Regular behaviour on open
```
## Issues
This functionality depends on nvim's `vim.filetype.match()` behaviour, which returns `nil` on unrecognized filetypes inferred from the filename. The issue with this is that some plaintext (i.e. `.txt` or files without an extension) would be opened externally. Directories are also treated as externally openable (https://github.com/nvim-orgmode/orgmode/issues/556). If this is not desired behaviour for directories, this could be fixed by checking the type with `vim.loop.fs_stat` and made configurable. 
