### PR TITLE
fix: run Org init as part of setup

### DIFF
--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -139,7 +139,7 @@ function Org.setup(opts)
   config:setup_ts_predicates()
   vim.defer_fn(function()
     if config.notifications.enabled and #vim.api.nvim_list_uis() > 0 then
-      Org.files:load():next(vim.schedule_wrap(function()
+      Org.instance().files:load():next(vim.schedule_wrap(function()
         instance.notifications = require('orgmode.notifications')
           :new({
             files = Org.files,


### PR DESCRIPTION
Copied from the commit message:

> This ensures that notifications do not error on startup. Prior to this commit the `OrgFiles` object wasn't loaded in time for notifications to work.

Currently Orgmode throws an error on startup on the `nightly` branch when notifications are enabled because the `Org` instance isn't ready in time for when the notifications are actually initialized. 

This was the simplest way I saw to ensure the notifications have `files` available on the `Org` instance at startup. 

Perhaps it would be better to move the notifications setup into the `Org:init` function and make the `config` object available across that module after setup? I didn't undertake that move as I'm not 100% sure as to the nuances involved with setting up the notifications and why they're setup [where they are](https://github.com/treatybreaker/orgmode/blob/org-init-on-setup/lua/orgmode/init.lua#L142).

<details>
<summary>Here's a patch I can apply for moving the notifications setup:</summary>

```diff
diff --git a/lua/orgmode/init.lua b/lua/orgmode/init.lua
index 2f13e8e..f04ce6c 100644
--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -13,6 +13,8 @@ local auto_instance_keys = {
   notifications = true,
 }
 
+local config = require('orgmode.config')
+
 ---@class Org
 ---@field initialized boolean
 ---@field files OrgFiles
@@ -60,6 +62,15 @@ function Org:init()
   self.clock = require('orgmode.clock'):new({
     files = self.files,
   })
+  if config.notifications.enabled and #vim.api.nvim_list_uis() > 0 then
+    Org.files:load():next(vim.schedule_wrap(function()
+      instance.notifications = require('orgmode.notifications')
+        :new({
+          files = Org.files,
+        })
+        :start_timer()
+    end))
+  end
   require('orgmode.org.autocompletion').register()
   self.statusline_debounced = require('orgmode.utils').debounce('statusline', self.clock.get_statusline, 300)
   self.initialized = true
@@ -134,20 +145,10 @@ end
 function Org.setup(opts)
   opts = opts or {}
   Org._check_ts_grammar()
-  local config = require('orgmode.config'):extend(opts)
+  config:extend(opts)
   instance = Org:new()
   config:setup_ts_predicates()
   vim.defer_fn(function()
-    if config.notifications.enabled and #vim.api.nvim_list_uis() > 0 then
-      Org:init()
-      Org.files:load():next(vim.schedule_wrap(function()
-        instance.notifications = require('orgmode.notifications')
-          :new({
-            files = Org.files,
-          })
-          :start_timer()
-      end))
-    end
     config:setup_mappings('global')
   end, 1)
   return instance
```
</details>