### PR TITLE
fix(indents): Address few indent issues

### DIFF
--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -2,7 +2,7 @@ local config = require('orgmode.config')
 local VirtualIndent = require('orgmode.ui.virtual_indent')
 local ts_utils = require('orgmode.utils.treesitter')
 local utils = require('orgmode.utils')
----@type Query
+---@type vim.treesitter.Query
 local query = nil
 
 local function get_indent_pad(linenr, bufnr)
@@ -93,121 +93,119 @@ local get_matches = ts_utils.memoize_by_buf_tick(function(bufnr)
   local matches = {}
   local mode = vim.fn.mode()
   local root = tree[1]:root()
-  for _, match, _ in query:iter_matches(root, bufnr, 0, -1) do
-    for id, node in pairs(match) do
-      local range = ts_utils.node_to_lsp_range(node)
-      local type = node:type()
+  for id, node in query:iter_captures(root, bufnr, 0, -1) do
+    local range = ts_utils.node_to_lsp_range(node)
+    local type = node:type()
 
-      local opts = {
-        type = type,
-        node = node,
-        parent = node:parent(),
-        line_nr = range.start.line + 1,
-        line_end_nr = range['end'].line,
-        name = query.captures[id],
-        indent = vim.fn.indent(range.start.line + 1),
-      }
+    local opts = {
+      type = type,
+      node = node,
+      parent = node:parent(),
+      line_nr = range.start.line + 1,
+      line_end_nr = range['end'].line,
+      name = query.captures[id],
+      indent = vim.fn.indent(range.start.line + 1),
+    }
 
-      if type == 'headline' then
-        local _, level = node:field('stars')[1]:end_()
-        opts.stars = level
-        opts.indent = opts.indent + opts.stars + 1
-        matches[range.start.line + 1] = opts
-      end
+    if type == 'headline' then
+      local _, level = node:field('stars')[1]:end_()
+      opts.stars = level
+      opts.indent = opts.indent + opts.stars + 1
+      matches[range.start.line + 1] = opts
+    end
 
-      if type == 'listitem' then
-        local content = node:named_child(1)
-        if content then
-          local content_linenr, content_indent = content:start()
-          if content_linenr == range.start.line then
-            opts.overhang = content_indent - opts.indent
-          end
-        end
-        if not opts.overhang then
-          local bullet = node:named_child(0)
-          opts.overhang = vim.treesitter.get_node_text(bullet, bufnr):len() + 1
-        end
-
-        local parent = node:parent()
-        while parent and parent:type() ~= 'section' and parent:type() ~= 'listitem' do
-          parent = parent:parent()
-        end
-        local prev_sibling = node:prev_sibling()
-        opts.prev_sibling_linenr = prev_sibling and (prev_sibling:start() + 1)
-        opts.nesting_parent_linenr = parent and (parent:start() + 1)
-
-        for i = range.start.line, range['end'].line - 1 do
-          matches[i + 1] = opts
+    if type == 'listitem' then
+      local content = node:named_child(1)
+      if content then
+        local content_linenr, content_indent = content:start()
+        if content_linenr == range.start.line then
+          opts.overhang = content_indent - opts.indent
         end
       end
+      if not opts.overhang then
+        local bullet = node:named_child(0)
+        opts.overhang = vim.treesitter.get_node_text(bullet, bufnr):len() + 1
+      end
 
-      if type == 'block' then
-        opts.indent_type = 'block'
-        local parent = node:parent()
-        while parent and parent:type() ~= 'section' and parent:type() ~= 'listitem' do
-          parent = parent:parent()
-        end
-        -- We want to find the difference in indentation level between the item to be indented and the parent node.
-        -- If the item is in the block, we shouldn't change the indentation beyond how much we modify the indent of the
-        -- block header and footer. This keeps code correctly indented in `BEGIN_SRC` blocks as well as ensuring
-        -- `BEGIN_EXAMPLE` blocks don't have their indentation changed inside of them.
-        local parent_linenr = parent:start() + 1
-        local parent_indent = get_indent_for_match(matches, parent:start() + 1, mode, bufnr)
+      local parent = node:parent()
+      while parent and parent:type() ~= 'section' and parent:type() ~= 'listitem' do
+        parent = parent:parent()
+      end
+      local prev_sibling = node:prev_sibling()
+      opts.prev_sibling_linenr = prev_sibling and (prev_sibling:start() + 1)
+      opts.nesting_parent_linenr = parent and (parent:start() + 1)
 
-        -- We want to align to the listitem body, not the bullet
-        if parent:type() == 'listitem' then
-          parent_indent = parent_indent + matches[parent_linenr].overhang
+      for i = range.start.line, range['end'].line - 1 do
+        matches[i + 1] = opts
+      end
+    end
+
+    if type == 'block' then
+      opts.indent_type = 'block'
+      local parent = node:parent()
+      while parent and parent:type() ~= 'section' and parent:type() ~= 'listitem' do
+        parent = parent:parent()
+      end
+      -- We want to find the difference in indentation level between the item to be indented and the parent node.
+      -- If the item is in the block, we shouldn't change the indentation beyond how much we modify the indent of the
+      -- block header and footer. This keeps code correctly indented in `BEGIN_SRC` blocks as well as ensuring
+      -- `BEGIN_EXAMPLE` blocks don't have their indentation changed inside of them.
+      local parent_linenr = parent:start() + 1
+      local parent_indent = get_indent_for_match(matches, parent:start() + 1, mode, bufnr)
+
+      -- We want to align to the listitem body, not the bullet
+      if parent:type() == 'listitem' then
+        parent_indent = parent_indent + matches[parent_linenr].overhang
+      else
+        parent_indent = get_indent_pad(range.start.line + 1, bufnr)
+      end
+
+      local curr_header_indent = vim.fn.indent(range.start.line + 1)
+      local header_indent_diff = curr_header_indent - parent_indent
+      local new_header_indent = curr_header_indent - header_indent_diff
+      -- Ensure the block footer is properly aligned with the header
+      matches[range.start.line + 1] = vim.tbl_deep_extend('force', opts, {
+        indent = new_header_indent,
+      })
+      matches[range['end'].line] = vim.tbl_deep_extend('force', opts, {
+        indent = new_header_indent,
+      })
+
+      local content_indent_pad = 0
+      -- Only include the header line and the content. Do not include the footer in the loop.
+      for i = range.start.line + 1, range['end'].line - 2 do
+        local curr_indent = vim.fn.indent(i + 1)
+        -- Correctly align the pad to the new header position if it was underindented
+        local new_indent_pad = new_header_indent - curr_indent
+        -- If the current content indentaion is less than the new header indent we want to increase all of the
+        -- content by the largest difference in indentation between a given content line and the new header indent.
+        if curr_indent < new_header_indent then
+          content_indent_pad = math.max(new_indent_pad, content_indent_pad)
         else
-          parent_indent = get_indent_pad(range.start.line + 1, bufnr)
-        end
-
-        local curr_header_indent = vim.fn.indent(range.start.line + 1)
-        local header_indent_diff = curr_header_indent - parent_indent
-        local new_header_indent = curr_header_indent - header_indent_diff
-        -- Ensure the block footer is properly aligned with the header
-        matches[range.start.line + 1] = vim.tbl_deep_extend('force', opts, {
-          indent = new_header_indent,
-        })
-        matches[range['end'].line] = vim.tbl_deep_extend('force', opts, {
-          indent = new_header_indent,
-        })
-
-        local content_indent_pad = 0
-        -- Only include the header line and the content. Do not include the footer in the loop.
-        for i = range.start.line + 1, range['end'].line - 2 do
-          local curr_indent = vim.fn.indent(i + 1)
-          -- Correctly align the pad to the new header position if it was underindented
-          local new_indent_pad = new_header_indent - curr_indent
-          -- If the current content indentaion is less than the new header indent we want to increase all of the
-          -- content by the largest difference in indentation between a given content line and the new header indent.
-          if curr_indent < new_header_indent then
-            content_indent_pad = math.max(new_indent_pad, content_indent_pad)
+          -- If the current content indentation is more than the new header indentation, but it was the current
+          -- content indentation was less than the current header indent then we want to add some indentation onto
+          -- the content by the largest negative difference (meaning -1 > -2 > -3 so take -1 as the pad).
+          --
+          -- We do a check for 0 here as we don't want to do a max of neg number against 0. 0 will always win. As
+          -- such if the current pad is 0 just set to the new calculated pad.
+          if content_indent_pad == 0 then
+            content_indent_pad = new_indent_pad
           else
-            -- If the current content indentation is more than the new header indentation, but it was the current
-            -- content indentation was less than the current header indent then we want to add some indentation onto
-            -- the content by the largest negative difference (meaning -1 > -2 > -3 so take -1 as the pad).
-            --
-            -- We do a check for 0 here as we don't want to do a max of neg number against 0. 0 will always win. As
-            -- such if the current pad is 0 just set to the new calculated pad.
-            if content_indent_pad == 0 then
-              content_indent_pad = new_indent_pad
-            else
-              content_indent_pad = math.max(new_indent_pad, content_indent_pad)
-            end
+            content_indent_pad = math.max(new_indent_pad, content_indent_pad)
           end
         end
-        -- If any of the content is underindented relative to the header and footer, we need to indent all of the
-        -- content until the most underindented content is equal in indention to the header and footer.
-        --
-        -- Only loop the content.
-        for i = range.start.line + 1, range['end'].line - 2 do
-          matches[i + 1] = vim.tbl_deep_extend('force', opts, {
-            indent = vim.fn.indent(i + 1) + content_indent_pad,
-          })
-        end
-      elseif type == 'paragraph' or type == 'drawer' or type == 'property_drawer' then
-        opts.indent_type = 'other'
       end
+      -- If any of the content is underindented relative to the header and footer, we need to indent all of the
+      -- content until the most underindented content is equal in indention to the header and footer.
+      --
+      -- Only loop the content.
+      for i = range.start.line + 1, range['end'].line - 2 do
+        matches[i + 1] = vim.tbl_deep_extend('force', opts, {
+          indent = vim.fn.indent(i + 1) + content_indent_pad,
+        })
+      end
+    elseif type == 'paragraph' or type == 'drawer' or type == 'property_drawer' then
+      opts.indent_type = 'other'
     end
   end
 

--- a/lua/orgmode/org/indent.lua
+++ b/lua/orgmode/org/indent.lua
@@ -150,11 +150,12 @@ local get_matches = ts_utils.memoize_by_buf_tick(function(bufnr)
       -- If the item is in the block, we shouldn't change the indentation beyond how much we modify the indent of the
       -- block header and footer. This keeps code correctly indented in `BEGIN_SRC` blocks as well as ensuring
       -- `BEGIN_EXAMPLE` blocks don't have their indentation changed inside of them.
-      local parent_linenr = parent:start() + 1
-      local parent_indent = get_indent_for_match(matches, parent:start() + 1, mode, bufnr)
+      local start = (parent and parent:start() or node:start()) + 1
+      local parent_indent = get_indent_for_match(matches, start, mode, bufnr)
 
       -- We want to align to the listitem body, not the bullet
-      if parent:type() == 'listitem' then
+      if parent and parent:type() == 'listitem' then
+        local parent_linenr = parent:start() + 1
         parent_indent = parent_indent + matches[parent_linenr].overhang
       else
         parent_indent = get_indent_pad(range.start.line + 1, bufnr)


### PR DESCRIPTION
This PR addresses few indent issues:

1. Prevent "missing parent" errors when opening `#+begin` blocks outside of headline and list item
    For example, having this content:
    ```
	#+begin_src lua
	print('test')
	#+end_src
    ```
    Pressing Enter on 2nd line currently errors out. 
2. If tree-sitter parsing is failing at the moment of requesting indentation, fallback to `-1` (autoindent). 
    For example, having this content:
    ```
	* TODO Test
	#+begin_src lua
    ```
    Pressing Enter on 2nd line to add a closing `#+end_src` will set indentation for that line to 0. This fallback ensures that indentation from previous line is followed.
3. For virtual indentation, if tree-sitter parsing is failing, fallback to searching closest headline by iterating previous lines. This removes some of the annoying jumps:
Before:
![virtual-indent-before](https://github.com/nvim-orgmode/orgmode/assets/1782860/d46c4ef6-6b0f-4caf-9140-7c06781d1741)
After:
![virtual-indent-after](https://github.com/nvim-orgmode/orgmode/assets/1782860/27ee50ca-af5b-4e3b-8d1c-cb6e6f1650c5)


@PriceHiller can you take a look and see if everything is working as expected? I also replaced `iter_matches` with `iter_captures`. Shouldn't be a problem, but let me know if you find some issues.

Note: Review with hidden whitespace changes.