### PR TITLE
Fix stale clocked header references when making edits to headers

### DIFF
--- a/lua/orgmode/clock/init.lua
+++ b/lua/orgmode/clock/init.lua
@@ -26,11 +26,20 @@ function Clock:init()
   end
 end
 
+function Clock:update_clocked_headline()
+  local last_clocked_headline = self.files:get_clocked_headline()
+  if last_clocked_headline and last_clocked_headline:is_clocked_in() then
+    self.clocked_headline = last_clocked_headline
+  end
+end
+
 function Clock:has_clocked_headline()
+  self:update_clocked_headline()
   return self.clocked_headline ~= nil
 end
 
 function Clock:org_clock_in()
+  self:update_clocked_headline()
   local item = self.files:get_closest_headline()
   if item:is_clocked_in() then
     return utils.echo_info(string.format('Clock continues in "%s"', item:get_title()))
@@ -54,6 +63,7 @@ function Clock:org_clock_in()
 end
 
 function Clock:org_clock_out()
+  self:update_clocked_headline()
   if not self.clocked_headline or not self.clocked_headline:is_clocked_in() then
     return
   end
@@ -63,6 +73,7 @@ function Clock:org_clock_out()
 end
 
 function Clock:org_clock_cancel()
+  self:update_clocked_headline()
   if not self.clocked_headline or not self.clocked_headline:is_clocked_in() then
     return utils.echo_info('No active clock')
   end
@@ -73,6 +84,7 @@ function Clock:org_clock_cancel()
 end
 
 function Clock:org_clock_goto()
+  self:update_clocked_headline()
   if not self.clocked_headline then
     return utils.echo_info('No active or recent clock task')
   end
@@ -100,6 +112,7 @@ function Clock:org_set_effort()
 end
 
 function Clock:get_statusline()
+  self:update_clocked_headline()
   if not self.clocked_headline or not self.clocked_headline:is_clocked_in() then
     return ''
   end

--- a/tests/plenary/clock/init_spec.lua
+++ b/tests/plenary/clock/init_spec.lua
@@ -1,0 +1,55 @@
+local OrgFiles = require('orgmode.files')
+local OrgFile = require('orgmode.files.file')
+local Files = require('orgmode.parser.files')
+local org = require('orgmode')
+
+describe('Clock', function()
+  ---@return OrgFile
+  local load_file_sync = function(content, filename)
+    content = content or {}
+    filename = filename or vim.fn.tempname() .. '.org'
+    vim.fn.writefile(content, filename)
+    return OrgFile.load(filename):wait()
+  end
+
+  it('should properly close out an existing clock when clocking in a new headline', function()
+    local file = load_file_sync({
+      '* TODO Test 1',
+      '  :LOGBOOK:',
+      '  CLOCK: [2024-05-22 Wed 05:15]',
+      '  :END:',
+      '* TODO Test 2',
+    })
+
+    vim.cmd('edit ' .. file.filename)
+
+    Files.file_loader = OrgFiles:new({
+      paths = { file.filename },
+    })
+    local files = Files.loader()
+    files:add_to_paths(file.filename):wait()
+
+    -- Establish baseline: Test 1 is clocked in
+    local clock = org.clock:new({ files = files })
+    assert.are.same('Test 1', clock.clocked_headline:get_title())
+    assert.is_true(clock.clocked_headline:is_clocked_in())
+
+    -- Move the test 2 header above test 1 and then clock test 2 in
+    vim.fn.cursor({ 5, 1 })
+    vim.cmd('normal! dd')
+    vim.fn.cursor({ 1, 1 })
+    vim.cmd('normal! P')
+    vim.fn.cursor({ 1, 1 })
+    clock:org_clock_in():wait()
+    file:reload():wait()
+
+    -- Test 2 is properly clocked in
+    assert.are.same('Test 2', clock.clocked_headline:get_title())
+    assert.are.same('Test 2', file:get_headlines()[1]:get_title())
+    assert.is_true(file:get_headlines()[1]:is_clocked_in())
+
+    -- Test 1 is properly clocked out
+    assert.are.same('Test 1', file:get_headlines()[2]:get_title())
+    assert.is_false(file:get_headlines()[2]:is_clocked_in())
+  end)
+end)


### PR DESCRIPTION
Hi all! Thanks for the development of such a useful tool! I've been a happy user of nvim-orgmode for quite some time now.

I use the clocking functionality frequently in nvim-orgmode, as I've written a custom plugin for exporting the clock reports as timesheets for my work. I noticed that after a substantial refactor change for nvim-orgmode got merged into master, I would frequently experience file corruption when trying to clock in a new header. I figured out after some experimentation that this was happening whenever I was editing a file such that the currently clocked in header moved positions in the buffer.mIt looks like the currently clocked-in header is stored in memory, but for certain conditions the actual position of the header would get out of sync (e.g., if I moved another header above the currently clocked-in one). 

This was a pretty significant issue for my workflow, so I went ahead and patched it locally and put together a unit test case which exercises the issue. My fix for this issue was to force a reload of the relevant files when performing clock-in or clock-out to ensure the right header position was used.

You can apply just the first commit of the test case and see the test fail against master, then apply the fix and see the test pass.

I'm happy to follow up with requests for changes or feedback if necessary. Thanks!