### PR TITLE
feat(links)!: Use refactor links structure

### DIFF
--- a/lua/orgmode/api/file.lua
+++ b/lua/orgmode/api/file.lua
@@ -1,6 +1,5 @@
 ---@diagnostic disable: invisible
 local OrgHeadline = require('orgmode.api.headline')
-local Hyperlinks = require('orgmode.org.hyperlinks')
 local org = require('orgmode')
 
 ---@class OrgApiFile
@@ -112,12 +111,12 @@ function OrgFile:get_link()
     -- do remote edit
     return org.files
       :update_file(filename, function(file)
-        return Hyperlinks.get_link_to_file(file)
+        return org.links:get_link_to_file(file)
       end)
       :wait()
   end
 
-  return Hyperlinks.get_link_to_file(self._file)
+  return org.links:get_link_to_file(self._file)
 end
 
 return OrgFile

--- a/lua/orgmode/api/headline.lua
+++ b/lua/orgmode/api/headline.lua
@@ -4,7 +4,6 @@ local PriorityState = require('orgmode.objects.priority_state')
 local Date = require('orgmode.objects.date')
 local Calendar = require('orgmode.objects.calendar')
 local Promise = require('orgmode.utils.promise')
-local Hyperlinks = require('orgmode.org.hyperlinks')
 local org = require('orgmode')
 
 ---@class OrgApiHeadline
@@ -281,12 +280,12 @@ function OrgHeadline:get_link()
     -- do remote edit
     return org.files
       :update_file(filename, function(_)
-        return Hyperlinks.get_link_to_headline(self._section)
+        return org.links:get_link_to_headline(self._section)
       end)
       :wait()
   end
 
-  return Hyperlinks.get_link_to_headline(self._section)
+  return org.links:get_link_to_headline(self._section)
 end
 
 return OrgHeadline

--- a/lua/orgmode/api/init.lua
+++ b/lua/orgmode/api/init.lua
@@ -1,7 +1,6 @@
 ---@diagnostic disable: invisible
 local OrgFile = require('orgmode.api.file')
 local OrgHeadline = require('orgmode.api.headline')
-local Hyperlinks = require('orgmode.org.hyperlinks')
 local orgmode = require('orgmode')
 
 ---@class OrgApiRefileOpts
@@ -110,7 +109,8 @@ end
 --- @param link_location string
 --- @return boolean
 function OrgApi.insert_link(link_location)
-  Hyperlinks.insert_link(link_location)
+  orgmode.links:insert_link(link_location)
+  return true
 end
 
 return OrgApi

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -5,7 +5,7 @@ local Headline = require('orgmode.files.headline')
 local ts = vim.treesitter
 local config = require('orgmode.config')
 local Block = require('orgmode.files.elements.block')
-local Link = require('orgmode.org.hyperlinks.link')
+local Hyperlink = require('orgmode.org.links.hyperlink')
 local Range = require('orgmode.files.elements.range')
 local Memoize = require('orgmode.utils.memoize')
 
@@ -722,7 +722,7 @@ function OrgFile:get_archive_file_location()
 end
 
 memoize('get_links')
----@return OrgLink[]
+---@return OrgHyperlink[]
 function OrgFile:get_links()
   self:parse(true)
   local ts_query = ts_utils.get_query([[
@@ -736,7 +736,7 @@ function OrgFile:get_links()
   for _, match in ts_query:iter_captures(self.root, self:_get_source()) do
     local line = match:start()
     if not processed_lines[line] then
-      vim.list_extend(links, Link.all_from_line(self.lines[line + 1], line + 1))
+      vim.list_extend(links, Hyperlink.all_from_line(self.lines[line + 1], line + 1))
       processed_lines[line] = true
     end
   end

--- a/lua/orgmode/org/autocompletion/sources/hyperlinks.lua
+++ b/lua/orgmode/org/autocompletion/sources/hyperlinks.lua
@@ -1,5 +1,3 @@
-local Hyperlinks = require('orgmode.org.hyperlinks')
-local Link = require('orgmode.org.hyperlinks.link')
 ---@class OrgCompletionHyperlinks:OrgCompletionSource
 ---@field completion OrgCompletion
 ---@field private pattern vim.regex
@@ -24,11 +22,10 @@ function OrgCompletionHyperlinks:get_start(context)
   return self.pattern:match_str(context.line)
 end
 
+---@param context OrgCompletionContext
 ---@return string[]
 function OrgCompletionHyperlinks:get_results(context)
-  local link = Link:new(context.base)
-  local result, mapper = Hyperlinks.find_matching_links(link.url)
-  return mapper(result)
+  return self.completion.links:autocomplete(context.base)
 end
 
 return OrgCompletionHyperlinks

--- a/lua/orgmode/org/links/types/headline_search.lua
+++ b/lua/orgmode/org/links/types/headline_search.lua
@@ -31,6 +31,10 @@ function OrgLinkHeadlineSearch:follow(link)
   local file = self.files:load_file_sync(opts.file_path)
 
   if file then
+    if opts.type == 'file' and not opts.target then
+      return link_utils.goto_file(file)
+    end
+
     local pattern = ('<<<?(%s[^>]*)>>>?'):format(opts.headline_text):lower()
     local headlines = file:find_headlines_matching_search_term(pattern, true)
     if #headlines == 0 then

--- a/lua/orgmode/org/links/types/headline_search.lua
+++ b/lua/orgmode/org/links/types/headline_search.lua
@@ -29,9 +29,10 @@ function OrgLinkHeadlineSearch:follow(link)
   end
 
   local file = self.files:load_file_sync(opts.file_path)
+  local is_file_only = opts.type == 'file' and not opts.target
 
   if file then
-    if opts.type == 'file' and not opts.target then
+    if is_file_only then
       return link_utils.goto_file(file)
     end
 
@@ -48,7 +49,13 @@ function OrgLinkHeadlineSearch:follow(link)
     )
   end
 
-  return link_utils.open_file_and_search(opts.file_path, opts.headline_text)
+  local search_text = opts.headline_text
+
+  if is_file_only then
+    search_text = ''
+  end
+
+  return link_utils.open_file_and_search(opts.file_path, search_text)
 end
 
 ---@param link string

--- a/lua/orgmode/org/links/utils.lua
+++ b/lua/orgmode/org/links/utils.lua
@@ -59,7 +59,7 @@ function link_utils.goto_oneof_headlines(headlines, file_path, error_message)
 end
 
 ---@param file_path string
----@param search_text string
+---@param search_text string | nil
 ---@return boolean
 function link_utils.open_file_and_search(file_path, search_text)
   if not file_path or file_path == '' then
@@ -68,6 +68,11 @@ function link_utils.open_file_and_search(file_path, search_text)
   if file_path ~= utils.current_file_path() then
     vim.cmd(('edit %s'):format(file_path))
   end
+
+  if not search_text or search_text == '' then
+    return true
+  end
+
   local result = vim.fn.search(search_text, 'W')
   if result == 0 then
     utils.echo_warning(string.format('No match found for expression: %s', search_text))

--- a/tests/plenary/ui/mappings/hyperlink_spec.lua
+++ b/tests/plenary/ui/mappings/hyperlink_spec.lua
@@ -109,8 +109,6 @@ describe('Hyperlink mappings', function()
   end)
 
   it('should store link to a headline with id', function()
-    ---@diagnostic disable-next-line: invisible
-    require('orgmode').links.stored_links = {}
     local org = require('orgmode').setup({
       org_id_link_to_org_use_id = true,
     })
@@ -125,6 +123,8 @@ describe('Hyperlink mappings', function()
     })
 
     org:init()
+    ---@diagnostic disable-next-line: invisible
+    require('orgmode').links.stored_links = {}
     vim.fn.cursor(4, 10)
     vim.cmd([[norm ,ols]])
     ---@diagnostic disable-next-line: invisible

--- a/tests/plenary/ui/mappings/hyperlink_spec.lua
+++ b/tests/plenary/ui/mappings/hyperlink_spec.lua
@@ -104,11 +104,13 @@ describe('Hyperlink mappings', function()
     vim.cmd([[norm ,ols]])
     assert.are.same({
       [('file:%s::*headline of target id'):format(target_file.filename)] = 'headline of target id',
-    }, require('orgmode.org.hyperlinks').stored_links)
+      ---@diagnostic disable-next-line: invisible
+    }, require('orgmode').links.stored_links)
   end)
 
   it('should store link to a headline with id', function()
-    require('orgmode.org.hyperlinks').stored_links = {}
+    ---@diagnostic disable-next-line: invisible
+    require('orgmode').links.stored_links = {}
     local org = require('orgmode').setup({
       org_id_link_to_org_use_id = true,
     })
@@ -125,7 +127,8 @@ describe('Hyperlink mappings', function()
     org:init()
     vim.fn.cursor(4, 10)
     vim.cmd([[norm ,ols]])
-    local stored_links = require('orgmode.org.hyperlinks').stored_links
+    ---@diagnostic disable-next-line: invisible
+    local stored_links = require('orgmode').links.stored_links
     local keys = vim.tbl_keys(stored_links)
     local values = vim.tbl_values(stored_links)
     assert.is.True(keys[1]:match('^id:' .. OrgId.uuid_pattern .. '.*$') ~= nil)
@@ -201,40 +204,6 @@ describe('Hyperlink mappings', function()
     local url = target_file.filename:gsub(dir, '.')
     helpers.create_file({
       string.format('This [[%s::11][link]] should bring us to the 11th line.', url),
-    })
-    vim.cmd([[norm w]])
-    vim.fn.cursor(1, 10)
-    vim.cmd([[norm ,oo]])
-    assert.is.same(' --> eleven <--', vim.api.nvim_get_current_line())
-  end)
-
-  it('should follow link to certain line (nvim-orgmode compatibility)', function()
-    local target_file = helpers.create_file({
-      '* Test hyperlink',
-      '  - some',
-      '  - boiler',
-      '  - plate',
-      '** some headline',
-      '   - more',
-      '   - boiler',
-      '   - plate',
-      ' ->   9',
-      ' ->  10',
-      ' --> eleven <--',
-      ' ->  12',
-      ' ->  13',
-      ' ->  14',
-      ' ->  15 <--',
-    })
-    vim.cmd([[norm w]])
-    assert.is.truthy(target_file)
-    if not target_file then
-      return
-    end
-    local dir = vim.fs.dirname(target_file.filename)
-    local url = target_file.filename:gsub(dir, '.')
-    helpers.create_file({
-      string.format('This [[%s +11][link]] should bring us to the 11th line.', url),
     })
     vim.cmd([[norm w]])
     vim.fn.cursor(1, 10)


### PR DESCRIPTION
Start using new links structure introduced in https://github.com/nvim-orgmode/orgmode/pull/802.

@chipsenkbeil can you check if using this branch breaks anything in org-roam.nvim? It shouldn't, but it's best to double check.
You will need to introduce one change here: https://github.com/chipsenkbeil/org-roam.nvim/blob/192732a8de167e7770b12db31e737239311b1a43/lua/org-roam/setup/plugin.lua?plain=1#L20

I added a hyperlink class in https://github.com/nvim-orgmode/orgmode/blob/71c57cab31b78d2c6907d2961b6c2666ea9383a1/lua/orgmode/org/links/hyperlink.lua?plain=1#L8, and it works basically the same for your usage. Underlining `url` prop is also a different class, but it has the `get_id` method that you are using.

For this line you can use `Hyperlink.at_cursor` function instead of these 3 lines to get current link.

Besides this I think everything should be working as expected, but please give it a thorough test. 


@seflue @SlayerOfTheBad could you switch to this branch and see if everything related to hyperlinks works as expected? 

Thanks!
