### PR TITLE
fix(hyperlinks): link-follow for "file:../" and "../"

### DIFF
--- a/lua/orgmode/objects/url.lua
+++ b/lua/orgmode/objects/url.lua
@@ -50,7 +50,7 @@ function Url:is_org_link()
 end
 
 function Url:is_file()
-  return self.str:find('^file:') or self.str:find('^./') or self.str:find('^/')
+  return self.str:find('^file:') or self.str:find('^%.%./') or self.str:find('^%./') or self.str:find('^/')
 end
 
 function Url:is_file_plain()
@@ -79,11 +79,20 @@ end
 function Url:extract_path()
   local url = self
   if url:is_file_headline() or url:is_file_custom_id() then
-    return url.str:match('^file:([^:]-)::') or url.str:match('^(./[^:]-)::') or url.str:match('^(/[^:]-)::')
+    return url.str:match('^file:([^:]-)::')
+      or url.str:match('^(%.%./[^:]-)::')
+      or url.str:match('^(%./[^:]-)::')
+      or url.str:match('^(/[^:]-)::')
   elseif url:is_file_line_number() then
-    return url.str:match('^file:([^:]-) %+') or url.str:match('^(./[^:]-) %+') or url.str:match('^(/[^:]-) %+')
+    return url.str:match('^file:([^:]-) %+')
+      or url.str:match('^(%.%./[^:]-) %+')
+      or url.str:match('^(%./[^:]-) %+')
+      or url.str:match('^(/[^:]-) %+')
   elseif url:is_file_plain() then
-    return url.str:match('^file:([^:]-)$') or url.str:match('^(./[^:]-)$') or url.str:match('^(/[^:]-)$')
+    return url.str:match('^file:([^:]-)$')
+      or url.str:match('^(%.%./[^:]-)$')
+      or url.str:match('^(%./[^:]-)$')
+      or url.str:match('^(/[^:]-)$')
   else
     return false
   end
@@ -98,7 +107,8 @@ end
 ---@return string | false
 function Url:get_headline()
   return self.str:match('^file:[^:]+::%*(.-)$')
-    or self.str:match('^./[^:]+::%*(.-)$')
+    or self.str:match('^%.%./[^:]+::%*(.-)$')
+    or self.str:match('^%./[^:]+::%*(.-)$')
     or self.str:match('^/[^:]+::%*(.-)$')
     or self.str:match('^%*(.-)$')
 end
@@ -106,7 +116,8 @@ end
 ---@return string | false
 function Url:get_custom_id()
   return self.str:match('^file:[^:]+::#(.-)$')
-    or self.str:match('^./[^:]+::#(.-)$')
+    or self.str:match('^%.%./[^:]+::#(.-)$')
+    or self.str:match('^%./[^:]+::#(.-)$')
     or self.str:match('^/[^:]+::#(.-)$')
     or self.str:match('^#(.-)$')
 end
@@ -115,11 +126,13 @@ end
 function Url:get_linenumber()
   -- official orgmode convention
   return self.str:match('^file:[^:]+::(%d+)$')
-    or self.str:match('^./[^:]+::(%d+)$')
+    or self.str:match('^%.%./[^:]+::(%d+)$')
+    or self.str:match('^%./[^:]+::(%d+)$')
     or self.str:match('^/[^:]+::(%d+)$')
     -- for backwards compatibility
     or self.str:match('^file:[^:]+ %+(%d+)$')
-    or self.str:match('^./[^:]+ %+(%d+)$')
+    or self.str:match('^%.%./[^:]+ %+(%d+)$')
+    or self.str:match('^%./[^:]+ %+(%d+)$')
     or self.str:match('^/[^:]+ %+(%d+)$')
 end
 
@@ -128,15 +141,19 @@ function Url:get_filepath()
   return
     -- for backwards compatibility
     self.str:match('^file:([^:]+) %+%d+')
+      or self.str:match('^(%.%./[^:]+) %+%d+')
       or self.str:match('^(%./[^:]+) %+%d+')
       or self.str:match('^(/[^:]+) %+%d+')
       -- official orgmode convention
       or self.str:match('^file:([^:]+)::')
+      or self.str:match('^(%.%./[^:]+)::')
       or self.str:match('^(%./[^:]+)::')
       or self.str:match('^(/[^:]+)::')
       or self.str:match('^file:([^:]+)$')
+      or self.str:match('^(%.%./[^:]+)$')
       or self.str:match('^(%./[^:]+)$')
       or self.str:match('^(/[^:]+)$')
+      or self.str:match('^(%.%./)$')
       or self.str:match('^(%./)$')
       or self.str:match('^(/)$')
 end

--- a/lua/orgmode/utils/fs.lua
+++ b/lua/orgmode/utils/fs.lua
@@ -10,9 +10,12 @@ function M.substitute_path(path_str)
   elseif path_str:match('^~/') then
     local home_path = os.getenv('HOME')
     return home_path and path_str:gsub('^~', home_path) or false
-  elseif path_str:match('^./') then
+  elseif path_str:match('^%./') then
     local base = vim.fn.fnamemodify(utils.current_file_path(), ':p:h')
-    return base .. '/' .. path_str:gsub('^./', '')
+    return base .. '/' .. path_str:gsub('^%./', '')
+  elseif path_str:match('^%.%./') then
+    local base = vim.fn.fnamemodify(utils.current_file_path(), ':p:h')
+    return base .. '/' .. path_str
   else
     return false
   end

--- a/tests/plenary/object/url_spec.lua
+++ b/tests/plenary/object/url_spec.lua
@@ -67,7 +67,9 @@ describe('Url', function()
   it('should handle different file paths', function()
     local filepath_examples = {
       { url_str = 'file:./../some_file', exp = './../some_file' },
+      { url_str = 'file:../some_file', exp = '../some_file' },
       { url_str = './../some_file.txt', exp = './../some_file.txt' },
+      { url_str = '../some_file.txt', exp = '../some_file.txt' },
       { url_str = '/some/path/some_file', exp = '/some/path/some_file' },
       { url_str = 'file:./../some_file.org::*headline', exp = './../some_file.org' },
       { url_str = 'file:./../some_file.org::#custom_id', exp = './../some_file.org' },


### PR DESCRIPTION
Following a relative link starting with "../" is now supported.

Examples:
file:../somedir/some.org
../somedir/some.org

Previous it was possible to follow the first link, but a file "false" got opened instead of the target file. The second type was unsupported.

Because autocompletion works, it was easy for the user to create such links and surprising, that they didn't work.