### PR TITLE
fix(date): persist all attributes passed by options

### DIFF
--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -95,21 +95,27 @@ end
 ---@param time table
 ---@return OrgDate
 function Date:from_time_table(time)
-  local range_diff = self.timestamp_end and self.timestamp_end - self.timestamp or 0
-  local timestamp = os.time(set_date_opts(time, {}, true))
+  local timestamp_end = time.timestamp_end or self.timestamp_end
+  local timestamp = time.timestamp or self.timestamp
+  local range_diff = timestamp_end and timestamp_end - timestamp or 0
+  timestamp = os.time(set_date_opts(time, {}, true))
   local opts = set_date_opts(os.date('*t', timestamp))
-  opts.date_only = self.date_only
-  opts.dayname = self.dayname
-  opts.adjustments = self.adjustments
-  opts.type = self.type
-  opts.active = self.active
-  opts.range = self.range
-  if self.timestamp_end then
+  if time.date_only ~= nil then
+    opts.date_only = time.date_only
+  else
+    opts.date_only = self.date_only
+  end
+  opts.dayname = time.dayname or self.dayname
+  opts.adjustments = time.adjustments or self.adjustments
+  opts.type = time.type or self.type
+  opts.active = time.active or self.active
+  opts.range = time.range or self.range
+  if time.timestamp_end or self.timestamp_end then
     opts.timestamp_end = timestamp + range_diff
   end
-  opts.is_date_range_start = self.is_date_range_start
-  opts.is_date_range_end = self.is_date_range_end
-  opts.related_date_range = self.related_date_range
+  opts.is_date_range_start = time.is_date_range_start or self.is_date_range_start
+  opts.is_date_range_end = time.is_date_range_end or self.is_date_range_end
+  opts.related_date_range = time.related_date_range or self.related_date_range
   return Date:new(opts)
 end
 

--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -95,8 +95,8 @@ end
 ---@param time table
 ---@return OrgDate
 function Date:from_time_table(time)
-  local timestamp_end = time.timestamp_end or self.timestamp_end
-  local timestamp = time.timestamp or self.timestamp
+  local timestamp_end = self.timestamp_end
+  local timestamp = self.timestamp
   local range_diff = timestamp_end and timestamp_end - timestamp or 0
   timestamp = os.time(set_date_opts(time, {}, true))
   local opts = set_date_opts(os.date('*t', timestamp))
@@ -105,17 +105,17 @@ function Date:from_time_table(time)
   else
     opts.date_only = self.date_only
   end
-  opts.dayname = time.dayname or self.dayname
-  opts.adjustments = time.adjustments or self.adjustments
-  opts.type = time.type or self.type
-  opts.active = time.active or self.active
-  opts.range = time.range or self.range
-  if time.timestamp_end or self.timestamp_end then
+  opts.dayname = self.dayname
+  opts.adjustments = self.adjustments
+  opts.type = self.type
+  opts.active = self.active
+  opts.range = self.range
+  if self.timestamp_end then
     opts.timestamp_end = timestamp + range_diff
   end
-  opts.is_date_range_start = time.is_date_range_start or self.is_date_range_start
-  opts.is_date_range_end = time.is_date_range_end or self.is_date_range_end
-  opts.related_date_range = time.related_date_range or self.related_date_range
+  opts.is_date_range_start = self.is_date_range_start
+  opts.is_date_range_end = self.is_date_range_end
+  opts.related_date_range = self.related_date_range
   return Date:new(opts)
 end
 


### PR DESCRIPTION
Store all attributes passed as option via Date:set, especially date_only.

I am raising this as a separate PR and precondition to PR #650. If we don't treat every field in the given date consequently, we get suprising behavior if some of the fields are present within the given "time" parameter. The idea of the function is, to allow adjusting an existing date instance by a subset of it's fields given as a table and returns the adjusted date as new value from the method.

This fix ensures, that every field can actually be adjusted within this function. I observed bugs while working on my time picker, if I used this function to get a Date object with adjusted time values (hours, minutes).