### PR TITLE
feat: Allow for configuration of `foldlevel` similar to Emacs Orgmode

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -153,6 +153,15 @@ Applies to:
         - agenda window
         - capture window
 
+#### **org_startup_folded**
+*type*: `string`<br />
+*default value*: `overview`<br />
+How many headings and other foldable items should be shown when an org file is opened.<br />
+Available options:
+* `overview` - Only show top level elements (default)
+* `content` - Only show the first two levels
+* `showeverything` - A double line box
+* `inherit` - Use the fold level set in Neovim's global `foldlevel` option
 
 #### **org_todo_keyword_faces**
 *type*: `table<string, string>`<br />

--- a/ftplugin/org.vim
+++ b/ftplugin/org.vim
@@ -5,6 +5,7 @@ let b:did_ftplugin = 1
 
 lua require('orgmode.config'):setup_mappings('org')
 lua require('orgmode.config'):setup_mappings('text_objects')
+lua require('orgmode.config'):setup_foldlevel()
 
 function! OrgmodeFoldText()
   return luaeval('require("orgmode.org.indent").foldtext()')
@@ -24,7 +25,6 @@ setlocal foldmethod=expr
 setlocal foldexpr=nvim_treesitter#foldexpr()
 setlocal foldtext=OrgmodeFoldText()
 setlocal formatexpr=OrgmodeFormatExpr()
-setlocal foldlevel=0
 setlocal omnifunc=OrgmodeOmni
 setlocal commentstring=#\ %s
 inoreabbrev <silent><buffer> :today: <C-R>=luaeval("require('orgmode.objects.date').today():to_wrapped_string(true)")<CR>

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -16,6 +16,7 @@ local DefaultConfig = {
       template = '* TODO %?\n  %u',
     },
   },
+  org_startup_folded = 'overview',
   org_agenda_skip_scheduled_if_done = false,
   org_agenda_skip_deadline_if_done = false,
   org_agenda_text_search_extra_files = {},

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -301,8 +301,8 @@ function Config:setup_foldlevel()
   elseif self.org_startup_folded == 'showeverything' then
     vim.opt_local.foldlevel = 99
   elseif self.org_startup_folded ~= 'inherit' then
-    vim.notify("Invalid option passed for 'org_startup_folded'!", vim.log.levels.WARN)
-    self.org_startup_folded = 'overview'
+    utils.echo_warning("Invalid option passed for 'org_startup_folded'!")
+    self.opts.org_startup_folded = 'overview'
     self:setup_foldlevel()
   end
 end

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -292,6 +292,21 @@ function Config:setup_mappings(category, buffer)
   end
 end
 
+--- Setup the foldlevel for a given org file
+function Config:setup_foldlevel()
+  if self.org_startup_folded == 'overview' then
+    vim.opt_local.foldlevel = 0
+  elseif self.org_startup_folded == 'content' then
+    vim.opt_local.foldlevel = 1
+  elseif self.org_startup_folded == 'showeverything' then
+    vim.opt_local.foldlevel = 99
+  elseif self.org_startup_folded ~= 'inherit' then
+    vim.notify("Invalid option passed for 'org_startup_folded'!", vim.log.levels.WARN)
+    self.org_startup_folded = 'overview'
+    self:setup_foldlevel()
+  end
+end
+
 ---@return string|nil
 function Config:parse_archive_location(file, archive_loc)
   if self:is_archive_file(file) then


### PR DESCRIPTION
### Summary
This PR permits configuration of the default fold level via the setup variable `org_startup_folded`.

- This PR fixes the issues identified in #614 as a user can now better modify the fold level used by Orgmode
- This PR also solves issues with `nvim-ufo` integration (#599) to a certain degree
  - It "solves" the issue for `nvim-ufo` users (such as I) by permitting them to inherit their `vim.opt.foldlevel` instead of using Orgmode's provided fold level. This makes Orgmode play nice with `nvim-ufo`. My earlier problems with `fillchars` cannot be reproduced at this time, so I consider it a non-issue.
- Wrote documentation to the `DOCS.md` file for the new option. As a note I have ***not*** written new documentation to the Orgmode help file. I noticed that it appeared autogenerated so I held off on that until I get some confirmation.

### Notes

- This PR introduced the new configuration variable as `org_startup_folded` with a default value of `overview`.
- The `org_startup_folded` mirrors the values and usage from [Emacs equivalent](https://orgmode.org/manual/Initial-visibility.html) with the same values for configuration
- This new configuration option doesn't play nice with users who lazy load on the `Filetype` event as the `foldlevel` is set upon that event matching for `org` file types.
  - A way to fix that is to add a line in their config `vim.cmd.edit()` after Neorg's initial load which will reload the file and retrigger the `Filetype` event permitting the event to work as anticipated.
- I had to pass the Orgmode config around in the `lua/orgmode/init.lua` file such that I could access the value of `config.org_startup_folded` and set the `foldlevel` accordingly.
- This PR conditionally sets the `foldlevel` value with logic embedded directly into the `setup_autocmds` `FileType` autocmd. If you dislike that, please do guide me as to where that logic should be placed.
- I created an inline type for the `org_startup_folded` variable in the `DefaultConfig`. This seems to be the only place within the `DefaultConfig` where that is done. If this is not desired I can readily rebase and remove the annotation.

### A Recommendation

If Nvim Orgmode isn't deadset on being a 100% spec accurate implementation of Orgmode (which I suspect it is attempting to be), I would recommend rejecting this PR in favor of using a more Vim-centric way of setting the `foldlevel`.

That is, don't even set the `foldlevel`, make the user set it themselves. If they want a different `foldlevel` for only `org` files then they can use an `autocmd` or a `ftplugin` located in their config at `after/ftplugin/org.lua`.

On the other hand, if Nvim Orgmode *is* deadset on being a 100% compliant implementation of Orgmode, then this PR will bring the implementation closer to the spec.

### Fin.

Feel free to provide critique and advice, I'm certainly inexperienced in working with Nvim Orgmode's code base, this PR marks the first time I have ever done so. Any thoughts you have are very much desired 😃.

Closes #614
Only partially resolves #599, for a tighter integration we may want to autodetect `nvim-ufo` and set the `foldlevel` accordingly.