### PR TITLE
fix: schedule write action for edit-special.

### DIFF
--- a/lua/orgmode/objects/edit_special/types/src.lua
+++ b/lua/orgmode/objects/edit_special/types/src.lua
@@ -129,7 +129,9 @@ function EditSpecialSrc:write(ctx)
   local new_content = vim.api.nvim_buf_get_lines(ctx.bufnr, 0, -1, false)
   new_content = self:_update_content('add', ctx.start_extmark_pos[1], new_content)
 
-  vim.api.nvim_buf_set_lines(ctx.org_bufnr, content_start, content_end, false, new_content)
+  vim.schedule(function()
+    vim.api.nvim_buf_set_lines(ctx.org_bufnr, content_start, content_end, false, new_content)
+  end)
 
   self.file:reload()
 


### PR DESCRIPTION
The action of writing to the original buffer need to be schedule wrapped. otherwise, on the first time writing the org buffer, it will issue an `"E315: ml_get: invalid lnum: 87"` error. I guess this might be some race conditions? Anyway schedule this call makes this error disappear.

