### PR TITLE
`vim.v.count1` is needed on fallback mapping so `<count><C-A>` mappings work outside dates

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -173,19 +173,19 @@ function OrgMappings:toggle_checkbox()
 end
 
 function OrgMappings:timestamp_up_day()
-  return self:_adjust_date(vim.v.count1, 'd', config.mappings.org.org_timestamp_up_day)
+  return self:_adjust_date(vim.v.count1, 'd', vim.v.count1 .. config.mappings.org.org_timestamp_up_day)
 end
 
 function OrgMappings:timestamp_down_day()
-  return self:_adjust_date(-vim.v.count1, 'd', config.mappings.org.org_timestamp_down_day)
+  return self:_adjust_date(-vim.v.count1, 'd', vim.v.count1 .. config.mappings.org.org_timestamp_down_day)
 end
 
 function OrgMappings:timestamp_up()
-  return self:_adjust_date_part('+', vim.v.count1, config.mappings.org.org_timestamp_up)
+  return self:_adjust_date_part('+', vim.v.count1, vim.v.count1 .. config.mappings.org.org_timestamp_up)
 end
 
 function OrgMappings:timestamp_down()
-  return self:_adjust_date_part('-', vim.v.count1, config.mappings.org.org_timestamp_down)
+  return self:_adjust_date_part('-', vim.v.count1, vim.v.count1 .. config.mappings.org.org_timestamp_down)
 end
 
 function OrgMappings:_adjust_date_part(direction, amount, fallback)


### PR DESCRIPTION
Currently pressing `6<C-A>` outside of a date just adds 1 instead of 6 to a number that isn't a date. This is because the fallback mapping does not include `vim.v.count1`.