### PR TITLE
docs(folds): better org_startup_folded.showeverything description

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -160,7 +160,7 @@ How many headings and other foldable items should be shown when an org file is o
 Available options:
 * `overview` - Only show top level elements (default)
 * `content` - Only show the first two levels
-* `showeverything` - A double line box
+* `showeverything` - Show all elements
 * `inherit` - Use the fold level set in Neovim's global `foldlevel` option
 
 #### **org_todo_keyword_faces**


### PR DESCRIPTION
Changing this setting's description to what it actually corresponds to.