### PR TITLE
Use the REPEAT_TO_STATE property

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -1022,7 +1022,7 @@ function OrgMappings:_change_todo_state(direction, use_fast_access)
     elseif direction == 'prev' then
       next_state = todo_state:get_prev()
     elseif direction == 'reset' then
-      next_state = todo_state:get_todo()
+      next_state = headline:get_property('REPEAT_TO_STATE') or todo_state:get_todo()
     end
   end
 

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -1022,7 +1022,20 @@ function OrgMappings:_change_todo_state(direction, use_fast_access)
     elseif direction == 'prev' then
       next_state = todo_state:get_prev()
     elseif direction == 'reset' then
-      next_state = headline:get_property('REPEAT_TO_STATE') or todo_state:get_todo()
+      local repeat_to_state = headline:get_property('REPEAT_TO_STATE')
+      if repeat_to_state ~= nil then
+        -- Check that a todo with that keyword exists
+        local filtered_todo = vim.tbl_filter(function(t)
+          return t == repeat_to_state
+        end, todo_state.todos.TODO)
+        if #filtered_todo > 0 then
+          next_state = { value = filtered_todo[1] }
+        else
+          next_state = todo_state:get_todo()
+        end
+      else
+        next_state = todo_state:get_todo()
+      end
     end
   end
 

--- a/tests/plenary/ui/mappings/todo_spec.lua
+++ b/tests/plenary/ui/mappings/todo_spec.lua
@@ -185,4 +185,41 @@ describe('Todo mappings', function()
       '  <2021-07-21 Wed 22:02>',
     }, vim.api.nvim_buf_get_lines(0, 2, 5, false))
   end)
+  it('Should reset state to the one defined in the REPEAT_TO_STATE property', function()
+    config:extend({
+      org_todo_keywords = { 'TODO(t)', 'PHONECALL(p)', 'WAITING(w)', '|', 'DONE(d)' },
+      org_log_into_drawer = 'LOGBOOK',
+    })
+    helpers.load_file_content({
+      '#+title: TEST',
+      '',
+      '* PHONECALL Call dad',
+      '  SCHEDULED: <2021-09-07 Tue 12:00 +1d>',
+      '  :PROPERTIES:',
+      '  :REPEAT_TO_STATE: PHONECALL',
+      '  :END:',
+    })
+
+    assert.are.same({
+      '* PHONECALL Call dad',
+      '  SCHEDULED: <2021-09-07 Tue 12:00 +1d>',
+      '  :PROPERTIES:',
+      '  :REPEAT_TO_STATE: PHONECALL',
+      '  :END:',
+    }, vim.api.nvim_buf_get_lines(0, 2, 7, false))
+    vim.fn.cursor(3, 3)
+    vim.cmd([[norm citd]])
+    vim.wait(50)
+    assert.are.same({
+      '* PHONECALL Call dad',
+      '  SCHEDULED: <2021-09-08 Wed 12:00 +1d>',
+      '  :PROPERTIES:',
+      '  :REPEAT_TO_STATE: PHONECALL',
+      '  :LAST_REPEAT: [' .. Date.now():to_string() .. ']',
+      '  :END:',
+      '  :LOGBOOK:',
+      '  - State "DONE" from "PHONECALL" [' .. Date.now():to_string() .. ']',
+      '  :END:',
+    }, vim.api.nvim_buf_get_lines(0, 2, 11, false))
+  end)
 end)

--- a/tests/plenary/ui/mappings/todo_spec.lua
+++ b/tests/plenary/ui/mappings/todo_spec.lua
@@ -190,7 +190,7 @@ describe('Todo mappings', function()
       org_todo_keywords = { 'TODO(t)', 'PHONECALL(p)', 'WAITING(w)', '|', 'DONE(d)' },
       org_log_into_drawer = 'LOGBOOK',
     })
-    helpers.load_file_content({
+    helpers.create_agenda_file({
       '#+title: TEST',
       '',
       '* PHONECALL Call dad',


### PR DESCRIPTION
Hello,

I honestly do not know if this is part of Emacs because I started using org-mode directly in Neovim thanks to this amazing plugin.

One thing that really bothered me with the current version of the plugin was that the `nvim-cmp` was proposing a `REPEAT_TO_STATE` property completion, but it wasn't used, and I know this is something I use a lot (lot of recurring meetings at work, like daily and stuff).

So some time ago I made this fix and now I adapted it to the recent modifications you've done. Let me know if there's something I can do!