### PR TITLE
Add tests for archiving subtree

### DIFF
--- a/tests/plenary/ui/mappings/archive_spec.lua
+++ b/tests/plenary/ui/mappings/archive_spec.lua
@@ -32,4 +32,31 @@ describe('Archive', function()
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
   end)
+
+  it('should set properties on top-level headline when refiling subtree', function()
+    local file = helpers.create_agenda_file({
+      '* foobar',
+      '** baz',
+      '* foo',
+    })
+
+    vim.cmd([[exe "norm ,o$"]])
+    -- Pause to finish the archiving
+    vim.wait(50)
+    assert.are.same({
+      '* foo',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+
+    vim.cmd(('edit %s'):format(file.filename .. '_archive'))
+    assert.are.same({
+      '* foobar',
+      '  :PROPERTIES:',
+      '  :ARCHIVE_TIME: ' .. Date.now():to_string(),
+      '  :ARCHIVE_FILE: ' .. file.filename,
+      '  :ARCHIVE_CATEGORY: ' .. file:get_category(),
+      '  :ARCHIVE_TODO: ',
+      '  :END:',
+      '** baz',
+    }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
+  end)
 end)


### PR DESCRIPTION
Given
```
* foo
** bar
*** baz
```

and the cursor on the foo-line, when archiving, the archive context is added to the last headline:

```
* foo
** bar
*** baz
    :PROPERTIES:
    :ARCHIVE_TIME: ...
    ...
    :END:
```

Emacs however adds the archive context to the foo-headline (which seems to be more appropriate):

```
* foo
  :PROPERTIES:
  :ARCHIVE_TIME: ...
  ...
  :END:
** bar
*** baz
```

Hence this PR, which aligns nvim-orgmode's behaviour with Emacs.

BTW, I second @seflue 's suggestion from https://github.com/nvim-orgmode/orgmode/pull/641#issue-2061135549 and https://github.com/nvim-orgmode/orgmode/issues/645#issuecomment-1881724227 to extract Refile and Archive from Capture (probably analogous to, `org-capture.el`, `org-refile.el`, and `org-archive.el` in https://github.com/emacs-mirror/emacs/tree/master/lisp/org), to prevent it from becoming unwieldy further down the line. I am interested in fleshing out the archiving a bit more (e.g. adding ARCHIVE_OLPATH and making the context configurable (see [org-archive-save-context-info](https://github.com/emacs-mirror/emacs/blob/master/lisp/org/org-archive.el#L119))), but I could work on the refactoring first. It would be helpful if you could provide an indication as to whether that would be fine (or not). Either way, thanks a lot for your work!