### PR TITLE
refactor(table): expose TsTable and reorganize table utility functions

### DIFF
--- a/lua/orgmode/org/format.lua
+++ b/lua/orgmode/org/format.lua
@@ -1,5 +1,5 @@
 local Files = require('orgmode.parser.files')
-local Table = require('orgmode.treesitter.table')
+local ts_table = require('orgmode.treesitter.table')
 local ts_org = require('orgmode.treesitter')
 
 local function format_line(linenr)
@@ -13,7 +13,9 @@ local function format_line(linenr)
     end
   end
 
-  if Table.format(linenr) then
+  local tbl = ts_table.from_current_node(linenr)
+  if tbl then
+    tbl:reformat()
     return true
   end
 

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -502,9 +502,27 @@ function OrgMappings:do_demote(whole_subtree)
   EventManager.dispatch(events.HeadlineDemoted:new(Files.get_closest_headline(), ts_org.closest_headline(), old_level))
 end
 
+local function table_handle_cr()
+  if vim.fn.col('.') == vim.fn.col('$') then
+    return false
+  end
+  local tbl = ts_table.from_current_node()
+  if not tbl then
+    return false
+  end
+
+  tbl:add_row()
+  vim.api.nvim_feedkeys(utils.esc('<Down>'), 'n', true)
+  vim.schedule(function()
+    vim.cmd([[norm! F|]])
+    vim.api.nvim_feedkeys(utils.esc('<Right><Right>'), 'n', true)
+  end)
+  return true
+end
+
 function OrgMappings:org_return()
   local actions = {
-    ts_table.handle_cr,
+    table_handle_cr,
   }
 
   for _, action in ipairs(actions) do

--- a/lua/orgmode/treesitter/table.lua
+++ b/lua/orgmode/treesitter/table.lua
@@ -96,36 +96,4 @@ function TsTable:add_row()
   return TsTable.from_current_node():reformat()
 end
 
-local function format(linenr)
-  local tbl = TsTable.from_current_node(linenr)
-
-  if not tbl then
-    return false
-  end
-
-  tbl:reformat()
-  return true
-end
-
-local function handle_cr()
-  if vim.fn.col('.') == vim.fn.col('$') then
-    return false
-  end
-  local tbl = TsTable.from_current_node()
-  if not tbl then
-    return false
-  end
-
-  tbl:add_row()
-  vim.api.nvim_feedkeys(utils.esc('<Down>'), 'n', true)
-  vim.schedule(function()
-    vim.cmd([[norm! F|]])
-    vim.api.nvim_feedkeys(utils.esc('<Right><Right>'), 'n', true)
-  end)
-  return true
-end
-
-return {
-  format = format,
-  handle_cr = handle_cr,
-}
+return TsTable


### PR DESCRIPTION
I decided to make this small refactor mainly for my own benefit. I wanted to utilize the treesitter TsTable helper in order to create a command for transposing tables (similar to `org-table-transpose-table-at-point` in Emacs). However, it was challenging to implement it because the TsTable object was not accessible from that module.

I imagine this litle helper may not be widely applicable enough to be included in the mainline code. Nevertheless, I'd love if more parts of the API exposed similar "from_current_node" or "at_cursor" functionality to facilitate ad-hoc scripting (even without committing to a stable API).

```lua
local function transpose(data)
  local data_t = {}
  for r, row in ipairs(data) do
    for c, cell in ipairs(row) do
      data_t[c] = data_t[c] or {}
      data_t[c][r] = cell
    end
  end
  return data_t
end

local function org_table_transpose()
  local ts_table = require('orgmode.treesitter.table')
  local Table = require('orgmode.parser.table')

  local ts_tbl = ts_table.from_current_node()
  if not ts_tbl then
    return
  end

  local data = vim.tbl_filter(function(row)
    return row ~= 'hr'
  end, ts_tbl.data)

  local data_t = transpose(data)
  local tbl_t = Table.from_list(data_t,
    ts_tbl.tbl.start_row,
    ts_tbl.tbl.start_col)

  local view = vim.fn.winsaveview()
  vim.api.nvim_buf_set_lines(0,
    ts_tbl.tbl.range.start_line - 1,
    ts_tbl.tbl.range.end_line,
    false, tbl_t:draw())
  vim.fn.winrestview(view)
end

vim.api.nvim_create_user_command("OrgTableTranspose", org_table_transpose, {})
```
