### PR TITLE
feat(foldtext)!: Use new empty foldtext option for Neovim 0.10

### DIFF
--- a/ftplugin/org.lua
+++ b/ftplugin/org.lua
@@ -5,6 +5,7 @@ end
 vim.b.did_ftplugin = true
 
 local config = require('orgmode.config')
+local utils = require('orgmode.utils')
 
 config:setup_mappings('org')
 config:setup_mappings('text_objects')
@@ -20,7 +21,11 @@ vim.bo.modeline = false
 vim.opt_local.fillchars:append('fold: ')
 vim.opt_local.foldmethod = 'expr'
 vim.opt_local.foldexpr = 'nvim_treesitter#foldexpr()'
-vim.opt_local.foldtext = 'v:lua.require("orgmode.org.indent").foldtext()'
+if utils.has_version_10() then
+  vim.opt_local.foldtext = ''
+else
+  vim.opt_local.foldtext = 'v:lua.require("orgmode.org.indent").foldtext()'
+end
 vim.opt_local.formatexpr = 'v:lua.require("orgmode.org.format")()'
 vim.opt_local.omnifunc = 'v:lua.orgmode.omnifunc'
 vim.opt_local.commentstring = '# %s'

--- a/lua/orgmode/colors/highlighter/foldtext.lua
+++ b/lua/orgmode/colors/highlighter/foldtext.lua
@@ -1,0 +1,83 @@
+local config = require('orgmode.config')
+local utils = require('orgmode.utils')
+
+---@alias OrgFoldtextLineValue false | { col: number, hl_group: string }
+
+---@class OrgFoldtextHighlighter
+---@field highlighter OrgHighlighter
+---@field namespace number
+---@field enabled number
+---@field cache table<number, table<number, OrgFoldtextLineValue>>
+local OrgFoldtext = {}
+
+---@param opts { highlighter: OrgHighlighter }
+function OrgFoldtext:new(opts)
+  local data = {
+    highlighter = opts.highlighter,
+    enabled = utils.has_version_10(),
+    cache = setmetatable({}, { __mode = 'k' }),
+  }
+  setmetatable(data, self)
+  self.__index = self
+  return data
+end
+
+---@param bufnr number
+---@param line number
+---@param value OrgFoldtextLineValue
+function OrgFoldtext:_highlight(bufnr, line, value)
+  if not value then
+    return
+  end
+
+  vim.api.nvim_buf_set_extmark(bufnr, self.highlighter.namespace, line, value.col, {
+    hl_mode = 'combine',
+    virt_text = { { config.org_ellipsis, value.hl_group } },
+    virt_text_pos = 'overlay',
+    ephemeral = true,
+  })
+end
+
+function OrgFoldtext:on_line(bufnr, line)
+  if not self.enabled then
+    return false
+  end
+
+  local is_current_buf = bufnr == vim.api.nvim_get_current_buf()
+
+  if not is_current_buf then
+    return self:_highlight(bufnr, line, self.cache[bufnr] and self.cache[bufnr][line])
+  end
+
+  self.cache[bufnr] = self.cache[bufnr] or {}
+  local is_fold_closed = vim.fn.foldclosed(line + 1) > -1
+
+  if not is_fold_closed then
+    self.cache[bufnr][line] = false
+    return
+  end
+
+  local col = vim.fn.col({ line + 1, '$' }) or 0
+
+  local hl_group = 'Comment'
+  local captures_at_pos = vim.treesitter.get_captures_at_pos(bufnr, line, col - 2)
+
+  if #captures_at_pos > 0 then
+    for i = #captures_at_pos, 1, -1 do
+      local capture = captures_at_pos[i]
+      if capture.capture ~= 'spell' then
+        hl_group = table.concat({ '@', capture.capture, '.', capture.lang }, '')
+        break
+      end
+    end
+  end
+
+  self.cache[bufnr][line] = { col = col - 1, hl_group = hl_group }
+  return self:_highlight(bufnr, line, self.cache[bufnr][line])
+end
+
+function OrgFoldtext:on_detach(bufnr)
+  self.cache[bufnr] = nil
+end
+
+return OrgFoldtext

--- a/lua/orgmode/colors/highlighter/init.lua
+++ b/lua/orgmode/colors/highlighter/init.lua
@@ -3,6 +3,7 @@
 ---@field private stars OrgStarsHighlighter
 ---@field private markup OrgMarkupHighlighter
 ---@field private todos OrgTodosHighlighter
+---@field private foldtext OrgFoldtextHighlighter
 ---@field private _ephemeral boolean
 ---@field private buffers table<number, { language_tree: LanguageTree, tree: TSTree }>
 local OrgHighlighter = {}
@@ -30,6 +31,7 @@ function OrgHighlighter:_setup()
   self.stars = require('orgmode.colors.highlighter.stars'):new({ highlighter = self })
   self.markup = require('orgmode.colors.highlighter.markup'):new({ highlighter = self })
   self.todos = require('orgmode.colors.highlighter.todos'):new()
+  self.foldtext = require('orgmode.colors.highlighter.foldtext'):new({ highlighter = self })
 
   vim.api.nvim_set_decoration_provider(self.namespace, {
     on_win = function(...)
@@ -65,11 +67,13 @@ function OrgHighlighter:_on_line(_, _, bufnr, line)
   if self.buffers[bufnr].tree then
     self.markup:on_line(bufnr, line, self.buffers[bufnr].tree)
     self.stars:on_line(bufnr, line)
+    self.foldtext:on_line(bufnr, line)
   end
 end
 
 function OrgHighlighter:_on_detach(bufnr)
   self.markup:on_detach(bufnr)
+  self.foldtext:on_detach(bufnr)
   self.buffers[bufnr] = nil
 end
 

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -1,6 +1,7 @@
 local config = require('orgmode.config')
 local VirtualIndent = require('orgmode.ui.virtual_indent')
 local ts_utils = require('orgmode.utils.treesitter')
+local utils = require('orgmode.utils')
 ---@type Query
 local query = nil
 
@@ -313,14 +314,14 @@ local function foldtext()
 end
 
 local function setup()
-  local v = vim.version()
+  if not utils.has_version_10() then
+    return
+  end
 
-  if not vim.version.lt({ v.major, v.minor, v.patch }, { 0, 10, 0 }) then
-    if config.org_startup_indented then
-      VirtualIndent:new():attach()
-    else
-      VirtualIndent:new():start_watch_org_indent()
-    end
+  if config.org_startup_indented then
+    VirtualIndent:new():attach()
+  else
+    VirtualIndent:new():start_watch_org_indent()
   end
 end
 

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -593,4 +593,9 @@ function utils.memoize(class, key_getter)
   end
 end
 
+function utils.has_version_10()
+  local v = vim.version()
+  return not vim.version.lt({ v.major, v.minor, v.patch }, { 0, 10, 0 })
+end
+
 return utils


### PR DESCRIPTION
Use new empty foldtext option (`set foldtext=`) to highlight folded lines. Also add `org_ellipsis` accordingly to look like Emacs Orgmode. Closes https://github.com/nvim-orgmode/orgmode/issues/661