### PR TITLE
Add dynamic query for coloring n-depth headlines

### DIFF
--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -399,6 +399,17 @@ function Config:setup_ts_predicates()
     end
     metadata['injection.language'] = utils.detect_filetype(text)
   end, { force = true })
+
+  vim.treesitter.query.add_predicate('org-is-headline-level?', function(match, _, _, predicate)
+    ---@type TSNode
+    local node = match[predicate[2]]
+    local level = tonumber(predicate[3])
+    if not node then
+      return false
+    end
+    local _, _, _, node_end_col = node:range()
+    return ((node_end_col - 1) % 8) + 1 == level
+  end, { force = true })
 end
 
 ---@param content table

--- a/queries/org/highlights.scm
+++ b/queries/org/highlights.scm
@@ -1,14 +1,14 @@
 (timestamp "<") @org.timestamp.active
 (timestamp "[") @org.timestamp.inactive
-(headline (stars) @stars (#eq? @stars "*")) @org.headline.level1
-(headline (stars) @stars (#eq? @stars "**")) @org.headline.level2
-(headline (stars) @stars (#eq? @stars "***")) @org.headline.level3
-(headline (stars) @stars (#eq? @stars "****")) @org.headline.level4
-(headline (stars) @stars (#eq? @stars "*****")) @org.headline.level5
-(headline (stars) @stars (#eq? @stars "******")) @org.headline.level6
-(headline (stars) @stars (#eq? @stars "*******")) @org.headline.level7
-(headline (stars) @stars (#eq? @stars "********")) @org.headline.level8
 (headline (item) @spell)
+(headline (stars) @stars (#org-is-headline-level? @stars "1")) @org.headline.level1
+(headline (stars) @stars (#org-is-headline-level? @stars "2")) @org.headline.level2
+(headline (stars) @stars (#org-is-headline-level? @stars "3")) @org.headline.level3
+(headline (stars) @stars (#org-is-headline-level? @stars "4")) @org.headline.level4
+(headline (stars) @stars (#org-is-headline-level? @stars "5")) @org.headline.level5
+(headline (stars) @stars (#org-is-headline-level? @stars "6")) @org.headline.level6
+(headline (stars) @stars (#org-is-headline-level? @stars "7")) @org.headline.level7
+(headline (stars) @stars (#org-is-headline-level? @stars "8")) @org.headline.level8
 (item . (expr) @org.keyword.todo @nospell (#org-is-todo-keyword? @org.keyword.todo "TODO"))
 (item . (expr) @org.keyword.done @nospell (#org-is-todo-keyword? @org.keyword.done "DONE"))
 (item (expr "[" "#" "str" @_priority "]") @org.priority.highest (#org-is-valid-priority? @_priority "highest"))


### PR DESCRIPTION
rather than define queries for set n=8 depth headlines, set autocommand that searches for stars and uses length of stars text to determine depth using modulo operation to wrap for number of color groups (hardcoded still at 8, but would be nice to define any number of groups easily in the futur
![image](https://github.com/user-attachments/assets/f9a0caae-fac8-4665-bd76-af229fb68330)
