### PR TITLE
Update promise.wait to throw an error when timeout reached or interrupted

### DIFF
--- a/lua/orgmode/utils/promise.lua
+++ b/lua/orgmode/utils/promise.lua
@@ -289,15 +289,17 @@ function Promise.wait(self, timeout)
     return error(value)
   end
 
-  if not success and code == -1 then
-    return error('promise timeout of ' .. tostring(timeout) .. 'ms reached')
-  elseif not success and code == -2 then
-    return error('promise interrupted')
-  elseif not success then
-    return error('promise failed with unknown reason')
+  if success then
+    return value
   end
 
-  return value
+  if code == -1 then
+    return error('promise timeout of ' .. tostring(timeout) .. 'ms reached')
+  elseif code == -2 then
+    return error('promise interrupted')
+  end
+
+  return error('promise failed with unknown reason')
 end
 
 --- Equivalents to JavaScript's Promise.all.

--- a/lua/orgmode/utils/promise.lua
+++ b/lua/orgmode/utils/promise.lua
@@ -290,11 +290,11 @@ function Promise.wait(self, timeout)
   end
 
   if not success and code == -1 then
-    return error("promise timeout of " .. tostring(timeout) .. "ms reached")
+    return error('promise timeout of ' .. tostring(timeout) .. 'ms reached')
   elseif not success and code == -2 then
-    return error("promise interrupted")
+    return error('promise interrupted')
   elseif not success then
-    return error("promise failed with unknown reason")
+    return error('promise failed with unknown reason')
   end
 
   return value

--- a/lua/orgmode/utils/promise.lua
+++ b/lua/orgmode/utils/promise.lua
@@ -87,12 +87,12 @@ function Promise.new(executor)
     local first = ...
     if is_promise(first) then
       first
-        :next(function(...)
-          self:_resolve(...)
-        end)
-        :catch(function(...)
-          self:_reject(...)
-        end)
+          :next(function(...)
+            self:_resolve(...)
+          end)
+          :catch(function(...)
+            self:_reject(...)
+          end)
       return
     end
     self:_resolve(...)
@@ -166,12 +166,12 @@ function Promise._start_resolve(self, value)
     end)
   end
   first
-    :next(function(...)
-      self:_resolve(...)
-    end)
-    :catch(function(...)
-      self:_reject(...)
-    end)
+      :next(function(...)
+        self:_resolve(...)
+      end)
+      :catch(function(...)
+        self:_reject(...)
+      end)
 end
 
 function Promise._reject(self, ...)
@@ -206,12 +206,12 @@ function Promise._start_reject(self, value)
     end)
   end
   first
-    :next(function(...)
-      self:_resolve(...)
-    end)
-    :catch(function(...)
-      self:_reject(...)
-    end)
+      :next(function(...)
+        self:_resolve(...)
+      end)
+      :catch(function(...)
+        self:_reject(...)
+      end)
 end
 
 --- Equivalents to JavaScript's Promise.then.
@@ -249,36 +249,37 @@ end
 function Promise.finally(self, on_finally)
   vim.validate({ on_finally = { on_finally, 'function', true } })
   return self
-    :next(function(...)
-      on_finally()
-      return ...
-    end)
-    :catch(function(...)
-      on_finally()
-      return Promise.reject(...)
-    end)
+      :next(function(...)
+        on_finally()
+        return ...
+      end)
+      :catch(function(...)
+        on_finally()
+        return Promise.reject(...)
+      end)
 end
 
 --- Equivalents to JavaScript's Promise.then.
 --- @param timeout? number
 --- @return any
 function Promise.wait(self, timeout)
+  timeout = timeout or 5000
   local is_done = false
   local has_error = false
   local result = nil
 
   self
-    :next(function(...)
-      result = PackedValue.new(...)
-      is_done = true
-    end)
-    :catch(function(...)
-      has_error = true
-      result = PackedValue.new(...)
-      is_done = true
-    end)
+      :next(function(...)
+        result = PackedValue.new(...)
+        is_done = true
+      end)
+      :catch(function(...)
+        has_error = true
+        result = PackedValue.new(...)
+        is_done = true
+      end)
 
-  vim.wait(timeout or 5000, function()
+  local success, code = vim.wait(timeout, function()
     return is_done
   end, 1)
 
@@ -286,6 +287,14 @@ function Promise.wait(self, timeout)
 
   if has_error then
     return error(value)
+  end
+
+  if not success and code == -1 then
+    return error("promise timeout of " .. tostring(timeout) .. "ms reached")
+  elseif not success and code == -2 then
+    return error("promise interrupted")
+  elseif not success then
+    return error("promise failed with unknown reason")
   end
 
   return value
@@ -306,17 +315,17 @@ function Promise.all(list)
     local results = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-        :next(function(...)
-          local first = ...
-          results[i] = first
-          if remain == 1 then
-            return resolve(results)
-          end
-          remain = remain - 1
-        end)
-        :catch(function(...)
-          reject(...)
-        end)
+          :next(function(...)
+            local first = ...
+            results[i] = first
+            if remain == 1 then
+              return resolve(results)
+            end
+            remain = remain - 1
+          end)
+          :catch(function(...)
+            reject(...)
+          end)
     end
   end)
 end
@@ -329,12 +338,12 @@ function Promise.race(list)
   return Promise.new(function(resolve, reject)
     for _, e in ipairs(list) do
       Promise.resolve(e)
-        :next(function(...)
-          resolve(...)
-        end)
-        :catch(function(...)
-          reject(...)
-        end)
+          :next(function(...)
+            resolve(...)
+          end)
+          :catch(function(...)
+            reject(...)
+          end)
     end
   end)
 end
@@ -354,17 +363,17 @@ function Promise.any(list)
     local errs = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-        :next(function(...)
-          resolve(...)
-        end)
-        :catch(function(...)
-          local first = ...
-          errs[i] = first
-          if remain == 1 then
-            return reject(errs)
-          end
-          remain = remain - 1
-        end)
+          :next(function(...)
+            resolve(...)
+          end)
+          :catch(function(...)
+            local first = ...
+            errs[i] = first
+            if remain == 1 then
+              return reject(errs)
+            end
+            remain = remain - 1
+          end)
     end
   end)
 end
@@ -384,20 +393,20 @@ function Promise.all_settled(list)
     local results = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-        :next(function(...)
-          local first = ...
-          results[i] = { status = PromiseStatus.Fulfilled, value = first }
-        end)
-        :catch(function(...)
-          local first = ...
-          results[i] = { status = PromiseStatus.Rejected, reason = first }
-        end)
-        :finally(function()
-          if remain == 1 then
-            return resolve(results)
-          end
-          remain = remain - 1
-        end)
+          :next(function(...)
+            local first = ...
+            results[i] = { status = PromiseStatus.Fulfilled, value = first }
+          end)
+          :catch(function(...)
+            local first = ...
+            results[i] = { status = PromiseStatus.Rejected, reason = first }
+          end)
+          :finally(function()
+            if remain == 1 then
+              return resolve(results)
+            end
+            remain = remain - 1
+          end)
     end
   end)
 end

--- a/lua/orgmode/utils/promise.lua
+++ b/lua/orgmode/utils/promise.lua
@@ -87,12 +87,12 @@ function Promise.new(executor)
     local first = ...
     if is_promise(first) then
       first
-          :next(function(...)
-            self:_resolve(...)
-          end)
-          :catch(function(...)
-            self:_reject(...)
-          end)
+        :next(function(...)
+          self:_resolve(...)
+        end)
+        :catch(function(...)
+          self:_reject(...)
+        end)
       return
     end
     self:_resolve(...)
@@ -166,12 +166,12 @@ function Promise._start_resolve(self, value)
     end)
   end
   first
-      :next(function(...)
-        self:_resolve(...)
-      end)
-      :catch(function(...)
-        self:_reject(...)
-      end)
+    :next(function(...)
+      self:_resolve(...)
+    end)
+    :catch(function(...)
+      self:_reject(...)
+    end)
 end
 
 function Promise._reject(self, ...)
@@ -206,12 +206,12 @@ function Promise._start_reject(self, value)
     end)
   end
   first
-      :next(function(...)
-        self:_resolve(...)
-      end)
-      :catch(function(...)
-        self:_reject(...)
-      end)
+    :next(function(...)
+      self:_resolve(...)
+    end)
+    :catch(function(...)
+      self:_reject(...)
+    end)
 end
 
 --- Equivalents to JavaScript's Promise.then.
@@ -249,14 +249,14 @@ end
 function Promise.finally(self, on_finally)
   vim.validate({ on_finally = { on_finally, 'function', true } })
   return self
-      :next(function(...)
-        on_finally()
-        return ...
-      end)
-      :catch(function(...)
-        on_finally()
-        return Promise.reject(...)
-      end)
+    :next(function(...)
+      on_finally()
+      return ...
+    end)
+    :catch(function(...)
+      on_finally()
+      return Promise.reject(...)
+    end)
 end
 
 --- Equivalents to JavaScript's Promise.then.
@@ -269,15 +269,15 @@ function Promise.wait(self, timeout)
   local result = nil
 
   self
-      :next(function(...)
-        result = PackedValue.new(...)
-        is_done = true
-      end)
-      :catch(function(...)
-        has_error = true
-        result = PackedValue.new(...)
-        is_done = true
-      end)
+    :next(function(...)
+      result = PackedValue.new(...)
+      is_done = true
+    end)
+    :catch(function(...)
+      has_error = true
+      result = PackedValue.new(...)
+      is_done = true
+    end)
 
   local success, code = vim.wait(timeout, function()
     return is_done
@@ -315,17 +315,17 @@ function Promise.all(list)
     local results = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-          :next(function(...)
-            local first = ...
-            results[i] = first
-            if remain == 1 then
-              return resolve(results)
-            end
-            remain = remain - 1
-          end)
-          :catch(function(...)
-            reject(...)
-          end)
+        :next(function(...)
+          local first = ...
+          results[i] = first
+          if remain == 1 then
+            return resolve(results)
+          end
+          remain = remain - 1
+        end)
+        :catch(function(...)
+          reject(...)
+        end)
     end
   end)
 end
@@ -338,12 +338,12 @@ function Promise.race(list)
   return Promise.new(function(resolve, reject)
     for _, e in ipairs(list) do
       Promise.resolve(e)
-          :next(function(...)
-            resolve(...)
-          end)
-          :catch(function(...)
-            reject(...)
-          end)
+        :next(function(...)
+          resolve(...)
+        end)
+        :catch(function(...)
+          reject(...)
+        end)
     end
   end)
 end
@@ -363,17 +363,17 @@ function Promise.any(list)
     local errs = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-          :next(function(...)
-            resolve(...)
-          end)
-          :catch(function(...)
-            local first = ...
-            errs[i] = first
-            if remain == 1 then
-              return reject(errs)
-            end
-            remain = remain - 1
-          end)
+        :next(function(...)
+          resolve(...)
+        end)
+        :catch(function(...)
+          local first = ...
+          errs[i] = first
+          if remain == 1 then
+            return reject(errs)
+          end
+          remain = remain - 1
+        end)
     end
   end)
 end
@@ -393,20 +393,20 @@ function Promise.all_settled(list)
     local results = {}
     for i, e in ipairs(list) do
       Promise.resolve(e)
-          :next(function(...)
-            local first = ...
-            results[i] = { status = PromiseStatus.Fulfilled, value = first }
-          end)
-          :catch(function(...)
-            local first = ...
-            results[i] = { status = PromiseStatus.Rejected, reason = first }
-          end)
-          :finally(function()
-            if remain == 1 then
-              return resolve(results)
-            end
-            remain = remain - 1
-          end)
+        :next(function(...)
+          local first = ...
+          results[i] = { status = PromiseStatus.Fulfilled, value = first }
+        end)
+        :catch(function(...)
+          local first = ...
+          results[i] = { status = PromiseStatus.Rejected, reason = first }
+        end)
+        :finally(function()
+          if remain == 1 then
+            return resolve(results)
+          end
+          remain = remain - 1
+        end)
     end
   end)
 end

--- a/tests/plenary/utils/promise_spec.lua
+++ b/tests/plenary/utils/promise_spec.lua
@@ -1,0 +1,14 @@
+local Promise = require('orgmode.utils.promise')
+
+describe('Promise', function()
+  it('should throw an error when wait exceeds its timeout', function()
+    -- Create a promise that will never resolve or reject
+    local promise = Promise.new(function() end)
+
+    -- We expect an error to occur here when the timeout is exceeded
+    assert.is.error(function()
+      -- Provide a smaller timeout so our test doesn't wait 5 seconds
+      promise:wait(50)
+    end)
+  end)
+end)


### PR DESCRIPTION
Per the comment I made in our main org roam issue, I discovered that `Promise.wait` does not throw an error when the timeout is reached. Instead, it returns `nil`.

This can be a problem if you're returning `OrgPromise<nil>`, as it misleads the promise as succeeding when in reality it may have not completed yet.

This updates `Promise.wait` to check the return values from `vim.wait` to determine if a value should be returned or if an error should be thrown.