### PR TITLE
Faster statusline

### DIFF
--- a/lua/orgmode/clock/init.lua
+++ b/lua/orgmode/clock/init.lua
@@ -14,6 +14,7 @@ function Clock:new(opts)
   }
   setmetatable(data, self)
   self.__index = self
+  data:init()
   return data
 end
 

--- a/lua/orgmode/clock/init.lua
+++ b/lua/orgmode/clock/init.lua
@@ -25,6 +25,10 @@ function Clock:init()
   end
 end
 
+function Clock:has_clocked_headline()
+  return self.clocked_headline ~= nil
+end
+
 function Clock:org_clock_in()
   local item = self.files:get_closest_headline()
   if item:is_clocked_in() then

--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -65,6 +65,7 @@ function Org:init()
   self.clock = require('orgmode.clock'):new({
     files = self.files,
   })
+  self.clock:init()
   self.completion = require('orgmode.org.autocompletion'):new({ files = self.files })
   self.statusline_debounced = require('orgmode.utils').debounce('statusline', function()
     return self.clock:get_statusline()

--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -65,7 +65,6 @@ function Org:init()
   self.clock = require('orgmode.clock'):new({
     files = self.files,
   })
-  self.clock:init()
   self.completion = require('orgmode.org.autocompletion'):new({ files = self.files })
   self.statusline_debounced = require('orgmode.utils').debounce('statusline', function()
     return self.clock:get_statusline()


### PR DESCRIPTION
Hello,
With the last updates I've noticed that the `get_statusline()` function was slowing down my Neovim instance a lot and I think the problem is related with the way the clock gets the currently clocked in headline, which is basically parsing all files and retrieving the first clocked in headline.

Now, on my PC the slow down was barely noticeable, but on my Android phone it became a real issue (despite it being a good smartphone) so I did my best trying to patch it.

The basic idea is that now, with the modifications here, we pay a little upfront cost (it is noticeable on my phone but it is only at startup, I could not test it on my PC yet, will do later this week) but afterwards we store the information of the clocked headline in the instance of the clock itself, making it faster to access the information to display the statusline.

I've been testing this code for a few hours and it is quite stable and reliable, the only problem I see is if someone deletes the LOGBOOK entry manually, the clocked headline won't be reset.. probably we could run an async job every now and then to check if the clock is still valid?

Also, with this modification it is easier for hackers to retrieve the current clocked headline and [customise the statusline](https://github.com/massix/dot-termux/blob/20bb90720353d98cb32fd500753bfc709e9b1919/nvim/lua/plugins/lualine.lua#L71) message, we don't even need a debouncer anymore since we're not modifying or touching the files.

Please let me know if you have better ideas!