### PR TITLE
refactor(agenda): use extmarks to set tags in right column

### DIFF
--- a/lua/orgmode/agenda/views/agenda.lua
+++ b/lua/orgmode/agenda/views/agenda.lua
@@ -293,12 +293,6 @@ function AgendaView.build_agenda_item_content(agenda_item, longest_category, lon
   todo_keyword = todo_padding .. todo_keyword
   local line = string.format('%s%s%s %s', category, date, todo_keyword, headline:get_title_with_priority())
   local todo_keyword_pos = string.format('%s%s%s', category, date, todo_padding):len()
-  if #headline:get_tags() > 0 then
-    local tags_string = headline:tags_to_string()
-    local padding_length = math.max(1, win_width - vim.api.nvim_strwidth(line) - vim.api.nvim_strwidth(tags_string))
-    local indent = string.rep(' ', padding_length)
-    line = string.format('%s%s%s', line, indent, tags_string)
-  end
 
   local item_highlights = {}
   if #agenda_item.highlights then

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -645,7 +645,7 @@ function OrgMappings:meta_return(suffix)
     end
 
     if #text_edits > 0 then
-      vim.lsp.util.apply_text_edits(text_edits, 0, constants.default_offset_encoding)
+      vim.lsp.util.apply_text_edits(text_edits, vim.api.nvim_get_current_buf(), constants.default_offset_encoding)
 
       vim.fn.cursor(end_row + 1 + (add_empty_line and 1 or 0), 1) -- +1 for next line
 


### PR DESCRIPTION
Before this change:
![agenda-tags-extmark-before](https://github.com/nvim-orgmode/orgmode/assets/58627896/937f4887-bc36-43d4-95bf-c7029811ef7a)

Notice that the tags end up off screen and do not get shifted to align to the right side of the screen.

After this change:
![agenda-tags-extmark-after](https://github.com/nvim-orgmode/orgmode/assets/58627896/ce1d6b4b-c810-4000-9b93-c7060bad9b2d)


Notice that the tags are correctly aligned when the window is resized. Tags are not off screen at all.