### PR TITLE
fix: links with relative path to parent directories

### DIFF
--- a/lua/orgmode/org/hyperlinks.lua
+++ b/lua/orgmode/org/hyperlinks.lua
@@ -3,7 +3,16 @@ local utils = require('orgmode.utils')
 local Hyperlinks = {}
 
 local function get_file_from_context(ctx)
-  return (ctx.hyperlinks and ctx.hyperlinks.filepath and Files.get(ctx.hyperlinks.filepath) or Files.get_current_file())
+  local filepath = (ctx.hyperlinks and ctx.hyperlinks.filepath)
+  if not filepath then
+    return Files.get_current_file()
+  end
+  local canonical = vim.loop.fs_realpath(filepath)
+  if not canonical then
+    return Files.get_current_file()
+  end
+
+  return Files.get(canonical)
 end
 
 local function update_hyperlink_ctx(ctx)
@@ -21,6 +30,10 @@ local function update_hyperlink_ctx(ctx)
   local file_match = ctx.line:match('file:(.-)::')
   if file_match then
     file_match = Hyperlinks.get_file_real_path(file_match)
+  end
+
+  if file_match then
+    file_match = vim.loop.fs_realpath(file_match)
   end
 
   if file_match and Files.get(file_match) then

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -218,11 +218,15 @@ describe('Autocompletion', function()
     })
 
     mock_line(api, string.format('  [[file:%s::*', filename))
+    local vim_loop = mock(vim.loop, true)
+    vim_loop.fs_realpath.returns(filename)
     result = OrgmodeOmniCompletion(0, '*')
     assert.are.same({
       { menu = '[Org]', word = '*' .. headlines[1].title },
       { menu = '[Org]', word = '*' .. headlines[2].title },
     }, result)
+
+    mock.revert(vim_loop)
 
     mock.revert(MockFiles)
 


### PR DESCRIPTION
Fixed headline autocompletion and jumping to files in parent or sibling directories. See also [org-open-at-point](https://orgmode.org/org.html#index-C_002dc-C_002do) in the Org manual. It solves issue [#583](https://github.com/nvim-orgmode/orgmode/issues/583).