### PR TITLE
feat: org_log_repeat

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -256,6 +256,14 @@ Possible values:
 * `note` - adds `CLOSED` date as above, and prompts for closing note via capture window. Confirm note with `org_note_finalize` (Default `<C-c>`), or ignore providing note via `org_note_kill` (Default `<Leader>ok`)
 * `false` - Disable any logging
 
+#### org_log_repeat
+*type*: `string|false`<br />
+*default value*: `time`<br />
+Possible values:
+* `time` - adds / updates `LAST_REPEAT` headline property and logs state change into `org_log_into_drawer`
+* `note` - adds / updates `LAST_REPEAT` as above, and prompts for closing note to log into `org_log_into_drawer`
+* `false` - Disable any logging
+
 #### **org_log_into_drawer**
 *type*: `string|nil`<br />
 *default value*: `nil`<br />

--- a/DOCS.md
+++ b/DOCS.md
@@ -256,7 +256,7 @@ Possible values:
 * `note` - adds `CLOSED` date as above, and prompts for closing note via capture window. Confirm note with `org_note_finalize` (Default `<C-c>`), or ignore providing note via `org_note_kill` (Default `<Leader>ok`)
 * `false` - Disable any logging
 
-#### org_log_repeat
+#### **org_log_repeat**
 *type*: `string|false`<br />
 *default value*: `time`<br />
 Possible values:

--- a/README.md
+++ b/README.md
@@ -105,8 +105,10 @@ require('orgmode').setup({
 --   ensure_installed = 'all',
 --   ignore_install = { 'org' },
 -- })
+```
 
 Or if you are using `init.vim`, wrap the above snippet like so:
+
 ```vim
 " init.vim
 lua << EOF

--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -244,7 +244,7 @@ end
 function Agenda:change_todo_state()
   return self:_remote_edit({
     action = 'org_mappings.todo_next_state',
-    update_in_place = true,
+    redo = true,
   })
 end
 

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -34,6 +34,7 @@ local DefaultConfig = {
   org_hide_emphasis_markers = false,
   org_ellipsis = '...',
   org_log_done = 'time',
+  org_log_repeat = 'time',
   org_log_into_drawer = nil,
   org_highlight_latex_and_related = nil,
   org_custom_exports = {},

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -400,7 +400,10 @@ function OrgMappings:_todo_change_state(direction)
 
   local log_note = config.org_log_done == 'note'
   local log_time = config.org_log_done == 'time'
+  local log_note_repeat = config.org_log_repeat == 'note'
+  local log_time_repeat = config.org_log_repeat == 'time'
   local should_log_time = log_note or log_time
+  local should_log_time_repeat = log_note_repeat or log_time_repeat
   local indent = headline:get_indent()
 
   local get_note = function(note)
@@ -452,7 +455,7 @@ function OrgMappings:_todo_change_state(direction)
   dispatchEvent()
   return Promise.resolve()
     :next(function()
-      if not log_note then
+      if not log_note_repeat then
         return state_change
       end
 
@@ -461,6 +464,10 @@ function OrgMappings:_todo_change_state(direction)
       end)
     end)
     :next(function(note)
+      if not should_log_time_repeat then
+        return
+      end
+
       headline:set_property('LAST_REPEAT', Date.now():to_wrapped_string(false))
       if not note then
         return


### PR DESCRIPTION
Separate logging settings for repeating TODOs

Implements #530 

Unfortunately I couldn't figure out how to redraw the agenda view without setting redo in:

```lua
function Agenda:change_todo_state()
  return self:_remote_edit({
    action = 'org_mappings.todo_next_state',
    redo = true,
  })
end
```