### PR TITLE
feature: support org_toggle_timestamp_type

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -1023,6 +1023,9 @@ Decrease date under cursor by 1 or "count" day(s) (Example count: `5<S-UP>`).
 #### **org_change_date**
 *mapped to*: `cid`<br />
 Change date under cursor. Opens calendar to select new date
+#### **org_toggle_timestamp_type**
+_mapped to_: `<prefix>d!`<br />
+Switches the timestamp under the cursor between inactive and active.
 #### **org_priority**
 *mapped to*: `<Leader>o,`<br />
 Choose the priority of a headline item.

--- a/DOCS.md
+++ b/DOCS.md
@@ -1024,7 +1024,7 @@ Decrease date under cursor by 1 or "count" day(s) (Example count: `5<S-UP>`).
 *mapped to*: `cid`<br />
 Change date under cursor. Opens calendar to select new date
 #### **org_toggle_timestamp_type**
-_mapped to_: `<prefix>d!`<br />
+*mapped to*: `<Leader>od!`<br />
 Switches the timestamp under the cursor between inactive and active.
 #### **org_priority**
 *mapped to*: `<Leader>o,`<br />

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -161,6 +161,7 @@ local DefaultConfig = {
       org_schedule = '<prefix>is',
       org_time_stamp = '<prefix>i.',
       org_time_stamp_inactive = '<prefix>i!',
+      org_toggle_timestamp_type = '<prefix>d!',
       org_insert_link = '<prefix>li',
       org_store_link = '<prefix>ls',
       org_clock_in = '<prefix>xi',

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -353,7 +353,7 @@ return {
     ),
     org_toggle_timestamp_type = m.action(
       'org_mappings.org_toggle_timestamp_type',
-      { opts = { desc = 'org toggle timestamp type' } }
+      { opts = { desc = 'org toggle timestamp type', help_desc = 'Toggle timestamp active/inactive type' } }
     ),
   },
   edit_src = {

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -351,6 +351,10 @@ return {
       'org_mappings.org_babel_tangle',
       { opts = { desc = 'org tangle', help_desc = 'Tangle current file' } }
     ),
+    org_toggle_timestamp_type = m.action(
+      'org_mappings.org_toggle_timestamp_type',
+      { opts = { desc = 'org toggle timestamp type' } }
+    ),
   },
   edit_src = {
     org_edit_src_abort = m.custom(

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -1009,6 +1009,16 @@ function OrgMappings:org_time_stamp(inactive)
   end)
 end
 
+function OrgMappings:org_toggle_timestamp_type()
+  local date = self:_get_date_under_cursor()
+  if not date then
+    return
+  end
+
+  date.active = not date.active
+  self:_replace_date(date)
+end
+
 ---@param direction string
 ---@param use_fast_access? boolean
 ---@return boolean


### PR DESCRIPTION
Allows to make active timestamp inactive and vice versa with one keybinding.

Implements feature request #652.

It is part of Emacs Orgmode, but not mapped.

See also:
- https://doc.endlessparentheses.com/Fun/org-toggle-timestamp-type.html
- https://emacs.stackexchange.com/questions/38062/configure-key-to-toggle-between-active-and-inactive-timestamps/38064#38064