### PR TITLE
fix: fix file type detection in `org-edit-special` on macOS.

### DIFF
--- a/lua/orgmode/objects/edit_special/types/src.lua
+++ b/lua/orgmode/objects/edit_special/types/src.lua
@@ -73,6 +73,9 @@ function EditSpecialSrc:init()
   -- Only the "content" of the block should change, however we might not have content yet
   -- so base the range off of the name of the block
   local ft = self.src_block.children.parameters.text
+  if ft then
+    ft = utils.detect_filetype(ft) or ft:lower()
+  end
 
   local bufnr = es_utils.make_temp_buf()
   if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then


### PR DESCRIPTION
There exists the same issue as in https://github.com/nvim-orgmode/orgmode/issues/727 for `org edit special`.

This commit uses the same logic as the one to handle the case in highlight injection to solve the problem for `edit-special`.