### PR TITLE
feat: add queries to highlight tables similar to markdown

### DIFF
--- a/queries/org/highlights.scm
+++ b/queries/org/highlights.scm
@@ -31,3 +31,11 @@
 (plan) @OrgTSPlan
 (comment) @OrgTSComment @spell
 (directive) @OrgTSDirective
+(row
+  "|" @punctuation.special)
+(cell
+  "|" @punctuation.special)
+(table
+  (row
+    (cell (contents) @markup.heading))
+  (hr) @punctuation.special)


### PR DESCRIPTION
This allows org tables to be highlighted similar to Markdown tables by treesitter.

See the screenshot below for a org table with the highlight groups:
![image](https://github.com/nvim-orgmode/orgmode/assets/58627896/6e050a41-cbbe-41fc-aae6-512c88da4c7a)

See `:h treesitter-highlight` for the captures available. The captures used in this PR apply to nightly versions of Neovim which has changed the captures to be more in line with other editors.

Specifically, the captures used are:
- `@punctuation.special`
- `@markup.heading`