### PR TITLE
feat: make VirtualIndent dynamically attach/detach based on `vim.b.org_indent_mode`

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -274,6 +274,10 @@ Possible values:
 * `true` - Uses *Virtual* indents to align content visually. The indents are only visual, they are not saved to the file.
 * `false` - Do not add any *Virtual* indentation.
 
+You can toggle Virtual indents on the fly by setting `vim.b.org_indent_mode` to either `true` or `false` when in a org
+buffer. For example, if virtual indents were enabled in the current buffer then you could disable them immediately by
+setting `vim.b.org_indent_mode = false`.
+
 This feature has no effect when enabled on Neovim versions < 0.10.0
 
 #### **org_adapt_indentation**

--- a/ftplugin/org.lua
+++ b/ftplugin/org.lua
@@ -15,6 +15,7 @@ if config.org_startup_indented then
 end
 require('orgmode.org.indent').setup()
 
+vim.b.org_bufnr = vim.api.nvim_get_current_buf()
 vim.bo.modeline = false
 vim.opt_local.fillchars:append('fold: ')
 vim.opt_local.foldmethod = 'expr'

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -314,8 +314,12 @@ end
 local function setup()
   local v = vim.version()
 
-  if config.org_startup_indented and not vim.version.lt({ v.major, v.minor, v.patch }, { 0, 10, 0 }) then
-    VirtualIndent:new():attach()
+  if not vim.version.lt({ v.major, v.minor, v.patch }, { 0, 10, 0 }) then
+    if config.org_startup_indented then
+      VirtualIndent:new():attach()
+    else
+      VirtualIndent:new():start_watch_org_indent()
+    end
   end
 end
 

--- a/lua/orgmode/ui/virtual_indent.lua
+++ b/lua/orgmode/ui/virtual_indent.lua
@@ -1,30 +1,48 @@
 local tree_utils = require('orgmode.utils.treesitter')
 ---@class OrgVirtualIndent
 ---@field private _ns_id number extmarks namespace id
+---@field private _bufnr integer Buffer VirtualIndent is attached to
+---@field private _attached boolean Whether or not VirtualIndent is attached for its buffer
+---@field private _bufnrs {integer: boolean} Buffers with VirtualIndent attached
+---@field private _timer uv_timer_t Timer used for tracking `org_indent_mode`
 local VirtualIndent = {
-  enabled = false,
-  lib = {},
+  _ns_id = vim.api.nvim_create_namespace('orgmode.ui.indent'),
+  _bufnrs = {},
 }
 
-function VirtualIndent:new()
-  if self.enabled then
-    return self
+--- Creates a new instance of VirtualIndent for a given buffer or returns the existing instance if
+--- one exists
+---@param bufnr? integer Buffer to use for VirtualIndent when attached
+---@return OrgVirtualIndent
+function VirtualIndent:new(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+  local curr_instance = VirtualIndent._bufnrs[bufnr]
+  if curr_instance then
+    return curr_instance
   end
-  self._ns_id = vim.api.nvim_create_namespace('orgmode.ui.indent')
-  self.enabled = true
-  return self
+
+  local new = {}
+  setmetatable(new, self)
+  self.__index = self
+
+  new._bufnr = bufnr
+  new._attached = false
+  VirtualIndent._bufnrs[new._bufnr] = new
+  new._timer = vim.uv.new_timer()
+  return new
 end
 
-function VirtualIndent:_delete_old_extmarks(buffer, start_line, end_line)
+function VirtualIndent:_delete_old_extmarks(start_line, end_line)
   local old_extmarks = vim.api.nvim_buf_get_extmarks(
-    buffer,
+    self._bufnr,
     self._ns_id,
     { start_line, 0 },
     { end_line, 0 },
     { type = 'virt_text' }
   )
   for _, ext in ipairs(old_extmarks) do
-    vim.api.nvim_buf_del_extmark(buffer, self._ns_id, ext[1])
+    vim.api.nvim_buf_del_extmark(self._bufnr, self._ns_id, ext[1])
   end
 end
 
@@ -43,11 +61,10 @@ function VirtualIndent:_get_indent_size(line)
   return 0
 end
 
----@param bufnr number buffer id
 ---@param start_line number start line number to set the indentation, 0-based inclusive
 ---@param end_line number end line number to set the indentation, 0-based inclusive
 ---@param ignore_ts? boolean whether or not to skip the treesitter start & end lookup
-function VirtualIndent:set_indent(bufnr, start_line, end_line, ignore_ts)
+function VirtualIndent:set_indent(start_line, end_line, ignore_ts)
   ignore_ts = ignore_ts or false
   local headline = tree_utils.closest_headline_node({ start_line + 1, 1 })
   if headline and not ignore_ts then
@@ -60,13 +77,13 @@ function VirtualIndent:set_indent(bufnr, start_line, end_line, ignore_ts)
   if start_line > 0 then
     start_line = start_line - 1
   end
-  self:_delete_old_extmarks(bufnr, start_line, end_line)
+  self:_delete_old_extmarks(start_line, end_line)
   for line = start_line, end_line do
     local indent = self:_get_indent_size(line)
 
     if indent > 0 then
       -- NOTE: `ephemeral = true` is not implemented for `inline` virt_text_pos :(
-      pcall(vim.api.nvim_buf_set_extmark, bufnr, self._ns_id, line, 0, {
+      pcall(vim.api.nvim_buf_set_extmark, self._bufnr, self._ns_id, line, 0, {
         virt_text = { { string.rep(' ', indent), 'OrgIndent' } },
         virt_text_pos = 'inline',
         right_gravity = false,
@@ -75,22 +92,56 @@ function VirtualIndent:set_indent(bufnr, start_line, end_line, ignore_ts)
   end
 end
 
----@param bufnr? number buffer id
-function VirtualIndent:attach(bufnr)
-  bufnr = bufnr or 0
-  self:set_indent(0, 0, vim.api.nvim_buf_line_count(bufnr) - 1, true)
+--- Begins a timer to check `vim.b.org_indent_mode` and correctly attach or detatch VirtualIndent as
+--- necessary
+function VirtualIndent:start_watch_org_indent()
+  self._timer:start(
+    50,
+    50,
+    vim.schedule_wrap(function()
+      local success, indent_mode_enabled = pcall(vim.api.nvim_buf_get_var, self._bufnr, 'org_indent_mode')
+      if success and indent_mode_enabled then
+        if not self._attached then
+          self:attach()
+        end
+      elseif self._attached then
+        self:detach()
+      end
+    end)
+  )
+end
 
-  vim.api.nvim_buf_attach(bufnr, false, {
+--- Stops the current VirtualIndent instance from reacting to changes in `vim.b.org_indent_mode`
+function VirtualIndent:stop_watch_org_indent()
+  self._timer:stop()
+end
+
+--- Enables virtual indentation in registered buffer
+function VirtualIndent:attach()
+  self._attached = true
+  self:set_indent(0, vim.api.nvim_buf_line_count(self._bufnr) - 1, true)
+  self:start_watch_org_indent()
+
+  vim.api.nvim_buf_attach(self._bufnr, false, {
     on_lines = function(_, _, _, start_line, _, end_line)
+      if not self._attached then
+        return true
+      end
       -- HACK: By calling `set_indent` twice, once synchronously and once in `vim.schedule` we get smooth usage of the
       -- virtual indent in most cases and still properly handle undo redo. Unfortunately this is called *early* when
       -- `undo` or `redo` is used causing the padding to be incorrect for some headlines.
-      self:set_indent(bufnr, start_line, end_line)
+      self:set_indent(start_line, end_line)
       vim.schedule(function()
-        self:set_indent(bufnr, start_line, end_line)
+        self:set_indent(start_line, end_line)
       end)
     end,
   })
+end
+
+function VirtualIndent:detach()
+  self._attached = false
+  vim.api.nvim_buf_set_var(self._bufnr, 'org_indent_mode', false)
+  self:_delete_old_extmarks(0, vim.api.nvim_buf_line_count(self._bufnr) - 1)
 end
 
 return VirtualIndent

--- a/lua/orgmode/utils/dict_watcher.lua
+++ b/lua/orgmode/utils/dict_watcher.lua
@@ -1,0 +1,32 @@
+-- NOTE: Be aware of https://github.com/neovim/neovim/issues/21469. Upstream *might* decide to
+-- deprecate this, seems unlikely but something to keep an eye on.
+local watchers = {}
+local M = {}
+
+---@param change_dict { old?: any, new: any }
+---@param key string
+---@param dict table
+function M.dict_changed(change_dict, key, dict)
+  if watchers[key] then
+    watchers[key](change_dict, key, dict)
+  end
+end
+
+---@param key string
+---@param callback fun(change_dict: { old?: any, new: any }, key: string, dict: table)
+function M.watch_buffer_variable(key, callback)
+  vim.cmd(([[
+    call dictwatcheradd(b:, '%s', 'OrgmodeWatchDictChanges')
+  ]]):format(key))
+  watchers[key] = callback
+end
+
+---@param key string
+function M.unwatch_buffer_variable(key)
+  vim.cmd(([[
+    call dictwatcherdel(b:, '%s', 'OrgmodeWatchDictChanges')
+  ]]):format(key))
+  watchers[key] = nil
+end
+
+return M

--- a/plugin/orgmode.vim
+++ b/plugin/orgmode.vim
@@ -6,3 +6,7 @@ function! OrgmodeInput(prompt, default, ...) abort
   endif
   return input(a:prompt, a:default)
 endfunction
+
+function OrgmodeWatchDictChanges(dict, key, change_dict) abort
+  return luaeval('require("orgmode.utils.dict_watcher").dict_changed(_A[1], _A[2], _A[3])', [a:change_dict, a:key, a:dict])
+endfunction


### PR DESCRIPTION
Following on from #627, this adds the capability to toggle virtual indentation within an orgmode buffer. This allows me to check one thing off my list [here](https://github.com/nvim-orgmode/orgmode/issues/422#issuecomment-1910991160).

See the short gif below:
![dynamic-org-indent-mode](https://github.com/nvim-orgmode/orgmode/assets/58627896/34800925-530b-499e-a97e-f53087004b89)

Bullet list of changes:
- Refactored `VirtualIndent` to allow multiple instances to easily track attachment to different buffers
- Added capability to `VirtualIndent` to enable/disable based on `vim.b.org_indent_mode` using a timer set to check the variable every 50ms
- Added tests for new functionality
- Updated docs to reflect this new functionality (`org_startup_indented` is where I placed them)


Do I need to add a user command like `OrgToggleIndentMode` or a keybind for this? Or is using the buffer variable, `vim.b.org_indent_mode` good enough to expose this functionality?