### PR TITLE
fix: correct emphasis text objects like builtin i" & a"

### DIFF
--- a/ftplugin/org.lua
+++ b/ftplugin/org.lua
@@ -50,16 +50,16 @@ for _, char in ipairs({ '*', '=', '/', '+', '~', '_' }) do
     'x',
     'i' .. char,
     ([[:<C-u>silent! lua require('orgmode.org.text_objects').select_nearest_token_pair('%s')<CR>]]):format(char),
-    { buffer = true }
+    { buffer = true, silent = true }
   )
-  vim.keymap.set('o', 'i' .. char, ":normal vi" .. char .. '<CR>', { buffer = true })
+  vim.keymap.set('o', 'i' .. char, ':silent! normal vi' .. char .. '<CR>', { buffer = true, silent = true })
   vim.keymap.set(
     'x',
     'a' .. char,
     ([[:<C-u>silent! lua require('orgmode.org.text_objects').select_nearest_token_pair('%s', true)<CR>]]):format(char),
-    { buffer = true }
+    { buffer = true, silent = true }
   )
-  vim.keymap.set('o', 'a' .. char, ':normal va' .. char .. '<CR>', { buffer = true })
+  vim.keymap.set('o', 'a' .. char, ':normal va' .. char .. '<CR>', { buffer = true, silent = true })
 end
 
 vim.b.undo_ftplugin = table.concat({
@@ -72,5 +72,5 @@ vim.b.undo_ftplugin = table.concat({
   'foldexpr<',
   'formatexpr<',
   'omnifunc<',
-  '| unlet! b:org_bufnr'
+  '| unlet! b:org_bufnr',
 }, ' ')

--- a/ftplugin/org.lua
+++ b/ftplugin/org.lua
@@ -46,9 +46,19 @@ for abbrev, cmd in pairs(abbreviations) do
 end
 
 for _, char in ipairs({ '*', '=', '/', '+', '~', '_' }) do
-  vim.keymap.set('x', 'i' .. char, ':<C-u>normal! T' .. char .. 'vt' .. char .. '<CR>', { buffer = true })
-  vim.keymap.set('o', 'i' .. char, ':normal vi' .. char .. '<CR>', { buffer = true })
-  vim.keymap.set('x', 'a' .. char, ':<C-u>normal! F' .. char .. 'vf' .. char .. '<CR>', { buffer = true })
+  vim.keymap.set(
+    'x',
+    'i' .. char,
+    ([[:<C-u>silent! lua require('orgmode.org.text_objects').select_nearest_token_pair('%s')<CR>]]):format(char),
+    { buffer = true }
+  )
+  vim.keymap.set('o', 'i' .. char, ":normal vi" .. char .. '<CR>', { buffer = true })
+  vim.keymap.set(
+    'x',
+    'a' .. char,
+    ([[:<C-u>silent! lua require('orgmode.org.text_objects').select_nearest_token_pair('%s', true)<CR>]]):format(char),
+    { buffer = true }
+  )
   vim.keymap.set('o', 'a' .. char, ':normal va' .. char .. '<CR>', { buffer = true })
 end
 

--- a/lua/orgmode/org/text_objects.lua
+++ b/lua/orgmode/org/text_objects.lua
@@ -140,4 +140,132 @@ function TextObjects.around_subtree_from_root()
   current_subtree_from_root(false)
 end
 
+---@class PairedTokenLocations
+---@field content string The content that was detected for the token
+---@field sindex integer The 0-indexed, starting position in the string the first token was found at
+---@field eindex integer The 0-indexed ending position in the string the second token was found at
+
+---Gets all positions of paried tokens
+---@param str string The string to search
+---@param token string The pair of strings to search for
+---@param strict? boolean Should not allow reuse of end token from previous pair for new pair, default: true
+---@param init? integer Starting position to search from in the string, default: 1
+---@return PairedTokenLocations locations The paired token locations
+function TextObjects.get_paired_token_locations(str, token, strict, init)
+  strict = strict or true
+  -- If the offset is 1, then it won't reuse the previous pair's token.
+  -- Consider the following string where the token is `%`:
+  --
+  -- > Hello %world%, %goodbye!%
+  --
+  -- If the offset is 0 then on the first pair the starting index will be on the last `%` of
+  -- 'world'. When the next pair is being found, it will be searching from that last `%` of 'world'
+  -- up to the first `%` of 'goodbye!'. So the next pair will be from the last `%` of 'world' and the
+  -- first `%` of 'goodbye!'
+  --
+  -- If the offset is 1, then the starting index will not be on a valid token and will consequently
+  -- be moved forward to the first `%` of 'goodbye!' and then the end index for the pair will be set
+  -- to the last `%` of 'goodbye!'.
+  local offset = (strict and 1 or 0)
+  local escaped_token = token:gsub('.', '%%%1')
+
+  init = init or 1
+  local locations = {}
+
+  ---@type integer | nil
+  local sindex = init
+  ---@type integer | nil
+  local eindex = init
+  while sindex and eindex do
+    sindex, eindex = str:find(escaped_token .. '(.-)' .. escaped_token, sindex)
+    if sindex and eindex then
+      local token_content = str:sub(sindex, eindex)
+      table.insert(locations, { content = token_content, sindex = sindex - 1, eindex = eindex - 1 })
+      sindex = eindex + offset
+    end
+  end
+
+  return locations
+end
+
+---Creates a visual selection in or around the nearest pair of tokens identical to Vim's quote
+---selection textobjects.
+---@param token string The string to select in or around
+---@param around boolean If true, the selection should be around the token, default: false
+function TextObjects.select_nearest_token_pair(token, around)
+  local buf = vim.api.nvim_get_current_buf()
+  local win = vim.api.nvim_get_current_win()
+  local cursor_pos = vim.api.nvim_win_get_cursor(win)
+  ---The position of the cursor in the current window
+  local cursor = {
+    ---@type integer The one-indexed position of the cursor row
+    row = cursor_pos[1],
+    ---@type integer The one-indexed position of the cursor's column
+    col = cursor_pos[2],
+  }
+  local cur_line_content = vim.api.nvim_buf_get_lines(buf, cursor.row - 1, cursor.row, true)[1]
+  local matches = TextObjects.get_paired_token_locations(cur_line_content, token, true)
+  if #matches == 0 then
+    return
+  end
+
+  ---@type PairedTokenLocations
+  local match
+  for curr_match_index, curr_match in ipairs(matches) do
+    -- We have a valid match location, we shouldn't search for any other matches as the match set
+    -- will be the nearest match
+    if match then
+      break
+    end
+
+    -- If the cursor is within a pair of tokens, then that is the nearest match
+    if cursor.col >= curr_match.sindex and cursor.col <= curr_match.eindex then
+      match = curr_match
+    -- If the cursor is behind a pair of tokens, then we want to correctly determine the correct
+    -- match from there.
+    elseif cursor.col < curr_match.sindex then
+      local last_match = matches[curr_match_index - 1]
+      -- If we have a previous pair of tokens that is behind our cursor (and since we're not in
+      -- between a STRICT pair of tokens) we are between two tokens currently and should create a
+      -- match coming from the end of the last pair of tokens and the start of the next pair.
+      --
+      -- Otherwise, the nearest match is the pair of tokens ahead of the cursor.
+      if last_match then
+        match = {
+          sindex = last_match.eindex,
+          eindex = curr_match.sindex,
+        }
+      else
+        match = curr_match
+      end
+    end
+  end
+
+  if not match then
+    return
+  end
+
+  if around then
+    -- The way vim's default text objects work is if they have trailing whitespace, the around
+    -- selection should also select the trailing whitespace. As such, we have to determine if
+    -- there's trailing whitespace after the match and if so, extend the selection to include it.
+    local whitespace_start, whitespace_end = cur_line_content:find('.%s*[^%S]', match.eindex)
+
+    -- whitespace_start is 1-indexed, have to decrement it to compare it with the 0-indexed
+    -- match.eindex
+    if (whitespace_start and whitespace_end) and whitespace_start - 1 == match.eindex then
+      match.eindex = whitespace_end - 1
+    end
+  else
+    -- The match currently is selecting the tokens as well, reduce the match to bring it within the
+    -- tokens for inner selection
+    match.sindex = match.sindex + 1
+    match.eindex = match.eindex - 1
+  end
+
+  vim.api.nvim_buf_set_mark(buf, '<', cursor.row, match.sindex, {})
+  vim.api.nvim_buf_set_mark(buf, '>', cursor.row, match.eindex, {})
+  vim.cmd('silent! normal! gv')
+end
+
 return TextObjects

--- a/tests/plenary/org/text_objects_spec.lua
+++ b/tests/plenary/org/text_objects_spec.lua
@@ -1,0 +1,158 @@
+local helpers = require('tests.plenary.helpers')
+
+--- Inserts a string into another and returns the newly created combined string
+---@param string_to_insert_into string The string to modify
+---@param string_to_be_inserted string The string to insert
+---@param pos integer The 1-indexed position to insert a string at
+---@return string combined A string with the new substring inserted at the given pos
+local function insert_substring(string_to_insert_into, string_to_be_inserted, pos)
+  local split_str = {}
+  ---@diagnostic disable-next-line: discard-returns
+  string_to_insert_into:gsub('.', function(c)
+    table.insert(split_str, c)
+  end)
+  table.insert(split_str, pos, string_to_be_inserted)
+  return table.concat(split_str)
+end
+
+---Loop through a given string and compare the custom textobject operation to Vim's builtin
+---operation and assert they are the same
+---@param marker string A single character textobject marker to use in operation
+---@param around boolean Whether or not to use the `around` operation or `inner` operation
+---@param content string A template string to use for the operations, place `%` signs where the marker should be inserted
+---@param builtin_marker? string A single character textobject marker that is builtin to vim, default: "
+local function expect_text_object(marker, around, content, builtin_marker)
+  builtin_marker = builtin_marker or '"'
+  if #builtin_marker > 1 then
+    error(
+      'Comparator token textobject may only be `1` in length. It should be a builtin token from Vim\'s textobjects like `"`.'
+    )
+  end
+  local comparator_content = content:gsub('%%', builtin_marker)
+  content = content:gsub('%%', marker)
+
+  local command = 'normal d' .. (around and 'a' or 'i')
+  helpers.create_file({})
+  -- Move one-by-one along the line and run a textobject operation at each position and compare
+  -- against a vim built-in textobject operation.
+  for cursor_col = 1, #content do
+    -- Run the text object actions with a vim built-in textobject so we know what the actual content
+    -- should become
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { comparator_content })
+    vim.api.nvim_win_set_cursor(0, { 1, cursor_col - 1 })
+    vim.cmd(command .. builtin_marker)
+    local expected = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    expected = vim.tbl_map(function(line)
+      return line:gsub('%' .. builtin_marker, marker)
+    end, expected)
+
+    -- Run the text object actions with the custom marker and capture the output
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { content })
+    vim.api.nvim_win_set_cursor(0, { 1, cursor_col - 1 })
+    vim.cmd(command .. marker)
+    local curr_content = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+
+    if not vim.deep_equal(expected, curr_content) then
+      ---@diagnostic disable-next-line: undefined-field
+      assert.are
+        .message(table.concat({
+          '\nTest Failed For Marker: ' .. vim.inspect(marker),
+          'Command: ' .. vim.inspect(command .. marker),
+          'Cursor col: ' .. vim.inspect(cursor_col),
+          'Given Content:         ' .. vim.inspect(content),
+          'Cursor (|) in Content: ' .. vim.inspect(insert_substring(content, '|', cursor_col)),
+        }, '\n  '))
+        .same(expected, curr_content)
+    end
+  end
+end
+
+local emphasis_markers = {
+  '_',
+  '=',
+  '/',
+  '+',
+  '*',
+  '~',
+}
+
+for _, emphasis_marker in ipairs(emphasis_markers) do
+  describe('The emphasis around textobject `' .. emphasis_marker .. '`', function()
+    local around = true
+
+    it('correctly selects the same as `"` in all line column positions with unbalanced pairs', function()
+      expect_text_object(emphasis_marker, around, [[-> %Hello% World%   %End%]])
+    end)
+
+    it('correctly selects the same as `"` in all line column positions with balanced pairs', function()
+      expect_text_object(emphasis_marker, around, [[-> %Hello% %World%   %End%]])
+    end)
+
+    it(
+      'correctly selects the same as `"` in all line column positions with limited whitespace with balanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello% %World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with limited whitespace with unbalanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello%World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with no whitespace with balanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello% %World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with no whitespace with unbalanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello%World%words%End%]])
+      end
+    )
+  end)
+
+  describe('The emphasis inner textobject `' .. emphasis_marker .. '`', function()
+    local around = false
+    it('correctly selects the same as `"` in all line column positions with unbalanced pairs', function()
+      expect_text_object(emphasis_marker, around, [[-> %Hello% World%   %End%]])
+    end)
+
+    it('correctly selects the same as `"` in all line column positions with balanced pairs', function()
+      expect_text_object(emphasis_marker, around, [[-> %Hello% %World%   %End%]])
+    end)
+
+    it(
+      'correctly selects the same as `"` in all line column positions with limited whitespace with balanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello% %World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with limited whitespace with unbalanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello% World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with no whitespace with balanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello% %World%words%End%]])
+      end
+    )
+
+    it(
+      'correctly selects the same as `"` in all line column positions with no whitespace with unbalanced pairs',
+      function()
+        expect_text_object(emphasis_marker, around, [[-> %Hello%World%words%End%]])
+      end
+    )
+  end)
+end


### PR DESCRIPTION
This PR fixes the text object motions for emphasis markers to work ***EXACTLY*** like vim's quote inner and around selections.

This PR also adds tests for those emphasis markers.

Let me know if you want me to Squash my separate test and fix commits together.

Of note, maybe it would be nicer to have the Treesitter parser pick up on these emphasis regions. The code I wrote to locate the pairs of emphasis markers was a true pain and would've been trivialized if the syntax tree TS had also included the emphasis markers as an object.

For now though, this works quite well actually.

Closes #686 