### PR TITLE
fix(virtual indent): make TS lookup not exclude lines

### DIFF
--- a/lua/orgmode/ui/virtual_indent.lua
+++ b/lua/orgmode/ui/virtual_indent.lua
@@ -84,8 +84,8 @@ function VirtualIndent:set_indent(start_line, end_line, ignore_ts)
   if headline and not ignore_ts then
     local parent = headline:parent()
     if parent then
-      start_line = parent:start()
-      end_line = parent:end_()
+      start_line = math.min(parent:start(), start_line)
+      end_line = math.max(parent:end_(), end_line)
     end
   end
   if start_line > 0 then


### PR DESCRIPTION
Copied from the body of the commit:
> Prior to this commit, it was possible that virtual indents would only apply to the first heading in a range of lines and the other headings would lose virtual indentation.
> 
> This change makes the Treesitter lookup prefer the largest range of lines to set virtual indentation on and thus ensures virtual indent is set correctly across the entire range.

I noticed an issue when after saving a file with many headers in it, the virtual indent would only apply to the first header region and exclude the rest leaving the buffer with very wonky virtual indentation. This fixes that.

Note that this does not invalidate the need for the Treesitter lookup, as it is possible the Treesitter lookup specifies a larger range than the given lines. For instance, when adding a more indented header above a bunch of content below it the `on_lines` function will only report the lines where the header was added, not the lines below the header that also require a change in virtual indentation.