### PR TITLE
fix(treesitter): correctly inject the language in blocks

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -415,7 +415,7 @@ function Config:setup_ts_predicates()
     if not text or vim.trim(text) == '' then
       return
     end
-    metadata['injection.language'] = utils.detect_filetype(text)
+    metadata['injection.language'] = utils.detect_filetype(text) or text
   end, true)
 end
 


### PR DESCRIPTION
Hello,
with the last refactoring I noticed that most languages were not being injected properly, I think that this is caused by the new directive `org-set-block-language!` which was returning `nil` for basically all the languages which were not listed in the map.

This should fix it.

I tested with the languages I use the most: `terraform`, `haskell`, `purescript` and `c_sharp` and it works well, it also works with the aliases from the map: `js`, `md`, ...

Since I am not that good when it comes to treesitter, there may be something else I'm missing, let me know!