### PR TITLE
Allow dynamic target in capture templates

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -421,6 +421,15 @@ Journal example:<br />
   } }
   ```
 
+Journal example with dynamic target, i.e. a separate file per month:<br />
+  ```lua
+  { J = {
+    description = 'Journal',
+    template = '\n*** %<%Y-%m-%d> %<%A>\n**** %U\n\n%?',
+    target = '~/sync/org/journal/%<%Y-%m>.org'
+  } }
+  ```
+
 Nested key example:<br />
   ```lua
   {

--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -135,7 +135,9 @@ end
 ---@private
 function Capture:_get_refile_vars()
   local template = vim.api.nvim_buf_get_var(0, 'org_template') or {}
-  local file = vim.fn.resolve(vim.fn.fnamemodify(template.target or config.org_default_notes_file, ':p'))
+  local target = self.templates:compile_target(template.target or config.org_default_notes_file)
+  local file = vim.fn.resolve(vim.fn.fnamemodify(target, ':p'))
+
   if vim.fn.filereadable(file) == 0 then
     local choice = vim.fn.confirm(('Refile destination %s does not exist. Create now?'):format(file), '&Yes\n&No')
     if choice ~= 1 then

--- a/lua/orgmode/capture/templates.lua
+++ b/lua/orgmode/capture/templates.lua
@@ -55,11 +55,14 @@ function Templates:compile(template)
   if type(content) == 'table' then
     content = table.concat(content, '\n')
   end
-  content = self:_compile_dates(content)
-  content = self:_compile_expansions(content)
-  content = self:_compile_expressions(content)
-  content = self:_compile_prompts(content)
+  content = self:_compile(content)
   return vim.split(content, '\n', true)
+end
+
+---@param target string
+---@return string
+function Templates:compile_target(target)
+  return self:_compile(target)
 end
 
 function Templates:setup()
@@ -74,6 +77,17 @@ function Templates:setup()
       vim.cmd([[startinsert]])
     end
   end
+end
+
+---@private
+---@param content string
+---@return string
+function Templates:_compile(content)
+  content = self:_compile_dates(content)
+  content = self:_compile_expansions(content)
+  content = self:_compile_expressions(content)
+  content = self:_compile_prompts(content)
+  return content
 end
 
 ---@param content string


### PR DESCRIPTION
Internally this compiles the target of the capture template the same way the template itself is compiled.

Also update the docs accordingly.

This is inspired by: https://github.com/nvim-orgmode/orgmode/discussions/540