### PR TITLE
fix(virtual indent): do not return virtual indentation for headlines

### DIFF
--- a/lua/orgmode/ui/virtual_indent.lua
+++ b/lua/orgmode/ui/virtual_indent.lua
@@ -53,9 +53,12 @@ function VirtualIndent:_get_indent_size(line, tree_has_errors)
   if tree_has_errors then
     local linenr = line
     while linenr > 0 do
-      local _, level = vim.fn.getline(linenr):find('^%*+')
+      -- We offset `linenr` by 1 because it's 0-indexed and `getline` is 1-indexed
+      local _, level = vim.fn.getline(linenr + 1):find('^%*+')
       if level then
-        return level + 1
+        -- If the current line is a headline we should return no virtual indentation, otherwise
+        -- return virtual indentation
+        return (linenr == line and 0 or level + 1)
       end
       linenr = linenr - 1
     end


### PR DESCRIPTION
Copied from the body of the commit message:

> This ensures when the treesitter parser has errors, the manual indent
sizing doesn't return virtual indentation for headlines.

### Before the Fix
![messed-up-vindent-headlines](https://github.com/nvim-orgmode/orgmode/assets/58627896/b85443ab-911a-4585-9658-50f761be7cbd)

### After the Fix
![fixed-vindent-headlines](https://github.com/nvim-orgmode/orgmode/assets/58627896/6695ffde-df1d-4f88-b622-fe08e3639afe)

### Misc

What's annoying is that the tests didn't catch this -- need a test to check raw insertion and typing I guess. That would've caught this for sure. The current tests loads the file, where the virtual indent works as expected.

Something to put on my TODO when I have more time.

Again, if anything crops up with Virtual Indent, ping me. I'll gladly look at it.