### PR TITLE
fix: allow query to tags agenda api

### DIFF
--- a/lua/orgmode/agenda/views/tags.lua
+++ b/lua/orgmode/agenda/views/tags.lua
@@ -22,6 +22,7 @@ function AgendaTagsView:new(opts)
     highlights = {},
     items = {},
     search = opts.search or '',
+    query = opts.query or '',
     todo_only = opts.todo_only or false,
     filters = opts.filters or AgendaFilter:new(),
     header = opts.org_agenda_overriding_header,
@@ -34,9 +35,15 @@ function AgendaTagsView:new(opts)
 end
 
 function AgendaTagsView:build()
-  local tags = vim.fn.OrgmodeInput('Match: ', self.search, function(arg_lead)
-    return utils.prompt_autocomplete(arg_lead, self.files:get_tags())
-  end)
+  local tags
+  -- Ugly fix until https://github.com/nvim-orgmode/orgmode/issues/483 is fixed
+  if self.query ~= '' then
+    tags = self.query
+  else
+    tags = vim.fn.OrgmodeInput('Match: ', self.search, function(arg_lead)
+      return utils.prompt_autocomplete(arg_lead, self.files:get_tags())
+    end)
+  end
   if vim.trim(tags) == '' then
     return utils.echo_warning('Invalid tag.')
   end

--- a/lua/orgmode/api/agenda.lua
+++ b/lua/orgmode/api/agenda.lua
@@ -60,9 +60,13 @@ function OrgAgenda.tags(options)
   if options.filters and options.filters ~= '' then
     orgmode.agenda.filters:parse(options.filters, true)
   end
-  orgmode.agenda:tags({
-    todo_only = options.todo_only,
-  })
+  -- Ugly fix until https://github.com/nvim-orgmode/orgmode/issues/483 is fixed
+  options.todo_only = true
+  options.query = options.query or ''
+  orgmode.agenda:tags(options)
+  -- orgmode.agenda:tags({
+  --   todo_only = options.todo_only,
+  -- })
 end
 
 return OrgAgenda


### PR DESCRIPTION
This is as far as I've gotten debugging https://github.com/nvim-orgmode/orgmode/issues/483 

As you can see my lua skills are awful, but after playing **a lot** with `options.filters` and `options.search` the only way the agenda works is if I don't touch any of those properties (I have no clue why)

The issue is that before this ugly patch if you run `require("orgmode.api.agenda").tags({ query = "+t/-DONE" })` the agenda returns no results because the query is disregarded and the user is prompted for the query as if you were to open the agenda yourself.

I know that this code is not ready for production, but maybe someone will pity me and lend me a hand (•‿•) . Or at least users may use my fork until this is solved to get the functionality