### PR TITLE
fix: explicitly pass treesitter language to `get_node()`

### DIFF
--- a/lua/orgmode/colors/highlighter/stars.lua
+++ b/lua/orgmode/colors/highlighter/stars.lua
@@ -22,6 +22,7 @@ function OrgStars:on_line(bufnr, line)
   local node = vim.treesitter.get_node({
     bufnr = bufnr,
     pos = { line, 0 },
+    lang = 'org',
   })
 
   if not node or node:type() ~= 'stars' then

--- a/lua/orgmode/ui/virtual_indent.lua
+++ b/lua/orgmode/ui/virtual_indent.lua
@@ -95,7 +95,7 @@ function VirtualIndent:set_indent(start_line, end_line, ignore_ts)
     start_line = start_line - 1
   end
 
-  local node_at_cursor = vim.treesitter.get_node()
+  local node_at_cursor = vim.treesitter.get_node({ lang = 'org' })
   local tree_has_errors = false
   if node_at_cursor then
     tree_has_errors = node_at_cursor:tree():root():has_error()

--- a/lua/orgmode/utils/treesitter/init.lua
+++ b/lua/orgmode/utils/treesitter/init.lua
@@ -6,7 +6,7 @@ local query_cache = {}
 function M.restart_highlights(bufnr)
   bufnr = bufnr or 0
   vim.treesitter.stop(bufnr)
-  vim.treesitter.start(bufnr)
+  vim.treesitter.start(bufnr, 'org')
 end
 
 function M.parse_current_file()
@@ -18,12 +18,13 @@ end
 function M.get_node_at_cursor(cursor)
   M.parse_current_file()
   if not cursor then
-    return vim.treesitter.get_node()
+    return vim.treesitter.get_node({ lang = 'org' })
   end
 
   return vim.treesitter.get_node({
     bufnr = 0,
     pos = { cursor[1] - 1, cursor[2] },
+    lang = 'org',
   })
 end
 


### PR DESCRIPTION
Fixes chipsenkbeil/org-roam.nvim#49

Org-roam offers a "node buffer", a sidebar that shows information such as backlinks from other locations to the current headline/file. The node buffer allows previewing the location of such a backlink. This inserts orgmode syntax into a buffer with filetype `org-roam-node-buffer`.

If virtual indent is enabled, it'll attempt to deduce the virtual indent of the preview. This in turn calls `closest_headline_node()`, which in turn calls `get_node_at_cursor`, which in turn calls `vim.treesitter.get_node()`.

If `get_node()` is called without an explicit treesitter language, it'll attempt to deduce that language from the filetype. The filetype `org-roam-node-buffer` isn't associated with the `org` language (and I don't think it *should*), so this call fails.

This fixes the issue by explicitly passing `{ lang = 'org' }` in all instances where the language *may* be deduced. I think this is acceptable because if someone calls
`orgmode.utils.treesitter.get_node()` AFAIK is only ever called on text that is org syntax.

While making this change, I grepped for other treesitter calls with an optional language argument. Where I found them, I passed it explicitly as well. AFAICT, this is only `Stars:on_line()` and `ts_utils.restart_highlighting()`.