### PR TITLE
refactor: remove sync call to set indent for virtual indents

### DIFF
--- a/lua/orgmode/ui/virtual_indent.lua
+++ b/lua/orgmode/ui/virtual_indent.lua
@@ -128,10 +128,7 @@ function VirtualIndent:attach()
       if not self._attached then
         return true
       end
-      -- HACK: By calling `set_indent` twice, once synchronously and once in `vim.schedule` we get smooth usage of the
-      -- virtual indent in most cases and still properly handle undo redo. Unfortunately this is called *early* when
-      -- `undo` or `redo` is used causing the padding to be incorrect for some headlines.
-      self:set_indent(start_line, end_line)
+
       vim.schedule(function()
         self:set_indent(start_line, end_line)
       end)


### PR DESCRIPTION
Copied from the body of my commit message:

> On the current version of nightly (at the time of writing this is NVIM
v0.10.0-dev-2361+ga376d979b) the synchronous call doesn't seem to have
any value.
>
> Using only a scheduled call is seemingly smooth now -- perhaps when I
made the original commit I had something wrong with my configuration or
perhaps upstream Neovim fixed whatever was causing some choppiness?
>
> Another note is that `on_lines` in `nvim_buf_attach` can have `textlock`
restrictions and more applied, thus we really should just use
`vim.schedule` only anyhow.

*I* don't see any laggy behavior during promotions/demotions or undos on my side with the change in this PR, hence why I made it. 

It wouldn't hurt if someone else could check on their side with the latest nightly and see if its choppy for them. If there's no choppiness, then this change is probably fine. I just want to pull hacks out of the codebase before they sit too long and grow roots.
