### PR TITLE
update doc to use correct highlight name

### DIFF
--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -442,7 +442,7 @@ Enabled:
 NOTE: Stars are hidden by applying highlight group that masks them with color that's same as background color.
 If this highlight group does not suit you, you can apply different highlight group to it:
 >
-    vim.cmd[[autocmd ColorScheme * hi link @org.leading.stars MyCustomHlGroup]]
+    vim.cmd[[autocmd ColorScheme * hi link @org.leading_stars MyCustomHlGroup]]
 <
 
 ORG_HIDE_EMPHASIS_MARKERS                      *orgmode-org_hide_emphasis_markers*


### PR DESCRIPTION
According to [this file](https://github.com/nvim-orgmode/orgmode/blob/8ec0bcc6f6476d246159f738081256c97a7a9b2c/lua/orgmode/colors/highlighter/stars.lua#L36), highlight for leading stars should be `@org.leading_stars` instead of `@org.leading.stars`.