### PR TITLE
fix(mappings): use explicit bufnr for meta return in `apply_text_edits`

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -645,7 +645,7 @@ function OrgMappings:meta_return(suffix)
     end
 
     if #text_edits > 0 then
-      vim.lsp.util.apply_text_edits(text_edits, 0, constants.default_offset_encoding)
+      vim.lsp.util.apply_text_edits(text_edits, vim.api.nvim_get_current_buf(), constants.default_offset_encoding)
 
       vim.fn.cursor(end_row + 1 + (add_empty_line and 1 or 0), 1) -- +1 for next line
 


### PR DESCRIPTION
Copied from the commit message:

> Since https://github.com/neovim/neovim/commit/2e1f5055acdef650c27efc4afdf8606037ec021b, Neovim now explicitly requires the bufnr for `vim.lsp.util.apply_text_edits` to be fully resolved — meaning it cannot be 0 or null.

This just ensures nightly users don't run into errors when using `meta return` and that the tests for nightly pass as expected.