### PR TITLE
fix: fix autocomplete for tags search prompt

### DIFF
--- a/lua/orgmode/agenda/views/tags.lua
+++ b/lua/orgmode/agenda/views/tags.lua
@@ -35,7 +35,7 @@ end
 
 function AgendaTagsView:build()
   local tags = vim.fn.OrgmodeInput('Match: ', self.search, function(arg_lead)
-    utils.prompt_autocomplete(arg_lead, self.files:get_tags())
+    return utils.prompt_autocomplete(arg_lead, self.files:get_tags())
   end)
   if vim.trim(tags) == '' then
     return utils.echo_warning('Invalid tag.')


### PR DESCRIPTION
`<leader>oa` + `m` - Match a TAGS/PROP/TODO query prompt autocomplete isn't working on `<tab>`.