### PR TITLE
Fix usage of 0 for buffer handle instead of `OrgFile:bufnr()` where possible

### DIFF
--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -432,7 +432,7 @@ function OrgFile:set_node_text(node, text, front_trim)
     end_row = last_line
 
     local end_row_text = vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, true)[1]
-    end_col = string.len(end_row_text) - 2
+    end_col = string.len(end_row_text)
   end
   local ok = pcall(vim.api.nvim_buf_set_text, bufnr, start_row, start_col, end_row, end_col, replacement)
   return ok

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -427,10 +427,12 @@ function OrgFile:set_node_text(node, text, front_trim)
   -- (section: 10, 0, 11, 0) instead of (section: 10, 0, 10, 10)
   -- If we are setting text at the end of the file it will throw an out of range error
   -- To avoid that,get the last line number and it's last column
-  local last_line = vim.fn.line('$') - 1
+  local last_line = vim.api.nvim_buf_line_count(bufnr) - 1
   if end_row > last_line then
     end_row = last_line
-    end_col = vim.fn.col({ end_row, '$' }) - 2
+
+    local end_row_text = vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, true)[1]
+    end_col = string.len(end_row_text) - 2
   end
   local ok = pcall(vim.api.nvim_buf_set_text, bufnr, start_row, start_col, end_row, end_col, replacement)
   return ok

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -445,7 +445,7 @@ function OrgFile:set_node_lines(node, lines)
     return false
   end
   local start_row, _, end_row, _ = node:range()
-  vim.api.nvim_buf_set_lines(0, start_row, end_row, false, lines)
+  vim.api.nvim_buf_set_lines(bufnr, start_row, end_row, false, lines)
   return true
 end
 

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -890,13 +890,13 @@ function Headline:id_get_or_create()
   return org_id
 end
 
----@param type OrgPlanDateTypes
+---@param date_type OrgPlanDateTypes
 ---@param date OrgDate
 ---@param active? boolean
 ---@private
-function Headline:_add_date(type, date, active)
+function Headline:_add_date(date_type, date, active)
   local _, date_nodes, has_plan_dates = self:get_plan_dates()
-  local text = type .. ': ' .. date:to_wrapped_string(active)
+  local text = date_type .. ': ' .. date:to_wrapped_string(active)
   if not has_plan_dates then
     local start_line = self:node():start()
 
@@ -914,18 +914,18 @@ function Headline:_add_date(type, date, active)
 
     return self:refresh()
   end
-  if date_nodes[type] then
-    return self:_set_node_text(date_nodes[type], text)
+  if date_nodes[date_type] then
+    return self:_set_node_text(date_nodes[date_type], text)
   end
 
   local keys = vim.tbl_keys(date_nodes)
   local other_types = vim.tbl_filter(function(t)
-    return t ~= type
+    return t ~= date_type
   end, { 'DEADLINE', 'SCHEDULED', 'CLOSED' })
   local last_child = date_nodes[keys[#keys]]
-  for _, date_type in ipairs(other_types) do
-    if date_nodes[date_type] then
-      last_child = date_nodes[date_type]
+  for _, other_date_type in ipairs(other_types) do
+    if date_nodes[other_date_type] then
+      last_child = date_nodes[other_date_type]
       break
     end
   end

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -876,8 +876,8 @@ end
 
 function Headline:is_same(other_headline)
   return self.file.filename == other_headline.filename
-      and self:get_range():is_same(other_headline:get_range())
-      and self:get_headline_line_content() == other_headline:get_headline_line_content()
+    and self:get_range():is_same(other_headline:get_range())
+    and self:get_headline_line_content() == other_headline:get_headline_line_content()
 end
 
 function Headline:id_get_or_create()
@@ -907,7 +907,9 @@ function Headline:_add_date(type, date, active)
 
     -- Append after starting line
     local replacement = self:_apply_indent(text)
-    if type(replacement) == "string" then replacement = { replacement } end
+    if type(replacement) == "string" then
+      replacement = { replacement }
+    end
     vim.api.nvim_buf_set_lines(bufnr, start_line + 1, start_line + 1, true, replacement)
 
     return self:refresh()

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -404,7 +404,7 @@ function Headline:set_property(name, value)
   if not value then
     local existing_property, property_node = self:get_property(name)
     if existing_property and property_node then
-      vim.fn.deletebufline(vim.api.nvim_get_current_buf(), property_node:start() + 1)
+      vim.fn.deletebufline(bufnr, property_node:start() + 1)
     end
     self:refresh()
     local properties_node, properties = self:get_properties()
@@ -931,7 +931,10 @@ function Headline:_remove_date(type)
   local line_nr = date_nodes[type]:start() + 1
   self.file:set_node_text(date_nodes[type], '', true)
   if vim.trim(vim.fn.getline(line_nr)) == '' then
-    vim.fn.deletebufline(vim.api.nvim_get_current_buf(), line_nr)
+    local bufnr = self.file:bufnr()
+    if bufnr >= 0 then
+      vim.fn.deletebufline(bufnr, line_nr)
+    end
   end
   return self:refresh()
 end

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -907,7 +907,7 @@ function Headline:_add_date(date_type, date, active)
 
     -- Append after starting line
     local replacement = self:_apply_indent(text)
-    if type(replacement) == "string" then
+    if type(replacement) == 'string' then
       replacement = { replacement }
     end
     vim.api.nvim_buf_set_lines(bufnr, start_line + 1, start_line + 1, true, replacement)

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -1023,16 +1023,16 @@ function Headline:_handle_promote_demote(recursive, modifier, dryRun)
     return whole_subtree()
   end
 
-  local start = self:node():start()
-  local end_line = first_child_section:start()
-  local lines = modifier(start, vim.api.nvim_buf_get_lines(0, start, end_line, false))
-  if dryRun then
-    return lines
-  end
-
   local bufnr = self.file:bufnr()
   if bufnr < 0 then
     -- TODO: What do we return here?? Empty lines? All lines?
+    return {}
+  end
+
+  local start = self:node():start()
+  local end_line = first_child_section:start()
+  local lines = modifier(start, vim.api.nvim_buf_get_lines(bufnr, start, end_line, false))
+  if dryRun then
     return lines
   end
 


### PR DESCRIPTION
Gave a quick scan of both `OrgFile` and `OrgHeadline` for additional situations of `nvim_buf_set_text` and `nvim_buf_set_lines` where 0 was used instead of the `OrgFile` buffer number.

I left some TODO comments for you to look through as I don't know how you'd want to handle these. I'm also totally fine with you writing this yourself. 😄 This was just easier for me to do to show areas where there may be gotchas if someone is using the API expecting it to update in once place, but it is instead updating it somewhere else.