### PR TITLE
feat: add `org-indent-mode-turns-on-hiding-stars` equivalent

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -301,8 +301,8 @@ Possible values:
 *type*: `boolean`<br />
 *default value*: `true`<br />
 Possible values:
-* `true` - Enable [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
-* `false` - Do not modify the value in [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
+* `true` - Enable [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`org_indent_mode`](#org_startup_indented) is enabled for buffer (`vim.b.org_indent_mode = true`).
+* `false` - Do not modify the value in [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`.org_indent_mode`](#org_startup_indented) is enabled for buffer (`vim.b.org_indent_mode = true`).
 
 #### **org_src_window_setup**
 *type*: `string|function`<br />

--- a/DOCS.md
+++ b/DOCS.md
@@ -296,6 +296,14 @@ Possible values:
 * `true` - Disable [`org_adapt_indentation`](#org_adapt_indentation) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
 * `false` - Do not disable [`org_adapt_indentation`](#org_adapt_indentation) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
 
+#### **org_indent_mode_turns_on_hiding_stars**
+
+*type*: `boolean`<br />
+*default value*: `true`<br />
+Possible values:
+* `true` - Enable [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
+* `false` - Do not modify the value in [`org_hide_leading_stars`](#org_hide_leading_stars) by default when [`org_startup_indented`](#org_startup_indented) is enabled.
+
 #### **org_src_window_setup**
 *type*: `string|function`<br />
 *default value*: "top 16new"<br />

--- a/lua/orgmode/colors/highlighter/stars.lua
+++ b/lua/orgmode/colors/highlighter/stars.lua
@@ -14,8 +14,20 @@ function OrgStars:new(opts)
   return data
 end
 
+function OrgStars:_is_enabled(bufnr)
+  if config.org_hide_leading_stars then
+    return true
+  end
+
+  if vim.b[bufnr].org_indent_mode and config.org_indent_mode_turns_on_hiding_stars then
+    return true
+  end
+
+  return false
+end
+
 function OrgStars:on_line(bufnr, line)
-  if not config.org_hide_leading_stars then
+  if not self:_is_enabled(bufnr) then
     return
   end
 

--- a/lua/orgmode/colors/highlights.lua
+++ b/lua/orgmode/colors/highlights.lua
@@ -102,13 +102,11 @@ function M.define_org_headline_colors(faces)
   for _, face in pairs(faces) do
     table.insert(contains, face)
   end
-  if config.org_hide_leading_stars then
-    if not ts_highlights_enabled then
-      vim.cmd([[syn match OrgHideLeadingStars /^\*\{2,\}/me=e-1 contained]])
-    end
-    vim.cmd([[hi default OrgHideLeadingStars ctermfg=0 guifg=bg]])
-    table.insert(contains, 'OrgHideLeadingStars')
+  if not ts_highlights_enabled then
+    vim.cmd([[syn match OrgHideLeadingStars /^\*\{2,\}/me=e-1 contained]])
   end
+  vim.cmd([[hi default OrgHideLeadingStars ctermfg=0 guifg=bg]])
+  table.insert(contains, 'OrgHideLeadingStars')
   for i, color in ipairs(headline_colors) do
     local j = i
     while j < 40 do

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -39,6 +39,7 @@ local DefaultConfig = {
   org_adapt_indentation = true,
   org_startup_indented = false,
   org_indent_mode_turns_off_org_adapt_indentation = true,
+  org_indent_mode_turns_on_hiding_stars = true,
   org_time_stamp_rounding_minutes = 5,
   org_blank_before_new_entry = {
     heading = true,


### PR DESCRIPTION
Follow on from #627.

Bullet points:
- Added new config flag: `org_indent_mode_turns_on_hiding_stars` which is enabled by default
- Added docs reflecting new configuration flag

Crosses another one off [my list](https://github.com/nvim-orgmode/orgmode/issues/422#issuecomment-1910991160) of indent mode features.