### PR TITLE
Migrate from README.md to README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -215,7 +215,7 @@ vim.cmd('language en_US.utf8')
 
 or ~init.vim~
 
-#+END_SRC
+#+BEGIN_SRC vim
 language en_US.utf8
 #+END_SRC
 

--- a/README.org
+++ b/README.org
@@ -5,17 +5,14 @@
 * nvim-orgmode
 
 #+HTML:<a href="/LICENSE">
-#+NAME: License
 #+CAPTION: License
 [[https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square]]
 #+HTML:</a>
 #+HTML:<a href="https://ko-fi.com/kristijanhusak">
-#+NAME: Kofi
 #+CAPTION: Kofi
 [[https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi]]
 #+HTML:</a>
 #+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org">
-#+NAME: Chat
 #+CAPTION: Chat
 [[https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square]]
 #+HTML:</a>
@@ -150,13 +147,13 @@ vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 
 #+HTML:</details>
 
-Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
+Or just use ~omnifunc~ via =\<C-x\>\<C-o\>=
 
 *** Usage
 
-- **Open agenda prompt**: <kbd>\<Leader\>oa</kbd>
-- **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
-- In any orgmode buffer press <kbd>g?</kbd> for help
+- **Open agenda prompt**: =\<Leader\>oa=
+- **Open capture prompt**: =\<Leader\>oc=
+- In any orgmode buffer press =g?= for help
 
 If you are new to Orgmode, see [[/DOCS.md#getting-started-with-orgmode][Getting started]] section in the Docs
 or a hands-on [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][tutorial]] in our wiki.
@@ -283,8 +280,8 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
 *** Detailed breakdown
 
 - Agenda prompt:
-  - Agenda view (<kbd>a</kbd>):
-    - Ability to show daily(<kbd>vd</kbd>)/weekly(<kbd>vw</kbd>)/monthly(<kbd>vm</kbd>)/yearly(<kbd>vy</kbd>) agenda
+  - Agenda view (=a=):
+    - Ability to show daily(=vd=)/weekly(=vw=)/monthly(=vm=)/yearly(=vy=) agenda
     - Support for various date settings:
       - DEADLINE: Warning settings - example: ~<2021-06-11 Fri 11:00 -1d>~
       - SCHEDULED: Delay setting - example: ~<2021-06-11 Fri 11:00 -2d>~
@@ -295,44 +292,44 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
       - Time ranges - example: ~<2021-06-11 Fri 11:00-12:30>~
       - Date ranges - example: ~<2021-06-11 Fri 11:00-12:30>--<2021-06-13 Sun 22:00>~
     - Properly lists tasks according to defined dates (DEADLINE,SCHEDULED,Plain date)
-    - Navigate forward (<kbd>f</kbd>)/backward(<kbd>b</kbd>) or jump to specific date (<kbd>J</kbd>)
-    - Go to task under cursor in current window(<kbd>\<CR\></kbd>) or other window(<kbd>\<TAB\></kbd>)
+    - Navigate forward (=f=)/backward(=b=) or jump to specific date (=J=)
+    - Go to task under cursor in current window(=\<CR\>=) or other window(=\<TAB\>=)
     - Print category from ":CATEGORY:" property if defined
-  - List tasks that have "TODO" state (<kbd>t</kbd>):
-  - Find headlines matching tag(s) (<kbd>m</kbd>):
-  - Search for headlines (and it's content) for a query (<kbd>s</kbd>):
+  - List tasks that have "TODO" state (=t=):
+  - Find headlines matching tag(s) (=m=):
+  - Search for headlines (and it's content) for a query (=s=):
   - [[DOCS.md#advanced-search][Advanced search]] for tags/todo kewords/properties
   - Notifications (experimental, see [[https://github.com/nvim-orgmode/orgmode/issues/49)][Issue #49]]
   - Clocking time
 - Capture:
   - Define custom templates
-  - Fast capturing to default notes file via <kbd>\<C-c\></kbd>
-  - Capturing to specific destination <kbd>\<Leader\>or</kbd>
-  - Abort capture with <kbd>\<Leader\>ok</kbd>
+  - Fast capturing to default notes file via =\<C-c\>=
+  - Capturing to specific destination =\<Leader\>or=
+  - Abort capture with =\<Leader\>ok=
 - Org files
   - Clocking time
-  - Refile to destination/headline: <kbd>\<Leader\>or</kbd>
-  - Increase/Decrease date under cursor: <kbd>\<C-a\></kbd>/<kbd>\<C-x\></kbd>
-  - Change date under cursor via calendar popup: <kbd>cid</kbd>
-  - Change headline TODO state: forward<kbd>cit</kbd> or backward<kbd>ciT</kbd>
-  - Open hyperlink or date under cursor: <kbd>\<Leader\>oo</kbd>
-  - Toggle checkbox: <kbd>\<C-space\></kbd>
-  - Toggle current line to headline and vice versa: <kbd>\<Leader\>o\*</kbd>
-  - Toggle folding of current headline: <kbd>\<TAB\></kbd>
-  - Toggle folding in whole file: <kbd>\<S-TAB\></kbd>
-  - Archive headline: <kbd>\<Leader\>o$</kbd>
-  - Add archive tag: <kbd>\<Leader\>oA</kbd>
-  - Change tags: <kbd>\<Leader\>ot</kbd>
-  - Promote headline: <kbd><<</kbd>
-  - Demote headline: <kbd>>></kbd>
-  - Promote subtree: <kbd>\<s</kbd>
-  - Demote subtree: <kbd>\>s</kbd>
-  - Add headline/list item/checkbox: <kbd>\<Leader\>\<CR\></kbd>
-  - Insert heading after current heading and it's content: <kbd>\<Leader\>oih</kbd>
-  - Insert TODO heading after current line: <kbd>\<Leader\>oiT</kbd>
-  - Insert TODO heading after current heading and it's content: <kbd>\<Leader\>oit</kbd>
-  - Move headline up: <kbd>\<Leader\>oK</kb>
-  - Move headline down: <kbd>\<Leader\>oJ</kb>
+  - Refile to destination/headline: =\<Leader\>or=
+  - Increase/Decrease date under cursor: =\<C-a\>=/=\<C-x\>=
+  - Change date under cursor via calendar popup: =cid=
+  - Change headline TODO state: forward=cit= or backward=ciT=
+  - Open hyperlink or date under cursor: =\<Leader\>oo=
+  - Toggle checkbox: =\<C-space\>=
+  - Toggle current line to headline and vice versa: =\<Leader\>o\*=
+  - Toggle folding of current headline: =\<TAB\>=
+  - Toggle folding in whole file: =\<S-TAB\>=
+  - Archive headline: =\<Leader\>o$=
+  - Add archive tag: =\<Leader\>oA=
+  - Change tags: =\<Leader\>ot=
+  - Promote headline: =<<=
+  - Demote headline: =>>=
+  - Promote subtree: =\<s=
+  - Demote subtree: =\>s=
+  - Add headline/list item/checkbox: =\<Leader\>\<CR\>=
+  - Insert heading after current heading and it's content: =\<Leader\>oih=
+  - Insert TODO heading after current line: =\<Leader\>oiT=
+  - Insert TODO heading after current heading and it's content: =\<Leader\>oit=
+  - Move headline up: =\<Leader\>oK</kb>
+  - Move headline down: =\<Leader\>oJ</kb>
   - Highlighted code blocks (~#+BEGIN_SRC filetype~)
    Exporting (via ~emacs~, ~pandoc~ and custom export options)
 

--- a/README.org
+++ b/README.org
@@ -304,7 +304,7 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
   - Refile to destination/headline: =<Leader>or=
   - Increase/Decrease date under cursor: =<C-a>= / =<C-x>=
   - Change date under cursor via calendar popup: =cid=
-  - Change headline TODO state: forward=cit= or backward=ciT=
+  - Change headline TODO state: forward =cit= or backward =ciT=
   - Open hyperlink or date under cursor: =<Leader>oo=
   - Toggle checkbox: =<C-space>=
   - Toggle current line to headline and vice versa: =<Leader>o*=

--- a/README.org
+++ b/README.org
@@ -5,13 +5,13 @@
 * nvim-orgmode
 
 #+HTML:<a href="/LICENSE">
-[[https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square]]
+#+HTML:<img alt="logo_desc" src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square">
 #+HTML:</a>
 #+HTML:<a href="https://ko-fi.com/kristijanhusak">
-[[https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi]]
+#+HTML:<img alt="logo_desc" src="https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi">
 #+HTML:</a>
 #+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org">
-[[https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square]]
+#+HTML:<img alt="logo_desc" src="https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square">
 #+HTML:</a>
 
 Orgmode clone written in Lua for Neovim 0.9.2+

--- a/README.org
+++ b/README.org
@@ -211,7 +211,7 @@ language en_US.utf8
 #+END_SRC
 
 Just make sure you have ~en_US~ locale installed on your system. To see what you have available on the system you can
-start the command ~:language ~ and press ~<TAB>~ to autocomplete possible options.
+start the command ~:language~ and press ~<TAB>~ to autocomplete possible options.
 
 *** Links are not concealed
 
@@ -233,7 +233,7 @@ set concealcursor=nc
 
 If you are using Windows, paths are by default written with backslashes.
 To use forward slashes, you must enable ~shellslash~ option
-(see ~:help 'shellslash'~).
+(see ~:help shellslash~).
 
 #+BEGIN_SRC lua
 vim.opt.shellslash = true
@@ -302,12 +302,12 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
 - Org files
   - Clocking time
   - Refile to destination/headline: =<Leader>or=
-  - Increase/Decrease date under cursor: =<C-a>=/=<C-x>=
+  - Increase/Decrease date under cursor: =<C-a>= / =<C-x>=
   - Change date under cursor via calendar popup: =cid=
   - Change headline TODO state: forward=cit= or backward=ciT=
   - Open hyperlink or date under cursor: =<Leader>oo=
   - Toggle checkbox: =<C-space>=
-  - Toggle current line to headline and vice versa: =<Leader>o\*=
+  - Toggle current line to headline and vice versa: =<Leader>o*=
   - Toggle folding of current headline: =<TAB>=
   - Toggle folding in whole file: =<S-TAB>=
   - Archive headline: =<Leader>o$=
@@ -321,14 +321,14 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
   - Insert heading after current heading and it's content: =<Leader>oih=
   - Insert TODO heading after current line: =<Leader>oiT=
   - Insert TODO heading after current heading and it's content: =<Leader>oit=
-  - Move headline up: =<Leader>oK</kb>
-  - Move headline down: =<Leader>oJ</kb>
+  - Move headline up: =<Leader>oK=
+  - Move headline down: =<Leader>oJ=
   - Highlighted code blocks (~#+BEGIN_SRC filetype~)
    Exporting (via ~emacs~, ~pandoc~ and custom export options)
 
 Link to detailed documentation: [[DOCS.md][DOCS]]
 
-** Plugins
+** Pluginsa
 
 - [[https://github.com/chipsenkbeil/org-roam.nvim][org-roam.nvim]] - Implementation of [[https://orgroam.com][Org-roam]] knowledge management system
 - [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters
@@ -338,13 +338,15 @@ Link to detailed documentation: [[DOCS.md][DOCS]]
 
 See all available plugins on [[https://github.com/topics/orgmode-nvim][orgmode-nvim]]
 
-***If you built a plugin please add "orgmode-nvim" topic to it.**
+*If you built a plugin please add "orgmode-nvim" topic to it.*
 
+#+BEGIN_QUOTE
 *NOTE*: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.
 The point of this plugin is to provide functionality that's built into Emacs Orgmode core,
 and a good foundation for external plugins.
-#+HTML:<br/>
+#+END_QUOTE
+
 If you want to build a plugin, post suggestions and improvements on [[https://github.com/nvim-orgmode/orgmode/issues/26][Plugins infrastructure]]
 issue.
 

--- a/README.org
+++ b/README.org
@@ -4,9 +4,21 @@
 
 * nvim-orgmode
 
-#+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a>
-#+HTML:<a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a>
-#+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
+#+HTML:<a href="/LICENSE">
+#+NAME: License
+#+CAPTION: License
+[[https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square]]
+#+HTML:</a>
+#+HTML:<a href="https://ko-fi.com/kristijanhusak">
+#+NAME: Kofi
+#+CAPTION: Kofi
+[[https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi]]
+#+HTML:</a>
+#+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org">
+#+NAME: Chat
+#+CAPTION: Chat
+[[https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square]]
+#+HTML:</a>
 
 Orgmode clone written in Lua for Neovim 0.9.2+
 

--- a/README.org
+++ b/README.org
@@ -1,10 +1,7 @@
 #+TITLE: nvim-orgmode
 #+HTML: <div align="center">
 
-#+CAPTION: A blend of the Neovim (shape) and Org-mode (colours) logos
-#+NAME: logo
-#+ATTR_HTML: :width 250px
-[[assets/nvim-orgmode.svg]]
+#+HTML: <img alt="A blend of the Neovim (shape) and Org-mode (colours) logos" src="assets/nvim-orgmode.svg" width="250px" />
 
 #+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a><a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
 

--- a/README.org
+++ b/README.org
@@ -1,4 +1,19 @@
 #+TITLE: nvim-orgmode
+#+HTML: <div align="center">
+
+#+CAPTION: A blend of the Neovim (shape) and Org-mode (colours) logos
+#+NAME: logo
+#+ATTR_HTML: :width 250px
+[[assets/nvim-orgmode.svg]]
+
+#+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a><a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
+
+Orgmode clone written in Lua for Neovim 0.9.2+
+
+[[#setup][Setup]] • [[/DOCS.md][Docs]] • [[#showcase][Showcase]] • [[#treesitter-info][Treesitter]] • [[#troubleshoot][Troubleshoot]] • [[#plugins][Plugins]] • [[CONTRIBUTING.md][Contributing]] • [[#thanks-to][Kudos]]
+
+#+HTML:</div>
+
 
 ** Quickstart
 

--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-+title: nvim-orgmode
+#+TITLE: nvim-orgmode
 
 * Quickstart
 

--- a/README.org
+++ b/README.org
@@ -368,16 +368,16 @@ Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgm
 
 ** Roadmap
 
-- [X] Support searching by properties
-- [ ] Improve checkbox hierarchy
-- [X] Support todo keyword faces
-- [X] Support clocking work time
-- [X] Improve folding
-- [X] Support exporting (via existing emacs tools)
-- [ ] Support archiving to specific headline
-- [X] Support tables
-- [ ] Support diary format dates
-- [ ] Support evaluating code blocks
+- :white_check_mark: Support searching by properties
+- :X: Improve checkbox hierarchy
+- :white_check_mark: Support todo keyword faces
+- :white_check_mark: Support clocking work time
+- :white_check_mark: Improve folding
+- :white_check_mark: Support exporting (via existing emacs tools)
+- :X: Support archiving to specific headline
+- :white_check_mark: Support tables
+- :X: Support diary format dates
+- :X: Support evaluating code blocks
 
 ** Thanks to
 

--- a/README.org
+++ b/README.org
@@ -205,7 +205,8 @@ Try running ~:lua require('orgmode.config'):reinstall_grammar()~ to reinstall it
 
 *** Dates are not in English
 
-Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
+Dates are generated with Lua native date support, and it reads your current locale when creating them.
+#+HTML: <br/>
 To use different locale you can add this to your ~init.lua~:
 
 #+BEGIN_SRC lua

--- a/README.org
+++ b/README.org
@@ -369,15 +369,15 @@ Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgm
 ** Roadmap
 
 - :white_check_mark: Support searching by properties
-- :X: Improve checkbox hierarchy
+- :white_square_button: Improve checkbox hierarchy
 - :white_check_mark: Support todo keyword faces
 - :white_check_mark: Support clocking work time
 - :white_check_mark: Improve folding
 - :white_check_mark: Support exporting (via existing emacs tools)
-- :X: Support archiving to specific headline
+- :white_square_button: Support archiving to specific headline
 - :white_check_mark: Support tables
-- :X: Support diary format dates
-- :X: Support evaluating code blocks
+- :white_square_button: Support diary format dates
+- :white_square_button: Support evaluating code blocks
 
 ** Thanks to
 

--- a/README.org
+++ b/README.org
@@ -4,6 +4,8 @@
 
 * nvim-orgmode
 
+** TODO: Logos add image alt text to links
+
 #+HTML:<a href="/LICENSE">
 #+HTML:<img alt="logo_desc" src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square">
 #+HTML:</a>
@@ -144,12 +146,12 @@ vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 
 #+HTML:</details>
 
-Or just use ~omnifunc~ via =\<C-x\>\<C-o\>=
+Or just use ~omnifunc~ via =<C-x><C-o>=
 
 *** Usage
 
-- **Open agenda prompt**: =\<Leader\>oa=
-- **Open capture prompt**: =\<Leader\>oc=
+- *Open agenda prompt*: =<Leader>oa=
+- *Open capture prompt*: =<Leader>oc=
 - In any orgmode buffer press =g?= for help
 
 If you are new to Orgmode, see [[/DOCS.md#getting-started-with-orgmode][Getting started]] section in the Docs
@@ -238,7 +240,8 @@ set concealcursor=nc
 *** Jumping to file path is not working for paths with forward slash
 
 If you are using Windows, paths are by default written with backslashes.
-To use forward slashes, you must enable ~shellslash~ option (see ~:help 'shellslash'~).
+To use forward slashes, you must enable ~shellslash~ option
+(see ~:help 'shellslash'~).
 
 #+BEGIN_SRC lua
 vim.opt.shellslash = true
@@ -335,7 +338,7 @@ Link to detailed documentation: [[DOCS.md][DOCS]]
 
 ** Plugins
 
-- [[https://www.orgroam.com/][org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim) - Implementation of [Org-roam]] knowledge management system
+- [[https://github.com/chipsenkbeil/org-roam.nvim][https://www.orgroam.com/org-roam.nvim]] - Implementation of [[https://orgroam.com][Org-roam]] knowledge management system
 - [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters
 - [[https://github.com/lukas-reineke/headlines.nvim][headlines.nvim]] - Add few highlight options for code blocks and headlines
 - [[https://github.com/michaelb/sniprun][sniprun]] - For code evaluation in blocks

--- a/README.org
+++ b/README.org
@@ -1,9 +1,11 @@
 #+TITLE: nvim-orgmode
 #+HTML: <div align="center">
 
-#+HTML: <img alt="A blend of the Neovim (shape) and Org-mode (colours) logos" src="assets/nvim-orgmode.svg" width="250px" />
+#+HTML: <img alt="A blend of the Neovim (shape) and Org-mode (colours) logos" src="assets/nvim-orgmode.svg" width="250" /><br/>
 
-#+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a><a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
+#+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a>
+#+HTML:<a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a>
+#+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
 
 Orgmode clone written in Lua for Neovim 0.9.2+
 

--- a/README.org
+++ b/README.org
@@ -1,12 +1,12 @@
 #+TITLE: nvim-orgmode
 
-* Quickstart
+** Quickstart
 
-** Requirements
+*** Requirements
 
 - Neovim 0.9.2 or later
 
-** Installation
+*** Installation
 
 Use your favourite package manager:
 
@@ -71,7 +71,7 @@ call dein#add('nvim-orgmode/orgmode')
 
 </details>
 
-** Setup
+*** Setup
 
 Note that this setup is not needed for [[https://github.com/folke/lazy.nvim][lazy.nvim]]
 since instructions above covers full setup
@@ -104,7 +104,7 @@ require('orgmode').setup({
 EOF
 #+begin_src ~
 
-*** Completion
+**** Completion
 
 <details>
   <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary>
@@ -138,7 +138,7 @@ vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 
 Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
 
-** Usage
+*** Usage
 
 - **Open agenda prompt**: <kbd>\<Leader\>oa</kbd>
 - **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
@@ -147,52 +147,52 @@ Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
 If you are new to Orgmode, see [[/DOCS.md#getting-started-with-orgmode][Getting started]] section in the Docs
 or a hands-on [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][tutorial]] in our wiki.
 
-* Showcase
+** Showcase
 
-** Agenda
+*** Agenda
 
 #+CAPTION: agenda
 #+NAME: agenda
 [[https://user-images.githubusercontent.com/1782860/123549968-8521f600-d76b-11eb-9a93-02bad08b37ce.gif]]
 
-** Org file
+*** Org file
 
 #+CAPTION: orgfile
 #+NAME: orgfile
 [[https://user-images.githubusercontent.com/1782860/123549982-90752180-d76b-11eb-8828-9edf9f76af08.gif]]
 
-** Capturing and refiling
+*** Capturing and refiling
 
 #+CAPTION: capture
 #+NAME: capture
 [[https://user-images.githubusercontent.com/1782860/123549993-9a972000-d76b-11eb-814b-b348a93df08a.gif]]
 
-** Autocompletion
+*** Autocompletion
 
 #+CAPTION: autocomplete
 #+NAME: autocomplete
 [[https://user-images.githubusercontent.com/1782860/123550227-e8605800-d76c-11eb-96f6-c0a677d562d4.gif]]
 
-* Treesitter Info
+** Treesitter Info
 
 The built-in treesitter parser is used for parsing the org files.
 
-** Known highlighting issues and limitations
+*** Known highlighting issues and limitations
 
 - LaTex is still highlighted through syntax file
 
-* Troubleshoot
+** Troubleshoot
 
-** Indentation is not working
+*** Indentation is not working
 
 Make sure you are not overriding indentexpr in Org buffers with [[https://github.com/nvim-treesitter/nvim-treesitter#indentation][nvim-treesitter indentation]]
 
-** I get ~treesitter/query.lua~ errors when opening agenda/capture prompt or org files
+*** I get ~treesitter/query.lua~ errors when opening agenda/capture prompt or org files
 
 Tree-sitter parser might not be installed.
 Try running ~:lua require('orgmode.config'):reinstall_grammar()~ to reinstall it.
 
-** Dates are not in English
+*** Dates are not in English
 
 Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
 To use different locale you can add this to your ~init.lua~:
@@ -210,7 +210,7 @@ language en_US.utf8
 Just make sure you have ~en_US~ locale installed on your system. To see what you have available on the system you can
 start the command ~:language ~ and press ~<TAB>~ to autocomplete possible options.
 
-** Links are not concealed
+*** Links are not concealed
 
 Links are concealed with Vim's conceal feature (see ~:help conceal~). To enable concealing, add this to your ~init.lua~:
 
@@ -226,7 +226,7 @@ set conceallevel=2
 set concealcursor=nc
 #+end_src
 
-** Jumping to file path is not working for paths with forward slash
+*** Jumping to file path is not working for paths with forward slash
 
 If you are using Windows, paths are by default written with backslashes.
 To use forward slashes, you must enable ~shellslash~ option (see ~:help 'shellslash'~).
@@ -243,9 +243,9 @@ set shellslash
 
 More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775][#281]]
 
-* Features
+** Features
 
-** TL;DR
+*** TL;DR
 
 - Agenda view
 - Search by tags/keyword
@@ -266,7 +266,7 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
 - Remote editing from agenda view
 - Repeatable mapping via [[https://github.com/tpope/vim-repeat][vim-repeat]]
 
-** Detailed breakdown
+*** Detailed breakdown
 
 - Agenda prompt:
   - Agenda view (<kbd>a</kbd>):
@@ -324,7 +324,7 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
 
 Link to detailed documentation: [[DOCS.md][DOCS]]
 
-* Plugins
+** Plugins
 
 - [[https://www.orgroam.com/][org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim) - Implementation of [Org-roam]] knowledge management system
 - [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters
@@ -334,24 +334,24 @@ Link to detailed documentation: [[DOCS.md][DOCS]]
 
 See all available plugins on [[https://github.com/topics/orgmode-nvim][orgmode-nvim]]
 
-**If you built a plugin please add "orgmode-nvim" topic to it.**
+***If you built a plugin please add "orgmode-nvim" topic to it.**
 
-**NOTE**: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
+***NOTE**: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.
 The point of this plugin is to provide functionality that's built into Emacs Orgmode core,
 and a good foundation for external plugins.<br />
 If you want to build a plugin, post suggestions and improvements on [[https://github.com/nvim-orgmode/orgmode/issues/26][Plugins infrastructure]]
 issue.
 
-** :wrench: API
+*** :wrench: API
 
 Documentation for our work-in-progress API can be found [[doc/orgmode_api.txt][here]]
 
-* Contributing
+** Contributing
 
 See [[CONTRIBUTING.md][CONTRIBUTING.md]]
 
-* Documentation
+** Documentation
 
 If you are just starting out with orgmode, have a look at the [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][Getting Started]] section in our wiki.
 
@@ -359,7 +359,7 @@ Vim documentation is auto generated from [[https://github.com/FooSoft/md2vim][DO
 
 Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgmode.github.io/]]
 
-* Roadmap
+** Roadmap
 
 - [x] Support searching by properties
 - [ ] Improve checkbox hierarchy
@@ -372,7 +372,7 @@ Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgm
 - [ ] Support diary format dates
 - [ ] Support evaluating code blocks
 
-* Thanks to
+** Thanks to
 
 - [[https://github.com/dhruvasagar/vim-dotoo][@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo]] plugin
   that got me started using orgmode. Without him this plugin would not happen.

--- a/README.org
+++ b/README.org
@@ -338,7 +338,7 @@ Link to detailed documentation: [[DOCS.md][DOCS]]
 
 ** Plugins
 
-- [[https://github.com/chipsenkbeil/org-roam.nvim][https://www.orgroam.com/org-roam.nvim]] - Implementation of [[https://orgroam.com][Org-roam]] knowledge management system
+- [[https://github.com/chipsenkbeil/org-roam.nvim][org-roam.nvim]] - Implementation of [[https://orgroam.com][Org-roam]] knowledge management system
 - [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters
 - [[https://github.com/lukas-reineke/headlines.nvim][headlines.nvim]] - Add few highlight options for code blocks and headlines
 - [[https://github.com/michaelb/sniprun][sniprun]] - For code evaluation in blocks
@@ -348,10 +348,11 @@ See all available plugins on [[https://github.com/topics/orgmode-nvim][orgmode-n
 
 ***If you built a plugin please add "orgmode-nvim" topic to it.**
 
-***NOTE**: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
+*NOTE*: None of the Emacs Orgmode plugins will be built into nvim-orgmode.
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.
 The point of this plugin is to provide functionality that's built into Emacs Orgmode core,
-and a good foundation for external plugins.<br />
+and a good foundation for external plugins.
+#+HTML:<br/>
 If you want to build a plugin, post suggestions and improvements on [[https://github.com/nvim-orgmode/orgmode/issues/26][Plugins infrastructure]]
 issue.
 
@@ -367,7 +368,7 @@ See [[CONTRIBUTING.md][CONTRIBUTING.md]]
 
 If you are just starting out with orgmode, have a look at the [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][Getting Started]] section in our wiki.
 
-Vim documentation is auto generated from [[https://github.com/FooSoft/md2vim][DOCS.md](DOCS.md) file with [md2vim]].
+Vim documentation is auto generated from [[DOCS.md][DOCS.md]] file with [[https://github.com/FooSoft/md2vim][md2vim]].
 
 Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgmode.github.io/]]
 
@@ -386,7 +387,7 @@ Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgm
 
 ** Thanks to
 
-- [[https://github.com/dhruvasagar/vim-dotoo][@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo]] plugin
+- [[https://github.com/dhruvasagar][@dhruvasagar]] and his [[https://github.com/dhruvasagar/vim-dotoo][vim-dotoo]] plugin
   that got me started using orgmode. Without him this plugin would not happen.
 - [[https://github.com/milisims][@milisims]] for writing a treesitter parser for org
-- [[https://github.com/jceb/vim-orgmode) for some parts of the code (mostly syntax][vim-orgmode]]
+- [[https://github.com/jceb/vim-orgmode][vim-orgmode]] for some parts of the code (mostly syntax)

--- a/README.org
+++ b/README.org
@@ -294,7 +294,7 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
       - Date ranges - example: ~<2021-06-11 Fri 11:00-12:30>--<2021-06-13 Sun 22:00>~
     - Properly lists tasks according to defined dates (DEADLINE,SCHEDULED,Plain date)
     - Navigate forward (=f=)/backward(=b=) or jump to specific date (=J=)
-    - Go to task under cursor in current window(=\<CR\>=) or other window(=\<TAB\>=)
+    - Go to task under cursor in current window(=<CR>=) or other window(=<TAB>=)
     - Print category from ":CATEGORY:" property if defined
   - List tasks that have "TODO" state (=t=):
   - Find headlines matching tag(s) (=m=):
@@ -304,33 +304,33 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
   - Clocking time
 - Capture:
   - Define custom templates
-  - Fast capturing to default notes file via =\<C-c\>=
-  - Capturing to specific destination =\<Leader\>or=
-  - Abort capture with =\<Leader\>ok=
+  - Fast capturing to default notes file via =<C-c>=
+  - Capturing to specific destination =<Leader>or=
+  - Abort capture with =<Leader>ok=
 - Org files
   - Clocking time
-  - Refile to destination/headline: =\<Leader\>or=
-  - Increase/Decrease date under cursor: =\<C-a\>=/=\<C-x\>=
+  - Refile to destination/headline: =<Leader>or=
+  - Increase/Decrease date under cursor: =<C-a>=/=<C-x>=
   - Change date under cursor via calendar popup: =cid=
   - Change headline TODO state: forward=cit= or backward=ciT=
-  - Open hyperlink or date under cursor: =\<Leader\>oo=
-  - Toggle checkbox: =\<C-space\>=
-  - Toggle current line to headline and vice versa: =\<Leader\>o\*=
-  - Toggle folding of current headline: =\<TAB\>=
-  - Toggle folding in whole file: =\<S-TAB\>=
-  - Archive headline: =\<Leader\>o$=
-  - Add archive tag: =\<Leader\>oA=
-  - Change tags: =\<Leader\>ot=
+  - Open hyperlink or date under cursor: =<Leader>oo=
+  - Toggle checkbox: =<C-space>=
+  - Toggle current line to headline and vice versa: =<Leader>o\*=
+  - Toggle folding of current headline: =<TAB>=
+  - Toggle folding in whole file: =<S-TAB>=
+  - Archive headline: =<Leader>o$=
+  - Add archive tag: =<Leader>oA=
+  - Change tags: =<Leader>ot=
   - Promote headline: =<<=
   - Demote headline: =>>=
-  - Promote subtree: =\<s=
-  - Demote subtree: =\>s=
-  - Add headline/list item/checkbox: =\<Leader\>\<CR\>=
-  - Insert heading after current heading and it's content: =\<Leader\>oih=
-  - Insert TODO heading after current line: =\<Leader\>oiT=
-  - Insert TODO heading after current heading and it's content: =\<Leader\>oit=
-  - Move headline up: =\<Leader\>oK</kb>
-  - Move headline down: =\<Leader\>oJ</kb>
+  - Promote subtree: =<s=
+  - Demote subtree: =>s=
+  - Add headline/list item/checkbox: =<Leader><CR>=
+  - Insert heading after current heading and it's content: =<Leader>oih=
+  - Insert TODO heading after current line: =<Leader>oiT=
+  - Insert TODO heading after current heading and it's content: =<Leader>oit=
+  - Move headline up: =<Leader>oK</kb>
+  - Move headline down: =<Leader>oJ</kb>
   - Highlighted code blocks (~#+BEGIN_SRC filetype~)
    Exporting (via ~emacs~, ~pandoc~ and custom export options)
 

--- a/README.org
+++ b/README.org
@@ -1,7 +1,8 @@
-#+TITLE: nvim-orgmode
 #+HTML: <div align="center">
 
 #+HTML: <img alt="A blend of the Neovim (shape) and Org-mode (colours) logos" src="assets/nvim-orgmode.svg" width="250" /><br/>
+
+* nvim-orgmode
 
 #+HTML:<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a>
 #+HTML:<a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a>

--- a/README.org
+++ b/README.org
@@ -26,8 +26,8 @@ Use your favourite package manager:
       org_default_notes_file = '~/orgfiles/refile.org',
     })
 
-    -- NOTE: If you are using nvim-treesitter with `ensure_installed = "all"` option
-    -- add `org` to ignore_install
+    -- NOTE: If you are using nvim-treesitter with ~ensure_installed = "all"~ option
+    -- add ~org~ to ignore_install
     -- require('nvim-treesitter.configs').setup({
     --   ensure_installed = 'all',
     --   ignore_install = { 'org' },
@@ -76,7 +76,7 @@ call dein#add('nvim-orgmode/orgmode')
 Note that this setup is not needed for [lazy.nvim](https://github.com/folke/lazy.nvim)
 since instructions above covers full setup
 
-#+begin_src `lua
+#+begin_src ~lua
 -- init.lua
 
 require('orgmode').setup({
@@ -84,14 +84,14 @@ require('orgmode').setup({
   org_default_notes_file = '~/Dropbox/org/refile.org',
 })
 
--- NOTE: If you are using nvim-treesitter with `ensure_installed = "all"` option
--- add `org` to ignore_install
+-- NOTE: If you are using nvim-treesitter with ~ensure_installed = "all"~ option
+-- add ~org~ to ignore_install
 -- require('nvim-treesitter.configs').setup({
 --   ensure_installed = 'all',
 --   ignore_install = { 'org' },
 -- })
 
-Or if you are using `init.vim`, wrap the above snippet like so:
+Or if you are using ~init.vim~, wrap the above snippet like so:
 #+begin_src vim
 " init.vim
 lua << EOF
@@ -102,7 +102,7 @@ require('orgmode').setup({
 })
 
 EOF
-#+begin_src `
+#+begin_src ~
 
 *** Completion
 
@@ -136,7 +136,7 @@ vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 
 </details>
 
-Or just use `omnifunc` via <kbd>\<C-x\>\<C-o\></kbd>
+Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
 
 ** Usage
 
@@ -179,39 +179,39 @@ The built-in treesitter parser is used for parsing the org files.
 
 Make sure you are not overriding indentexpr in Org buffers with [nvim-treesitter indentation](https://github.com/nvim-treesitter/nvim-treesitter#indentation)
 
-** I get `treesitter/query.lua` errors when opening agenda/capture prompt or org files
+** I get ~treesitter/query.lua~ errors when opening agenda/capture prompt or org files
 
 Tree-sitter parser might not be installed.
-Try running `:lua require('orgmode.config'):reinstall_grammar()` to reinstall it.
+Try running ~:lua require('orgmode.config'):reinstall_grammar()~ to reinstall it.
 
 ** Dates are not in English
 
 Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
-To use different locale you can add this to your `init.lua`:
+To use different locale you can add this to your ~init.lua~:
 
 #+begin_src lua
 vim.cmd('language en_US.utf8')
 #+end_src
 
-or `init.vim`
+or ~init.vim~
 
 #+end_src
 language en_US.utf8
 #+end_src
 
-Just make sure you have `en_US` locale installed on your system. To see what you have available on the system you can
-start the command `:language ` and press `<TAB>` to autocomplete possible options.
+Just make sure you have ~en_US~ locale installed on your system. To see what you have available on the system you can
+start the command ~:language ~ and press ~<TAB>~ to autocomplete possible options.
 
 ** Links are not concealed
 
-Links are concealed with Vim's conceal feature (see `:help conceal`). To enable concealing, add this to your `init.lua`:
+Links are concealed with Vim's conceal feature (see ~:help conceal~). To enable concealing, add this to your ~init.lua~:
 
 #+begin_src lua
 vim.opt.conceallevel = 2
 vim.opt.concealcursor = 'nc'
 #+end_src
 
-Or if you are using `init.vim`:
+Or if you are using ~init.vim~:
 
 #+begin_src vim
 set conceallevel=2
@@ -221,13 +221,13 @@ set concealcursor=nc
 ** Jumping to file path is not working for paths with forward slash
 
 If you are using Windows, paths are by default written with backslashes.
-To use forward slashes, you must enable `shellslash` option (see `:help 'shellslash'`).
+To use forward slashes, you must enable ~shellslash~ option (see ~:help 'shellslash'~).
 
 #+begin_src lua
 vim.opt.shellslash = true
 #+end_src
 
-Or if you are using `init.vim`:
+Or if you are using ~init.vim~:
 
 #+begin_src vim
 set shellslash
@@ -245,7 +245,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
 - Repeatable dates, date and time ranges
 - Capturing to default notes file/destination
 - Archiving (archive file or ARCHIVE tag)
-- Exporting (via `emacs`, `pandoc` and custom export options)
+- Exporting (via ~emacs~, ~pandoc~ and custom export options)
 - Notifications (experimental, see [Issue #49](https://github.com/nvim-orgmode/orgmode/issues/49))
 - Calendar popup for easier navigation and date updates
 - Various org file mappings:
@@ -264,14 +264,14 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
   - Agenda view (<kbd>a</kbd>):
     - Ability to show daily(<kbd>vd</kbd>)/weekly(<kbd>vw</kbd>)/monthly(<kbd>vm</kbd>)/yearly(<kbd>vy</kbd>) agenda
     - Support for various date settings:
-      - DEADLINE: Warning settings - example: `<2021-06-11 Fri 11:00 -1d>`
-      - SCHEDULED: Delay setting - example: `<2021-06-11 Fri 11:00 -2d>`
+      - DEADLINE: Warning settings - example: ~<2021-06-11 Fri 11:00 -1d>~
+      - SCHEDULED: Delay setting - example: ~<2021-06-11 Fri 11:00 -2d>~
       - All dates - Repeater settings:
-        - Cumulate type: `<2021-06-11 Fri 11:00 +1w>`
-        - Catch-up type: `<2021-06-11 Fri 11:00 ++1w>`
-        - Restart type: `<2021-06-11 Fri 11:00 .+1w>`
-      - Time ranges - example: `<2021-06-11 Fri 11:00-12:30>`
-      - Date ranges - example: `<2021-06-11 Fri 11:00-12:30>--<2021-06-13 Sun 22:00>`
+        - Cumulate type: ~<2021-06-11 Fri 11:00 +1w>~
+        - Catch-up type: ~<2021-06-11 Fri 11:00 ++1w>~
+        - Restart type: ~<2021-06-11 Fri 11:00 .+1w>~
+      - Time ranges - example: ~<2021-06-11 Fri 11:00-12:30>~
+      - Date ranges - example: ~<2021-06-11 Fri 11:00-12:30>--<2021-06-13 Sun 22:00>~
     - Properly lists tasks according to defined dates (DEADLINE,SCHEDULED,Plain date)
     - Navigate forward (<kbd>f</kbd>)/backward(<kbd>b</kbd>) or jump to specific date (<kbd>J</kbd>)
     - Go to task under cursor in current window(<kbd>\<CR\></kbd>) or other window(<kbd>\<TAB\></kbd>)
@@ -311,8 +311,8 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
   - Insert TODO heading after current heading and it's content: <kbd>\<Leader\>oit</kbd>
   - Move headline up: <kbd>\<Leader\>oK</kb>
   - Move headline down: <kbd>\<Leader\>oJ</kb>
-  - Highlighted code blocks (`#+BEGIN_SRC filetype`)
-  - Exporting (via `emacs`, `pandoc` and custom export options)
+  - Highlighted code blocks (~#+BEGIN_SRC filetype~)
+  - Exporting (via ~emacs~, ~pandoc~ and custom export options)
 
 Link to detailed documentation: [DOCS](DOCS.md)
 

--- a/README.org
+++ b/README.org
@@ -36,7 +36,7 @@ Use your favourite package manager:
 
 #+HTML:<details open><summary><b><a href="https://github.com/folke/lazy.nvim">lazy.nvim</a> (recommended)</b></summary></br>
 
-#+begin_src lua
+#+BEGIN_SRC lua
 {
   'nvim-orgmode/orgmode',
   event = 'VeryLazy',
@@ -56,34 +56,34 @@ Use your favourite package manager:
     -- })
   end,
 }
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
 #+HTML:<details> <summary><b><a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a></b></summary> </br>
 
-#+begin_src lua
+#+BEGIN_SRC lua
 use {'nvim-orgmode/orgmode', config = function()
   require('orgmode').setup{}
 end
 }
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
 #+HTML:<details> <summary><a href="https://github.com/junegunn/vim-plug"><b>vim-plug</b></a></summary> </br>
 
-#+begin_src vim
+#+BEGIN_SRC vim
 Plug 'nvim-orgmode/orgmode'
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
 #+HTML:<details> <summary><a href="https://github.com/Shougo/dein.vim"><b>dein.vim</b></a></summary> </br>
 
-#+begin_src vim
+#+BEGIN_SRC vim
 call dein#add('nvim-orgmode/orgmode')
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
@@ -92,7 +92,7 @@ call dein#add('nvim-orgmode/orgmode')
 Note that this setup is not needed for [[https://github.com/folke/lazy.nvim][lazy.nvim]]
 since instructions above covers full setup
 
-#+begin_src ~lua
+#+BEGIN_SRC lua
 -- init.lua
 
 require('orgmode').setup({
@@ -108,7 +108,7 @@ require('orgmode').setup({
 -- })
 
 Or if you are using ~init.vim~, wrap the above snippet like so:
-#+begin_src vim
+#+BEGIN_SRC vim
 " init.vim
 lua << EOF
 
@@ -118,24 +118,24 @@ require('orgmode').setup({
 })
 
 EOF
-#+begin_src ~
+#+END_SRC
 
 **** Completion
 
 #+HTML:<details> <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary> </br>
-#+begin_src lua
+#+BEGIN_SRC lua
 require('cmp').setup({
   sources = {
     { name = 'orgmode' }
   }
 })
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
 #+HTML:<details> <summary><a href="https://github.com/nvim-lua/completion-nvim"><b>completion-nvim</b></a></summary> </br>
 
-#+begin_src lua
+#+BEGIN_SRC lua
 vim.g.completion_chain_complete_list = {
   org = {
     { mode = 'omni'},
@@ -143,7 +143,7 @@ vim.g.completion_chain_complete_list = {
 }
 -- add additional keyword chars
 vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
-#+end_src
+#+END_SRC
 
 #+HTML:</details>
 
@@ -208,15 +208,15 @@ Try running ~:lua require('orgmode.config'):reinstall_grammar()~ to reinstall it
 Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
 To use different locale you can add this to your ~init.lua~:
 
-#+begin_src lua
+#+BEGIN_SRC lua
 vim.cmd('language en_US.utf8')
-#+end_src
+#+END_SRC
 
 or ~init.vim~
 
-#+end_src
+#+END_SRC
 language en_US.utf8
-#+end_src
+#+END_SRC
 
 Just make sure you have ~en_US~ locale installed on your system. To see what you have available on the system you can
 start the command ~:language ~ and press ~<TAB>~ to autocomplete possible options.
@@ -225,32 +225,32 @@ start the command ~:language ~ and press ~<TAB>~ to autocomplete possible option
 
 Links are concealed with Vim's conceal feature (see ~:help conceal~). To enable concealing, add this to your ~init.lua~:
 
-#+begin_src lua
+#+BEGIN_SRC lua
 vim.opt.conceallevel = 2
 vim.opt.concealcursor = 'nc'
-#+end_src
+#+END_SRC
 
 Or if you are using ~init.vim~:
 
-#+begin_src vim
+#+BEGIN_SRC vim
 set conceallevel=2
 set concealcursor=nc
-#+end_src
+#+END_SRC
 
 *** Jumping to file path is not working for paths with forward slash
 
 If you are using Windows, paths are by default written with backslashes.
 To use forward slashes, you must enable ~shellslash~ option (see ~:help 'shellslash'~).
 
-#+begin_src lua
+#+BEGIN_SRC lua
 vim.opt.shellslash = true
-#+end_src
+#+END_SRC
 
 Or if you are using ~init.vim~:
 
-#+begin_src vim
+#+BEGIN_SRC vim
 set shellslash
-#+end_src
+#+END_SRC
 
 More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775][#281]]
 

--- a/README.org
+++ b/README.org
@@ -368,14 +368,14 @@ Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgm
 
 ** Roadmap
 
-- [x] Support searching by properties
+- [X] Support searching by properties
 - [ ] Improve checkbox hierarchy
-- [x] Support todo keyword faces
-- [x] Support clocking work time
-- [x] Improve folding
-- [x] Support exporting (via existing emacs tools)
+- [X] Support todo keyword faces
+- [X] Support clocking work time
+- [X] Improve folding
+- [X] Support exporting (via existing emacs tools)
 - [ ] Support archiving to specific headline
-- [x] Support tables
+- [X] Support tables
 - [ ] Support diary format dates
 - [ ] Support evaluating code blocks
 

--- a/README.org
+++ b/README.org
@@ -5,15 +5,12 @@
 * nvim-orgmode
 
 #+HTML:<a href="/LICENSE">
-#+CAPTION: License
 [[https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square]]
 #+HTML:</a>
 #+HTML:<a href="https://ko-fi.com/kristijanhusak">
-#+CAPTION: Kofi
 [[https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi]]
 #+HTML:</a>
 #+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org">
-#+CAPTION: Chat
 [[https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square]]
 #+HTML:</a>
 

--- a/README.org
+++ b/README.org
@@ -1,23 +1,12 @@
-<div align="center">
-  <img alt="A blend of the Neovim (shape) and Org-mode (colours) logos" src="assets/nvim-orgmode.svg" width="250px" />
++title: nvim-orgmode
 
-# nvim-orgmode
+* Quickstart
 
-<a href="/LICENSE">![License](https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square)</a><a href="https://ko-fi.com/kristijanhusak"> ![Kofi](https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi)</a><a href="https://matrix.to/#/#neovim-orgmode:matrix.org"> ![Chat](https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square)</a>
-
-Orgmode clone written in Lua for Neovim 0.9.2+
-
-[Setup](#setup) • [Docs](/DOCS.md) • [Showcase](#showcase) • [Treesitter](#treesitter-info) • [Troubleshoot](#troubleshoot) • [Plugins](#plugins) • [Contributing](CONTRIBUTING.md) • [Kudos](#thanks-to)
-
-</div>
-
-## Quickstart
-
-### Requirements
+** Requirements
 
 - Neovim 0.9.2 or later
 
-### Installation
+** Installation
 
 Use your favourite package manager:
 
@@ -25,7 +14,7 @@ Use your favourite package manager:
   <summary><b><a href="https://github.com/folke/lazy.nvim">lazy.nvim</a> (recommended)</b></summary>
   </br>
 
-```lua
+#+begin_src lua
 {
   'nvim-orgmode/orgmode',
   event = 'VeryLazy',
@@ -45,7 +34,7 @@ Use your favourite package manager:
     -- })
   end,
 }
-```
+#+end_src
 
 </details>
 
@@ -53,12 +42,12 @@ Use your favourite package manager:
   <summary><b><a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a></b></summary>
   </br>
 
-```lua
+#+begin_src lua
 use {'nvim-orgmode/orgmode', config = function()
   require('orgmode').setup{}
 end
 }
-```
+#+end_src
 
 </details>
 
@@ -66,9 +55,9 @@ end
   <summary><a href="https://github.com/junegunn/vim-plug"><b>vim-plug</b></a></summary>
   </br>
 
-```vim
+#+begin_src vim
 Plug 'nvim-orgmode/orgmode'
-```
+#+end_src
 
 </details>
 
@@ -76,18 +65,18 @@ Plug 'nvim-orgmode/orgmode'
   <summary><a href="https://github.com/Shougo/dein.vim"><b>dein.vim</b></a></summary>
   </br>
 
-```vim
+#+begin_src vim
 call dein#add('nvim-orgmode/orgmode')
-```
+#+end_src
 
 </details>
 
-### Setup
+** Setup
 
 Note that this setup is not needed for [lazy.nvim](https://github.com/folke/lazy.nvim)
 since instructions above covers full setup
 
-````lua
+#+begin_src `lua
 -- init.lua
 
 require('orgmode').setup({
@@ -103,7 +92,7 @@ require('orgmode').setup({
 -- })
 
 Or if you are using `init.vim`, wrap the above snippet like so:
-```vim
+#+begin_src vim
 " init.vim
 lua << EOF
 
@@ -113,21 +102,21 @@ require('orgmode').setup({
 })
 
 EOF
-````
+#+begin_src `
 
-#### Completion
+*** Completion
 
 <details>
   <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary>
   </br>
 
-```lua
+#+begin_src lua
 require('cmp').setup({
   sources = {
     { name = 'orgmode' }
   }
 })
-```
+#+end_src
 
 </details>
 
@@ -135,7 +124,7 @@ require('cmp').setup({
   <summary><a href="https://github.com/nvim-lua/completion-nvim"><b>completion-nvim</b></a></summary>
   </br>
 
-```lua
+#+begin_src lua
 vim.g.completion_chain_complete_list = {
   org = {
     { mode = 'omni'},
@@ -143,13 +132,13 @@ vim.g.completion_chain_complete_list = {
 }
 -- add additional keyword chars
 vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
-```
+#+end_src
 
 </details>
 
 Or just use `omnifunc` via <kbd>\<C-x\>\<C-o\></kbd>
 
-### Usage
+** Usage
 
 - **Open agenda prompt**: <kbd>\<Leader\>oa</kbd>
 - **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
@@ -158,97 +147,97 @@ Or just use `omnifunc` via <kbd>\<C-x\>\<C-o\></kbd>
 If you are new to Orgmode, see [Getting started](/DOCS.md#getting-started-with-orgmode) section in the Docs
 or a hands-on [tutorial](https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started) in our wiki.
 
-## Showcase
+* Showcase
 
-### Agenda
+** Agenda
 
 ![agenda](https://user-images.githubusercontent.com/1782860/123549968-8521f600-d76b-11eb-9a93-02bad08b37ce.gif)
 
-### Org file
+** Org file
 
 ![orgfile](https://user-images.githubusercontent.com/1782860/123549982-90752180-d76b-11eb-8828-9edf9f76af08.gif)
 
-### Capturing and refiling
+** Capturing and refiling
 
 ![capture](https://user-images.githubusercontent.com/1782860/123549993-9a972000-d76b-11eb-814b-b348a93df08a.gif)
 
-### Autocompletion
+** Autocompletion
 
 ![autocomplete](https://user-images.githubusercontent.com/1782860/123550227-e8605800-d76c-11eb-96f6-c0a677d562d4.gif)
 
-## Treesitter Info
+* Treesitter Info
 
 The built-in treesitter parser is used for parsing the org files.
 
-### Known highlighting issues and limitations
+** Known highlighting issues and limitations
 
 - LaTex is still highlighted through syntax file
 
-## Troubleshoot
+* Troubleshoot
 
-### Indentation is not working
+** Indentation is not working
 
 Make sure you are not overriding indentexpr in Org buffers with [nvim-treesitter indentation](https://github.com/nvim-treesitter/nvim-treesitter#indentation)
 
-### I get `treesitter/query.lua` errors when opening agenda/capture prompt or org files
+** I get `treesitter/query.lua` errors when opening agenda/capture prompt or org files
 
 Tree-sitter parser might not be installed.
 Try running `:lua require('orgmode.config'):reinstall_grammar()` to reinstall it.
 
-### Dates are not in English
+** Dates are not in English
 
 Dates are generated with Lua native date support, and it reads your current locale when creating them.<br />
 To use different locale you can add this to your `init.lua`:
 
-```lua
+#+begin_src lua
 vim.cmd('language en_US.utf8')
-```
+#+end_src
 
 or `init.vim`
 
-```
+#+end_src
 language en_US.utf8
-```
+#+end_src
 
 Just make sure you have `en_US` locale installed on your system. To see what you have available on the system you can
 start the command `:language ` and press `<TAB>` to autocomplete possible options.
 
-### Links are not concealed
+** Links are not concealed
 
 Links are concealed with Vim's conceal feature (see `:help conceal`). To enable concealing, add this to your `init.lua`:
 
-```lua
+#+begin_src lua
 vim.opt.conceallevel = 2
 vim.opt.concealcursor = 'nc'
-```
+#+end_src
 
 Or if you are using `init.vim`:
 
-```vim
+#+begin_src vim
 set conceallevel=2
 set concealcursor=nc
-```
+#+end_src
 
-### Jumping to file path is not working for paths with forward slash
+** Jumping to file path is not working for paths with forward slash
 
 If you are using Windows, paths are by default written with backslashes.
 To use forward slashes, you must enable `shellslash` option (see `:help 'shellslash'`).
 
-```lua
+#+begin_src lua
 vim.opt.shellslash = true
-```
+#+end_src
 
 Or if you are using `init.vim`:
 
-```vim
+#+begin_src vim
 set shellslash
-```
+#+end_src
 
 More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775)
 
-## Features
+* Features
 
-### TL;DR
+** TL;DR
 
 - Agenda view
 - Search by tags/keyword
@@ -269,7 +258,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
 - Remote editing from agenda view
 - Repeatable mapping via [vim-repeat](https://github.com/tpope/vim-repeat)
 
-### Detailed breakdown
+** Detailed breakdown
 
 - Agenda prompt:
   - Agenda view (<kbd>a</kbd>):
@@ -327,7 +316,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
 
 Link to detailed documentation: [DOCS](DOCS.md)
 
-## Plugins
+* Plugins
 
 - [org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim) - Implementation of [Org-roam](https://www.orgroam.com/) knowledge management system
 - [org-bullets.nvim](https://github.com/akinsho/org-bullets.nvim) - Show org mode bullets as UTF-8 characters
@@ -346,15 +335,15 @@ and a good foundation for external plugins.<br />
 If you want to build a plugin, post suggestions and improvements on [Plugins infrastructure](https://github.com/nvim-orgmode/orgmode/issues/26)
 issue.
 
-### :wrench: API
+** :wrench: API
 
 Documentation for our work-in-progress API can be found [here](doc/orgmode_api.txt)
 
-## Contributing
+* Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-## Documentation
+* Documentation
 
 If you are just starting out with orgmode, have a look at the [Getting Started](https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started) section in our wiki.
 
@@ -362,7 +351,7 @@ Vim documentation is auto generated from [DOCS.md](DOCS.md) file with [md2vim](h
 
 Hosted documentation is on: [https://nvim-orgmode.github.io/](https://nvim-orgmode.github.io/)
 
-## Roadmap
+* Roadmap
 
 - [x] Support searching by properties
 - [ ] Improve checkbox hierarchy
@@ -375,7 +364,7 @@ Hosted documentation is on: [https://nvim-orgmode.github.io/](https://nvim-orgmo
 - [ ] Support diary format dates
 - [ ] Support evaluating code blocks
 
-## Thanks to
+* Thanks to
 
 - [@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo](https://github.com/dhruvasagar/vim-dotoo) plugin
   that got me started using orgmode. Without him this plugin would not happen.

--- a/README.org
+++ b/README.org
@@ -10,9 +10,7 @@
 
 Use your favourite package manager:
 
-<details open>
-  <summary><b><a href="https://github.com/folke/lazy.nvim">lazy.nvim</a> (recommended)</b></summary>
-  </br>
+#+HTML:<details open><summary><b><a href="https://github.com/folke/lazy.nvim">lazy.nvim</a> (recommended)</b></summary></br>
 
 #+begin_src lua
 {
@@ -36,11 +34,9 @@ Use your favourite package manager:
 }
 #+end_src
 
-</details>
+#+HTML:</details>
 
-<details>
-  <summary><b><a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a></b></summary>
-  </br>
+#+HTML:<details> <summary><b><a href="https://github.com/wbthomason/packer.nvim">packer.nvim</a></b></summary> </br>
 
 #+begin_src lua
 use {'nvim-orgmode/orgmode', config = function()
@@ -49,27 +45,23 @@ end
 }
 #+end_src
 
-</details>
+#+HTML:</details>
 
-<details>
-  <summary><a href="https://github.com/junegunn/vim-plug"><b>vim-plug</b></a></summary>
-  </br>
+#+HTML:<details> <summary><a href="https://github.com/junegunn/vim-plug"><b>vim-plug</b></a></summary> </br>
 
 #+begin_src vim
 Plug 'nvim-orgmode/orgmode'
 #+end_src
 
-</details>
+#+HTML:</details>
 
-<details>
-  <summary><a href="https://github.com/Shougo/dein.vim"><b>dein.vim</b></a></summary>
-  </br>
+#+HTML:<details> <summary><a href="https://github.com/Shougo/dein.vim"><b>dein.vim</b></a></summary> </br>
 
 #+begin_src vim
 call dein#add('nvim-orgmode/orgmode')
 #+end_src
 
-</details>
+#+HTML:</details>
 
 *** Setup
 
@@ -106,10 +98,7 @@ EOF
 
 **** Completion
 
-<details>
-  <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary>
-  </br>
-
+#+HTML:<details> <summary><a href="https://github.com/hrsh7th/nvim-cmp"><b>nvim-cmp</b></a></summary> </br>
 #+begin_src lua
 require('cmp').setup({
   sources = {
@@ -118,11 +107,9 @@ require('cmp').setup({
 })
 #+end_src
 
-</details>
+#+HTML:</details>
 
-<details>
-  <summary><a href="https://github.com/nvim-lua/completion-nvim"><b>completion-nvim</b></a></summary>
-  </br>
+#+HTML:<details> <summary><a href="https://github.com/nvim-lua/completion-nvim"><b>completion-nvim</b></a></summary> </br>
 
 #+begin_src lua
 vim.g.completion_chain_complete_list = {
@@ -134,7 +121,7 @@ vim.g.completion_chain_complete_list = {
 vim.cmd[[autocmd FileType org setlocal iskeyword+=:,#,+]]
 #+end_src
 
-</details>
+#+HTML:</details>
 
 Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
 

--- a/README.org
+++ b/README.org
@@ -4,17 +4,9 @@
 
 * nvim-orgmode
 
-** TODO: Logos add image alt text to links
-
-#+HTML:<a href="/LICENSE">
-#+HTML:<img alt="logo_desc" src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square">
-#+HTML:</a>
-#+HTML:<a href="https://ko-fi.com/kristijanhusak">
-#+HTML:<img alt="logo_desc" src="https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi">
-#+HTML:</a>
-#+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org">
-#+HTML:<img alt="logo_desc" src="https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square">
-#+HTML:</a>
+#+HTML:<a href="/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-brightgreen?style=flat-square"></a>
+#+HTML:<a href="https://ko-fi.com/kristijanhusak"><img alt="Kofi" src="https://img.shields.io/badge/support-kofi-00b9fe?style=flat-square&logo=kofi"></a>
+#+HTML:<a href="https://matrix.to/#/#neovim-orgmode:matrix.org"><img alt="Chat" src="https://img.shields.io/matrix/neovim-orgmode:matrix.org?logo=matrix&server_fqdn=matrix.org&style=flat-square"></a>
 
 Orgmode clone written in Lua for Neovim 0.9.2+
 

--- a/README.org
+++ b/README.org
@@ -73,7 +73,7 @@ call dein#add('nvim-orgmode/orgmode')
 
 ** Setup
 
-Note that this setup is not needed for [lazy.nvim](https://github.com/folke/lazy.nvim)
+Note that this setup is not needed for [[https://github.com/folke/lazy.nvim][lazy.nvim]]
 since instructions above covers full setup
 
 #+begin_src ~lua
@@ -144,26 +144,34 @@ Or just use ~omnifunc~ via <kbd>\<C-x\>\<C-o\></kbd>
 - **Open capture prompt**: <kbd>\<Leader\>oc</kbd>
 - In any orgmode buffer press <kbd>g?</kbd> for help
 
-If you are new to Orgmode, see [Getting started](/DOCS.md#getting-started-with-orgmode) section in the Docs
-or a hands-on [tutorial](https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started) in our wiki.
+If you are new to Orgmode, see [[/DOCS.md#getting-started-with-orgmode][Getting started]] section in the Docs
+or a hands-on [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][tutorial]] in our wiki.
 
 * Showcase
 
 ** Agenda
 
-![agenda](https://user-images.githubusercontent.com/1782860/123549968-8521f600-d76b-11eb-9a93-02bad08b37ce.gif)
+#+CAPTION: agenda
+#+NAME: agenda
+[[https://user-images.githubusercontent.com/1782860/123549968-8521f600-d76b-11eb-9a93-02bad08b37ce.gif]]
 
 ** Org file
 
-![orgfile](https://user-images.githubusercontent.com/1782860/123549982-90752180-d76b-11eb-8828-9edf9f76af08.gif)
+#+CAPTION: orgfile
+#+NAME: orgfile
+[[https://user-images.githubusercontent.com/1782860/123549982-90752180-d76b-11eb-8828-9edf9f76af08.gif]]
 
 ** Capturing and refiling
 
-![capture](https://user-images.githubusercontent.com/1782860/123549993-9a972000-d76b-11eb-814b-b348a93df08a.gif)
+#+CAPTION: capture
+#+NAME: capture
+[[https://user-images.githubusercontent.com/1782860/123549993-9a972000-d76b-11eb-814b-b348a93df08a.gif]]
 
 ** Autocompletion
 
-![autocomplete](https://user-images.githubusercontent.com/1782860/123550227-e8605800-d76c-11eb-96f6-c0a677d562d4.gif)
+#+CAPTION: autocomplete
+#+NAME: autocomplete
+[[https://user-images.githubusercontent.com/1782860/123550227-e8605800-d76c-11eb-96f6-c0a677d562d4.gif]]
 
 * Treesitter Info
 
@@ -177,7 +185,7 @@ The built-in treesitter parser is used for parsing the org files.
 
 ** Indentation is not working
 
-Make sure you are not overriding indentexpr in Org buffers with [nvim-treesitter indentation](https://github.com/nvim-treesitter/nvim-treesitter#indentation)
+Make sure you are not overriding indentexpr in Org buffers with [[https://github.com/nvim-treesitter/nvim-treesitter#indentation][nvim-treesitter indentation]]
 
 ** I get ~treesitter/query.lua~ errors when opening agenda/capture prompt or org files
 
@@ -233,7 +241,7 @@ Or if you are using ~init.vim~:
 set shellslash
 #+end_src
 
-More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775)
+More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecomment-1120200775][#281]]
 
 * Features
 
@@ -246,7 +254,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
 - Capturing to default notes file/destination
 - Archiving (archive file or ARCHIVE tag)
 - Exporting (via ~emacs~, ~pandoc~ and custom export options)
-- Notifications (experimental, see [Issue #49](https://github.com/nvim-orgmode/orgmode/issues/49))
+- Notifications (experimental, see [[https://github.com/nvim-orgmode/orgmode/issues/49)][Issue #49]]
 - Calendar popup for easier navigation and date updates
 - Various org file mappings:
   - Promote/Demote
@@ -256,7 +264,7 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
   - Change tags
   - Toggle checkbox state
 - Remote editing from agenda view
-- Repeatable mapping via [vim-repeat](https://github.com/tpope/vim-repeat)
+- Repeatable mapping via [[https://github.com/tpope/vim-repeat][vim-repeat]]
 
 ** Detailed breakdown
 
@@ -279,8 +287,8 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
   - List tasks that have "TODO" state (<kbd>t</kbd>):
   - Find headlines matching tag(s) (<kbd>m</kbd>):
   - Search for headlines (and it's content) for a query (<kbd>s</kbd>):
-  - [Advanced search](DOCS.md#advanced-search) for tags/todo kewords/properties
-  - Notifications (experimental, see [Issue #49](https://github.com/nvim-orgmode/orgmode/issues/49))
+  - [[DOCS.md#advanced-search][Advanced search]] for tags/todo kewords/properties
+  - Notifications (experimental, see [[https://github.com/nvim-orgmode/orgmode/issues/49)][Issue #49]]
   - Clocking time
 - Capture:
   - Define custom templates
@@ -312,19 +320,19 @@ More info on issue [#281](https://github.com/nvim-orgmode/orgmode/issues/281#iss
   - Move headline up: <kbd>\<Leader\>oK</kb>
   - Move headline down: <kbd>\<Leader\>oJ</kb>
   - Highlighted code blocks (~#+BEGIN_SRC filetype~)
-  - Exporting (via ~emacs~, ~pandoc~ and custom export options)
+   Exporting (via ~emacs~, ~pandoc~ and custom export options)
 
-Link to detailed documentation: [DOCS](DOCS.md)
+Link to detailed documentation: [[DOCS.md][DOCS]]
 
 * Plugins
 
-- [org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim) - Implementation of [Org-roam](https://www.orgroam.com/) knowledge management system
-- [org-bullets.nvim](https://github.com/akinsho/org-bullets.nvim) - Show org mode bullets as UTF-8 characters
-- [headlines.nvim](https://github.com/lukas-reineke/headlines.nvim) - Add few highlight options for code blocks and headlines
-- [sniprun](https://github.com/michaelb/sniprun) - For code evaluation in blocks
-- [vim-table-mode](https://github.com/dhruvasagar/vim-table-mode) - For table support
+- [[https://www.orgroam.com/][org-roam.nvim](https://github.com/chipsenkbeil/org-roam.nvim) - Implementation of [Org-roam]] knowledge management system
+- [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters
+- [[https://github.com/lukas-reineke/headlines.nvim][headlines.nvim]] - Add few highlight options for code blocks and headlines
+- [[https://github.com/michaelb/sniprun][sniprun]] - For code evaluation in blocks
+- [[https://github.com/dhruvasagar/vim-table-mode][vim-table-mode]] - For table support
 
-See all available plugins on [orgmode-nvim](https://github.com/topics/orgmode-nvim)
+See all available plugins on [[https://github.com/topics/orgmode-nvim][orgmode-nvim]]
 
 **If you built a plugin please add "orgmode-nvim" topic to it.**
 
@@ -332,24 +340,24 @@ See all available plugins on [orgmode-nvim](https://github.com/topics/orgmode-nv
 Anything that's a separate plugin in Emacs Orgmode should be a separate plugin in here.
 The point of this plugin is to provide functionality that's built into Emacs Orgmode core,
 and a good foundation for external plugins.<br />
-If you want to build a plugin, post suggestions and improvements on [Plugins infrastructure](https://github.com/nvim-orgmode/orgmode/issues/26)
+If you want to build a plugin, post suggestions and improvements on [[https://github.com/nvim-orgmode/orgmode/issues/26][Plugins infrastructure]]
 issue.
 
 ** :wrench: API
 
-Documentation for our work-in-progress API can be found [here](doc/orgmode_api.txt)
+Documentation for our work-in-progress API can be found [[doc/orgmode_api.txt][here]]
 
 * Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md)
+See [[CONTRIBUTING.md][CONTRIBUTING.md]]
 
 * Documentation
 
-If you are just starting out with orgmode, have a look at the [Getting Started](https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started) section in our wiki.
+If you are just starting out with orgmode, have a look at the [[https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started][Getting Started]] section in our wiki.
 
-Vim documentation is auto generated from [DOCS.md](DOCS.md) file with [md2vim](https://github.com/FooSoft/md2vim).
+Vim documentation is auto generated from [[https://github.com/FooSoft/md2vim][DOCS.md](DOCS.md) file with [md2vim]].
 
-Hosted documentation is on: [https://nvim-orgmode.github.io/](https://nvim-orgmode.github.io/)
+Hosted documentation is on: [[https://nvim-orgmode.github.io/][https://nvim-orgmode.github.io/]]
 
 * Roadmap
 
@@ -366,7 +374,7 @@ Hosted documentation is on: [https://nvim-orgmode.github.io/](https://nvim-orgmo
 
 * Thanks to
 
-- [@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo](https://github.com/dhruvasagar/vim-dotoo) plugin
+- [[https://github.com/dhruvasagar/vim-dotoo][@dhruvasagar](https://github.com/dhruvasagar) and his [vim-dotoo]] plugin
   that got me started using orgmode. Without him this plugin would not happen.
-- [@milisims](https://github.com/milisims) for writing a treesitter parser for org
-- [vim-orgmode](https://github.com/jceb/vim-orgmode) for some parts of the code (mostly syntax)
+- [[https://github.com/milisims][@milisims]] for writing a treesitter parser for org
+- [[https://github.com/jceb/vim-orgmode) for some parts of the code (mostly syntax][vim-orgmode]]

--- a/README.org
+++ b/README.org
@@ -328,7 +328,7 @@ More info on issue [[https://github.com/nvim-orgmode/orgmode/issues/281#issuecom
 
 Link to detailed documentation: [[DOCS.md][DOCS]]
 
-** Pluginsa
+** Plugins
 
 - [[https://github.com/chipsenkbeil/org-roam.nvim][org-roam.nvim]] - Implementation of [[https://orgroam.com][Org-roam]] knowledge management system
 - [[https://github.com/akinsho/org-bullets.nvim][org-bullets.nvim]] - Show org mode bullets as UTF-8 characters


### PR DESCRIPTION
This entire plugin is about orgmode. I recently noticed that github supports formatting README files with `.org` notation.

I let myself be inspired by [this beautiful repo](https://github.com/emacs-tw/awesome-emacs/tree/master) and decided I'd try my hand at migrating this repos' README as it only felt fitting.

I had to make two concessions to read feature parity with your readme:
1. `<kbd>` tags and inline code look the same
  - I did format kbd tags with `=key=` notation and inline code with `~code~` notation to make it easier to refactor if a better solution is found
2. Checkmarks (`- [ ]` and `- [x]`) were not getting formatted properly
  - I used emojis with `:white_check_mark:` and `:white_square_button:` to obtain a similar effect
 

Feel free to look at the result on [my fork of the repo](https://github.com/ChausseBenjamin/orgmode)