### PR TITLE
feat(refile): improve ux by matching files more fuzzily

### DIFF
--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -408,19 +408,17 @@ end
 ---@param arg_lead string
 ---@return string[]
 function Capture:autocomplete_refile(arg_lead)
-  local valid_filenames = self:_get_autocompletion_files(true)
+  local valid_files = self:_get_autocompletion_files(true)
 
-  if not arg_lead then
-    return vim.tbl_keys(valid_filenames)
+  if not arg_lead or #arg_lead == 0 then
+    return vim.tbl_keys(valid_files)
   end
-  local parts = vim.split(arg_lead, '/', { plain = true })
 
-  local selected_file = valid_filenames[parts[1] .. '/']
+  local filename = vim.split(arg_lead, '/', { plain = true })[1]
+  local selected_file = valid_files[filename .. '/']
 
   if not selected_file then
-    return vim.tbl_filter(function(file)
-      return file:match('^' .. vim.pesc(parts[1]))
-    end, vim.tbl_keys(valid_filenames))
+    return vim.fn.matchfuzzy(vim.tbl_keys(valid_files), filename)
   end
 
   local headlines = selected_file:get_opened_unfinished_headlines()


### PR DESCRIPTION
Hi, I really like this project!

I'm using the org-roam plugin, and it will prefix every file with the current timestamp to make sure it's unique (e.g. `20241013095846-helloworld.org`).
Refiling to such files is really inconvenient as I need to circle through all filenames with the TAB key.
Searching for it is really cumbersome as I'd have to type in the exact timestamp of this orgfile.

My suggestion is to remove the anchor (`^`) from the file pattern matching, and allow the search string to be anywhere in the filename.
This way I can just type `hello` or even `world` to quickly select the refile target.