### PR TITLE
feat(indent): Always check for b:org_indent_mode if available

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -394,6 +394,7 @@ function Config:ts_highlights_enabled()
       return false
     end
 
+    ---@diagnostic disable-next-line: param-type-mismatch
     if type(hl_module.disable) == 'table' and vim.tbl_contains(hl_module.disable, 'org') then
       return false
     end
@@ -413,33 +414,26 @@ function Config:respect_blank_before_new_entry(content, option, prepend_content)
   return content
 end
 
----@param amount number
----@return string
-function Config:get_indent(amount)
-  if self.org_adapt_indentation then
-    return string.rep(' ', amount)
+---Check if buffer should apply indentation
+---@param bufnr number
+---@return boolean
+function Config:should_indent(bufnr)
+  if bufnr > -1 and vim.b[bufnr].org_indent_mode then
+    return not self.opts.org_indent_mode_turns_off_org_adapt_indentation
   end
-  return ''
+
+  return self.org_adapt_indentation
 end
 
----@param content string|string[]
 ---@param amount number
----@return string|string[]
-function Config:apply_indent(content, amount)
-  local indent = self:get_indent(amount)
-
-  if indent == '' then
-    return content
+---@param bufnr number
+---@return string
+function Config:get_indent(amount, bufnr)
+  if self:should_indent(bufnr) then
+    return string.rep(' ', amount)
   end
 
-  if type(content) ~= 'table' then
-    return indent .. content
-  end
-
-  for i, line in ipairs(content) do
-    content[i] = indent .. line
-  end
-  return content
+  return ''
 end
 
 ---@param bufnr number

--- a/lua/orgmode/files/elements/logbook.lua
+++ b/lua/orgmode/files/elements/logbook.lua
@@ -159,7 +159,7 @@ end
 ---@param headline OrgHeadline
 function Logbook.new_from_headline(headline)
   local append_line = headline:get_append_line()
-  local indent = config:get_indent(headline:get_level() + 1)
+  local indent = headline:get_indent()
 
   local date = Date.now({ active = false })
   local content = {

--- a/lua/orgmode/files/elements/table/init.lua
+++ b/lua/orgmode/files/elements/table/init.lua
@@ -86,7 +86,7 @@ function Table:reformat()
     return false
   end
   local _, start_col = self.node:range()
-  local indent = config:get_indent(start_col)
+  local indent = config:get_indent(start_col, vim.api.nvim_get_current_buf())
   local contents = vim.tbl_map(function(line)
     return ('%s%s'):format(indent, line)
   end, self:draw())
@@ -104,7 +104,7 @@ function Table:handle_cr()
 
   local line = vim.fn.line('.') or 0
   local indent_amount = vim.fn.indent(line) or 0
-  local indent = config:get_indent(indent_amount)
+  local indent = config:get_indent(indent_amount, vim.api.nvim_get_current_buf())
   vim.api.nvim_buf_set_lines(0, line, line, true, { ('%s|'):format(indent) })
   local tbl = Table.from_current_node({ line, vim.fn.col('.') })
   if tbl then

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -60,7 +60,7 @@ function OrgMappings:archive()
   local lines = headline:get_lines()
   local properties_node = headline:get_properties()
   local append_line = headline:get_append_line() - start_line
-  local indent = config:get_indent(headline:get_level() + 1)
+  local indent = headline:get_indent()
 
   local archive_props = {
     ('%s:ARCHIVE_TIME: %s'):format(indent, Date.now():to_string()),
@@ -439,7 +439,7 @@ function OrgMappings:_todo_change_state(direction)
   local log_note = config.org_log_done == 'note'
   local log_time = config.org_log_done == 'time'
   local should_log_time = log_note or log_time
-  local indent = config:get_indent(headline:get_level() + 1)
+  local indent = headline:get_indent()
 
   local get_note = function(note)
     if note == nil then


### PR DESCRIPTION
Always check for `vim.b.org_indent_mode` before applying indentation to the buffer.
If it's `true`, treat all indentations in a buffer as if the configuration has `org_startup_indented` enabled.

@PriceHiller can you review and test this to see if it works ok?