### PR TITLE
fix: open external urls with vim.ui.open() if it exists

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -849,6 +849,9 @@ function OrgMappings:open_at_point()
   end
 
   if link.url:is_external_url() then
+    if vim.ui['open'] then
+      return vim.ui.open(link.url:to_string())
+    end
     if not vim.g.loaded_netrwPlugin then
       return utils.echo_warning('Netrw plugin must be loaded in order to open urls.')
     end


### PR DESCRIPTION
This enables opening URLs with `<leader>oo` even when netrw is not loaded.

Neovim `gx` was changed to this as well in 0.10.0 according to news.txt.
As far as I can tell, it was introduced here: https://github.com/neovim/neovim/pull/23401

I'm not sure if there's a better way to detect if `vim.ui.open` exists.
I'm also not sure if the return value is used for anything, but everything seemed to work fine.