### PR TITLE
feat: add a way to cache state between restarts of Neovim

### DIFF
--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -150,4 +150,18 @@ function State:load_sync(timeout)
   return state
 end
 
+---Reset the current state to empty
+---@param overwrite? boolean Whether or not the cache should also be wiped
+function State:wipe(overwrite)
+  overwrite = overwrite or false
+
+  self.data = {}
+  self._ctx.curr_loader = nil
+  self._ctx.loaded = false
+  self._ctx.saved = false
+  if overwrite then
+    state:save_sync()
+  end
+end
+
 return State.new()

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -47,9 +47,7 @@ function State:load()
 
   --- If we've already loaded the state from cache we don't need to do so again
   if self._ctx.loaded then
-    return Promise.new(function(resolve, _)
-      return resolve()
-    end)
+    return Promise.resolve()
   end
 
   self._ctx.curr_loader = utils.readfile(cache_path, { raw = true }):next(

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -1,0 +1,100 @@
+local utils = require('orgmode.utils')
+local Promise = require('orgmode.utils.promise')
+
+local State = { data = {}, _ctx = { loaded = false, curr_loader = nil } }
+
+local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
+--- Returns the current State singleton
+function State:new()
+  -- This is done so we can later iterate the 'data'
+  -- subtable cleanly and shove it into a cache
+  setmetatable(State, {
+    __index = function(tbl, key)
+      return tbl.data[key]
+    end,
+    __newindex = function(tbl, key, value)
+      tbl.data[key] = value
+    end,
+  })
+  -- Start trying to load the state from cache as part of initializing the state
+  self:load()
+  return self
+end
+
+---Save the current state to cache
+---@return Promise
+function State:save()
+  --- We want to ensure the state was loaded before saving.
+  return self:load():next(function(_)
+    utils.writefile(cache_path, vim.json.encode(State.data)):next(function(_) end, function(err_msg)
+      vim.schedule_wrap(function()
+        vim.notify('Failed to save current state! Error: ' .. err_msg, vim.log.levels.WARN, { title = 'Orgmode' })
+      end)
+    end)
+  end, function(_) end)
+end
+
+---Load the state cache into the current state
+---@return Promise
+function State:load()
+  --- If we currently have a loading operation already running, return that
+  --- promise. This avoids a race condition of sorts as without this there's
+  --- potential to have two State:load operations occuring and whichever
+  --- finishes last sets the state. Not desirable.
+  if self._ctx.curr_loader ~= nil then
+    return self._ctx.curr_loader
+  end
+
+  --- If we've already loaded the state from cache we don't need to do so again
+  if self._ctx.loaded then
+    return Promise.new(function(resolve, _)
+      return resolve()
+    end)
+  end
+
+  self._ctx.curr_loader = utils.readfile(cache_path, { raw = true }):next(
+    function(data)
+      local success, decoded = pcall(vim.json.decode, data, {
+        luanil = { object = true, array = true },
+      })
+      self._ctx.curr_loader = nil
+      if not success then
+        vim.schedule(function()
+          vim.notify('State cache load failure, error: ' .. decoded, vim.log.levels.WARN, {
+            title = 'Orgmode',
+          })
+          -- Try to 'repair' the cache by saving the current state
+          self:save()
+        end)
+      end
+      -- Because the state cache repair happens potentially after the data has
+      -- been added to the cache, we need to ensure the decoded table is set to
+      -- empty if we got an error back on the json decode operation.
+      if type(decoded) ~= 'table' then
+        decoded = {}
+      end
+
+      self._ctx.loaded = true
+      -- It is possible that while the state was loading from cache values
+      -- were saved into the state. We want to preference the newer values in
+      -- the state and still get whatever values may not have been set in the
+      -- interim of the load operation.
+      self.data = vim.tbl_deep_extend('force', decoded, self.data)
+      return self
+    end, ---@param err string
+    function(err)
+      -- If the file didn't exist then go ahead and save
+      -- our current cache and as a side effect create the file
+      if type(err) == 'string' and err:match([[^ENOENT.*]]) then
+        self:save()
+      else
+        -- If the file did exist, something is wrong. Kick this to the top
+        error(err)
+      end
+    end
+  )
+
+  return self._ctx.curr_loader
+end
+
+return State:new()

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -35,7 +35,7 @@ function State:save()
       end)
       :catch(function(err_msg)
         vim.schedule_wrap(function()
-          vim.notify('Failed to save current state! Error: ' .. err_msg, vim.log.levels.WARN, { title = 'Orgmode' })
+          utils.echo_warning('Failed to save current state! Error: ' .. err_msg)
         end)
       end)
   end)
@@ -67,9 +67,7 @@ function State:load()
       if not success then
         local err_msg = vim.deepcopy(decoded)
         vim.schedule(function()
-          vim.notify('State cache load failure, error: ' .. vim.inspect(err_msg), vim.log.levels.WARN, {
-            title = 'Orgmode',
-          })
+          utils.echo_warning('State cache load failure, error: ' .. vim.inspect(err_msg))
           -- Try to 'repair' the cache by saving the current state
           self:save()
         end)

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -27,18 +27,17 @@ end
 function State:save()
   State._ctx.saved = false
   --- We want to ensure the state was loaded before saving.
-  return self:load():finally(function()
-    utils
-      .writefile(cache_path, vim.json.encode(State.data))
-      :next(function()
-        State._ctx.saved = true
+  self:load()
+  return utils
+    .writefile(cache_path, vim.json.encode(State.data))
+    :next(function()
+      State._ctx.saved = true
+    end)
+    :catch(function(err_msg)
+      vim.schedule_wrap(function()
+        utils.echo_warning('Failed to save current state! Error: ' .. err_msg)
       end)
-      :catch(function(err_msg)
-        vim.schedule_wrap(function()
-          utils.echo_warning('Failed to save current state! Error: ' .. err_msg)
-        end)
-      end)
-  end)
+    end)
 end
 
 ---Load the state cache into the current state

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -4,7 +4,9 @@ local Promise = require('orgmode.utils.promise')
 local State = { data = {}, _ctx = { loaded = false, saved = false, curr_loader = nil } }
 
 local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
---- Returns the current State singleton
+
+---Returns the current State singleton
+---@return State
 function State.new()
   -- This is done so we can later iterate the 'data'
   -- subtable cleanly and shove it into a cache

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -25,13 +25,13 @@ end
 ---@return Promise
 function State:save()
   --- We want to ensure the state was loaded before saving.
-  return self:load():next(function(_)
-    utils.writefile(cache_path, vim.json.encode(State.data)):next(function(_) end, function(err_msg)
+  return self:load():finally(function(_)
+    utils.writefile(cache_path, vim.json.encode(State.data)):catch(function(err_msg)
       vim.schedule_wrap(function()
         vim.notify('Failed to save current state! Error: ' .. err_msg, vim.log.levels.WARN, { title = 'Orgmode' })
       end)
     end)
-  end, function(_) end)
+  end)
 end
 
 ---Load the state cache into the current state

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -86,11 +86,10 @@ function State:load()
       -- If the file didn't exist then go ahead and save
       -- our current cache and as a side effect create the file
       if type(err) == 'string' and err:match([[^ENOENT.*]]) then
-        self:save()
-      else
-        -- If the file did exist, something is wrong. Kick this to the top
-        error(err)
+        return self:save()
       end
+      -- If the file did exist, something is wrong. Kick this to the top
+      error(err)
     end)
 
   return self._ctx.curr_loader

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -97,4 +97,4 @@ function State:load()
   return self._ctx.curr_loader
 end
 
-return State.new
+return State.new()

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -51,8 +51,9 @@ function State:load()
     return Promise.resolve()
   end
 
-  self._ctx.curr_loader = utils.readfile(cache_path, { raw = true }):next(
-    function(data)
+  self._ctx.curr_loader = utils
+    .readfile(cache_path, { raw = true })
+    :next(function(data)
       local success, decoded = pcall(vim.json.decode, data, {
         luanil = { object = true, array = true },
       })
@@ -81,8 +82,8 @@ function State:load()
       -- interim of the load operation.
       self.data = vim.tbl_deep_extend('force', decoded, self.data)
       return self
-    end):catch(
-    function(err)
+    end)
+    :catch(function(err)
       -- If the file didn't exist then go ahead and save
       -- our current cache and as a side effect create the file
       if type(err) == 'string' and err:match([[^ENOENT.*]]) then

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -81,7 +81,7 @@ function State:load()
       -- interim of the load operation.
       self.data = vim.tbl_deep_extend('force', decoded, self.data)
       return self
-    end, ---@param err string
+    end):catch(
     function(err)
       -- If the file didn't exist then go ahead and save
       -- our current cache and as a side effect create the file
@@ -91,8 +91,7 @@ function State:load()
         -- If the file did exist, something is wrong. Kick this to the top
         error(err)
       end
-    end
-  )
+    end)
 
   return self._ctx.curr_loader
 end

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -59,8 +59,9 @@ function State:load()
       })
       self._ctx.curr_loader = nil
       if not success then
+        local err_msg = vim.deepcopy(decoded)
         vim.schedule(function()
-          vim.notify('State cache load failure, error: ' .. decoded, vim.log.levels.WARN, {
+          vim.notify('State cache load failure, error: ' .. vim.inspect(err_msg), vim.log.levels.WARN, {
             title = 'Orgmode',
           })
           -- Try to 'repair' the cache by saving the current state

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -75,7 +75,6 @@ function State:load()
         decoded = {}
       end
 
-      self._ctx.loaded = true
       -- It is possible that while the state was loading from cache values
       -- were saved into the state. We want to preference the newer values in
       -- the state and still get whatever values may not have been set in the
@@ -87,10 +86,15 @@ function State:load()
       -- If the file didn't exist then go ahead and save
       -- our current cache and as a side effect create the file
       if type(err) == 'string' and err:match([[^ENOENT.*]]) then
-        return self:save()
+        self:save()
+        return self
       end
       -- If the file did exist, something is wrong. Kick this to the top
       error(err)
+    end)
+    :finally(function()
+      self._ctx.loaded = true
+      self._ctx.curr_loader = nil
     end)
 
   return self._ctx.curr_loader

--- a/lua/orgmode/state/state.lua
+++ b/lua/orgmode/state/state.lua
@@ -5,7 +5,7 @@ local State = { data = {}, _ctx = { loaded = false, curr_loader = nil } }
 
 local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
 --- Returns the current State singleton
-function State:new()
+function State.new()
   -- This is done so we can later iterate the 'data'
   -- subtable cleanly and shove it into a cache
   setmetatable(State, {
@@ -16,6 +16,7 @@ function State:new()
       tbl.data[key] = value
     end,
   })
+  local self = State
   -- Start trying to load the state from cache as part of initializing the state
   self:load()
   return self
@@ -96,4 +97,4 @@ function State:load()
   return self._ctx.curr_loader
 end
 
-return State:new()
+return State.new

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -7,7 +7,7 @@ local query_cache = {}
 local tmp_window_augroup = vim.api.nvim_create_augroup('OrgTmpWindow', { clear = true })
 
 function utils.readfile(file, opts)
-  opts = vim.tbl_deep_extend('keep', opts or {}, { raw = false })
+  opts = opts or {}
   return Promise.new(function(resolve, reject)
     uv.fs_open(file, 'r', 438, function(err1, fd)
       if err1 then

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -65,6 +65,16 @@ function M.setup(plugins)
   vim.env.XDG_STATE_HOME = M.root('xdg/state')
   vim.env.XDG_CACHE_HOME = M.root('xdg/cache')
 
+  local std_paths = {
+    'cache',
+    'data',
+    'config',
+  }
+
+  for _, std_path in pairs(std_paths) do
+    vim.fn.mkdir(vim.fn.stdpath(std_path), 'p')
+  end
+
   -- NOTE: Cleanup the xdg cache on exit so new runs of the minimal init doesn't share any previous state, e.g. shada
   vim.api.nvim_create_autocmd('VimLeave', {
     callback = function()

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -5,7 +5,7 @@ local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json'
 describe('State', function()
   before_each(function()
     -- Ensure the cache file is removed before each run
-    state = require("orgmode.state.state")
+    state = require('orgmode.state.state')
     vim.fn.delete(cache_path, 'rf')
   end)
   it("should create a state file if it doesn't exist", function()
@@ -42,7 +42,6 @@ describe('State', function()
   end)
 
   it('should be able to save and load state data', function()
-
     -- Set a variable into the state object
     state.my_var = 'hello world'
     state:save():finally(function()

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -6,64 +6,112 @@ describe('State', function()
   before_each(function()
     -- Ensure the cache file is removed before each run
     state = require('orgmode.state.state')
+    vim.wait(50, function()
+      return state._ctx.saved
+    end, 10)
+    state._ctx.saved = false
+    state._ctx.loaded = false
     vim.fn.delete(cache_path, 'rf')
   end)
+
+  after_each(function()
+    state._ctx.saved = false
+    state._ctx.loaded = false
+    state = nil
+    -- vim.fn.delete(cache_path, 'rf')
+  end)
+
   it("should create a state file if it doesn't exist", function()
     -- Ensure the file doesn't exist
-    local err, stat = pcall(vim.loop.fs_stat, cache_path)
-    if not err then
+    vim.fn.delete(cache_path, 'rf')
+    local stat = vim.loop.fs_stat(cache_path)
+    if stat then
       error('Cache file existed before it should! Ensure it is deleted before each test run!')
     end
 
     -- This creates the cache file on new instances of `State`
-    state:load():finally(function()
-      ---@diagnostic disable-next-line: redefined-local
-      local err, stat = pcall(vim.loop.fs_stat, cache_path)
-      if err then
-        if type(stat) == 'string' and stat:match([[^ENOENT.*]]) then
-          error('Cache file did not exist')
-        end
-      end
-    end)
+    state:load()
+
+    -- wait until the state has been saved
+    vim.wait(50, function()
+      return state._ctx.saved
+    end, 10)
+
+    local stat, err, _ = vim.loop.fs_stat(cache_path)
+    if not stat then
+      error(err)
+    end
   end)
 
   it('should save the cache file as valid json', function()
-    state:save():finally(function()
-      utils.readfile(cache_path, { raw = true }):next(function(cache_content)
-        local err, err_msg = vim.json.decode(cache_content, {
-          luanil = { object = true, array = true },
-        })
-
-        if err then
-          error('Cache file did not contain valid json after saving! Error: ' .. vim.inspect(err_msg))
-        end
-      end)
+    local data = nil
+    local read_f_err = nil
+    state:save():next(function()
+      utils
+        .readfile(cache_path, { raw = true })
+        :next(function(state_data)
+          data = state_data
+        end)
+        :catch(function(err)
+          read_f_err = err
+        end)
     end)
+
+    -- wait until the newly saved state file has been read
+    vim.wait(50, function()
+      return data ~= nil or read_f_err ~= nil
+    end, 10)
+    if read_f_err then
+      error(read_f_err)
+    end
+
+    local success, decoded = pcall(vim.json.decode, data, {
+      luanil = { object = true, array = true },
+    })
+    if not success then
+      error('Cache file did not contain valid json after saving! Error: ' .. vim.inspect(decoded))
+    end
   end)
 
   it('should be able to save and load state data', function()
     -- Set a variable into the state object
     state.my_var = 'hello world'
-    state:save():finally(function()
-      -- "Wipe" the variable
-      state.my_var = nil
-      state:load():finally(function()
-        -- These should be the same after the wipe. We just loaded it back in from the state cache.
-        assert.are.equal(state.my_var, 'hello world')
-      end)
-    end)
+    -- Save the state
+    state:save()
+    vim.wait(50, function()
+      return state._ctx.saved
+    end, 10)
+    -- Wipe the variable and "unload" the State
+    state.my_var = nil
+    state._ctx.loaded = false
+
+    -- Ensure the state can be loaded from the file now by ignoring the previous load
+    state:load()
+    -- wait until the state has been loaded
+    vim.wait(50, function()
+      return state._ctx.loaded
+    end, 10)
+    -- These should be the same after the wipe. We just loaded it back in from the state cache.
+    assert.are.equal('hello world', state.my_var)
   end)
 
   it('should be able to self-heal from an invalid state file', function()
+    local err = nil
     state.my_var = 'hello world'
     state:save():finally(function()
       vim.cmd.edit(cache_path)
       vim.api.nvim_buf_set_lines(0, 0, -1, false, { '[ invalid json!' })
       vim.cmd.write()
-      local err, err_msg = state:load()
-      if err then
-        error('Unable to self-heal from an invalid state! Error: ' .. vim.inspect(err_msg))
-      end
+      state:load():catch(function(err)
+        err = err
+      end)
     end)
+    vim.wait(50, function()
+      return state._ctx.loaded
+    end, 10)
+
+    if err then
+      error('Unable to self-heal from an invalid state! Error: ' .. vim.inspect(err_msg))
+    end
   end)
 end)

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -102,6 +102,8 @@ describe('State', function()
     vim.wait(500, function()
       return state._ctx.saved
     end)
+    -- Wait a little longer to ensure the data is flushed into the cache
+    vim.wait(100)
 
     -- Now attempt to read the file and check that it is, in fact, "healed"
     local cache_data = nil

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -56,4 +56,18 @@ describe('State', function()
       end)
     end)
   end)
+
+  it('should be able to self-heal from an invalid state file', function()
+    local state = state_mod()
+    state.my_var = 'hello world'
+    state:save():finally(function()
+      vim.cmd.edit(cache_path)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { '[ invalid json!' })
+      vim.cmd.write()
+      local err, err_msg = state:load()
+      if err then
+        error('Unable to self-heal from an invalid state! Error: ' .. vim.inspect(err_msg))
+      end
+    end)
+  end)
 end)

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -1,10 +1,11 @@
 local utils = require('orgmode.utils')
-local state_mod = require('orgmode.state.state')
+local state = nil
 local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
 
 describe('State', function()
   before_each(function()
     -- Ensure the cache file is removed before each run
+    state = require("orgmode.state.state")
     vim.fn.delete(cache_path, 'rf')
   end)
   it("should create a state file if it doesn't exist", function()
@@ -15,7 +16,6 @@ describe('State', function()
     end
 
     -- This creates the cache file on new instances of `State`
-    local state = state_mod()
     state:load():finally(function()
       ---@diagnostic disable-next-line: redefined-local
       local err, stat = pcall(vim.loop.fs_stat, cache_path)
@@ -28,7 +28,6 @@ describe('State', function()
   end)
 
   it('should save the cache file as valid json', function()
-    local state = state_mod()
     state:save():finally(function()
       utils.readfile(cache_path, { raw = true }):next(function(cache_content)
         local err, err_msg = vim.json.decode(cache_content, {
@@ -43,7 +42,6 @@ describe('State', function()
   end)
 
   it('should be able to save and load state data', function()
-    local state = state_mod()
 
     -- Set a variable into the state object
     state.my_var = 'hello world'
@@ -58,7 +56,6 @@ describe('State', function()
   end)
 
   it('should be able to self-heal from an invalid state file', function()
-    local state = state_mod()
     state.my_var = 'hello world'
     state:save():finally(function()
       vim.cmd.edit(cache_path)

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -6,23 +6,11 @@ describe('State', function()
   before_each(function()
     -- Ensure the cache file is removed before each run
     state = require('orgmode.state.state')
-    vim.wait(50, function()
-      return state._ctx.saved
-    end, 10)
     state:wipe()
     vim.fn.delete(cache_path, 'rf')
   end)
 
-  after_each(function()
-    state._ctx.saved = false
-    state._ctx.loaded = false
-    state = nil
-    -- vim.fn.delete(cache_path, 'rf')
-  end)
-
   it("should create a state file if it doesn't exist", function()
-    -- Ensure the file doesn't exist
-    vim.fn.delete(cache_path, 'rf')
     local stat = vim.loop.fs_stat(cache_path)
     if stat then
       error('Cache file existed before it should! Ensure it is deleted before each test run!')

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -1,4 +1,5 @@
 local utils = require('orgmode.utils')
+---@type OrgState
 local state = nil
 local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
 

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -1,0 +1,59 @@
+local utils = require('orgmode.utils')
+local state_mod = require('orgmode.state.state')
+local cache_path = vim.fs.normalize(vim.fn.stdpath('cache') .. '/org-cache.json', { expand_env = false })
+
+describe('State', function()
+  before_each(function()
+    -- Ensure the cache file is removed before each run
+    vim.fn.delete(cache_path, 'rf')
+  end)
+  it("should create a state file if it doesn't exist", function()
+    -- Ensure the file doesn't exist
+    local err, stat = pcall(vim.loop.fs_stat, cache_path)
+    if not err then
+      error('Cache file existed before it should! Ensure it is deleted before each test run!')
+    end
+
+    -- This creates the cache file on new instances of `State`
+    local state = state_mod()
+    state:load():finally(function()
+      ---@diagnostic disable-next-line: redefined-local
+      local err, stat = pcall(vim.loop.fs_stat, cache_path)
+      if err then
+        if type(stat) == 'string' and stat:match([[^ENOENT.*]]) then
+          error('Cache file did not exist')
+        end
+      end
+    end)
+  end)
+
+  it('should save the cache file as valid json', function()
+    local state = state_mod()
+    state:save():finally(function()
+      utils.readfile(cache_path, { raw = true }):next(function(cache_content)
+        local err, err_msg = vim.json.decode(cache_content, {
+          luanil = { object = true, array = true },
+        })
+
+        if err then
+          error('Cache file did not contain valid json after saving! Error: ' .. vim.inspect(err_msg))
+        end
+      end)
+    end)
+  end)
+
+  it('should be able to save and load state data', function()
+    local state = state_mod()
+
+    -- Set a variable into the state object
+    state.my_var = 'hello world'
+    state:save():finally(function()
+      -- "Wipe" the variable
+      state.my_var = nil
+      state:load():finally(function()
+        -- These should be the same after the wipe. We just loaded it back in from the state cache.
+        assert.are.equal(state.my_var, 'hello world')
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
This is useful for features such as `org-clock-in-last` that has the ability to persist its "knowledge" of the last clocked in task. Org mode does this by saving to a cache file on system. This commit gives `nvim-orgmode` the same capability.

I'm creating this PR in what I consider a partially finished state. I'm primarily looking for feedback as to the design of this module. In the scenario we're all happy with the design then I can get some simple tests written and then promote this to a non draft PR.

Some quick notes:

1. This state management system uses the in-built promises library that `nvim-orgmode` bundles. This means there's some additional validation and steps taken than what might exist in fully synchronous code. 
2. I use a metatable to ensure any accesses against the `State` table in which we assign new values are saved into the subtable `data`. This is so later on it is easy to determine what to save into the cache. Without it, I'd have to write additional logic explicitly excluding specific keys from the `State` table.
3. Seeing as the `State` object is a singleton is may seem weird to bother with a `State:new()` function. This actually is quite important, this sets up the metatable after all other functions are read in the file, ensuring they are not bound to the `data` subtable within the `State` object.
4. Reading the cache should work on all platforms as I'm "normalizing" the paths with `vim.fs.normalize`.

Any feedback (especially critical feedback) is desired on this. I'm looking to iron out kinks and find out if this is even desired 😃.

