### PR TITLE
feat(log-state): align with the emacs orgmode format

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -460,10 +460,10 @@ function OrgMappings:_todo_change_state(direction)
 
   local prompt_repeat_note = config.org_log_repeat == 'note'
   local log_repeat_enabled = config.org_log_repeat ~= false
-  local repeat_note_template = ('%s- State "%s" from "%s" [%s]'):format(
+  local repeat_note_template = ('%s- State %-12s from %-12s [%s]'):format(
     indent,
-    new_todo,
-    old_state,
+    [["]] .. new_todo .. [["]],
+    [["]] .. old_state .. [["]],
     Date.now():to_string()
   )
   local repeat_note_title = ('Insert note for state change from "%s" to "%s"'):format(old_state, new_todo)

--- a/tests/plenary/ui/mappings/todo_spec.lua
+++ b/tests/plenary/ui/mappings/todo_spec.lua
@@ -69,7 +69,7 @@ describe('Todo mappings', function()
       '  :PROPERTIES:',
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
-      '  - State "DONE" from "TODO" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "TODO"       [' .. now:to_string() .. ']',
       '',
       '* TODO Another task',
     }, vim.api.nvim_buf_get_lines(0, 2, 10, false))
@@ -137,7 +137,7 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "TODO" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "TODO"       [' .. now:to_string() .. ']',
       '  :END:',
       '',
       '* TODO Another task',
@@ -154,8 +154,8 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "TODO" [' .. now:to_string() .. ']',
-      '  - State "DONE" from "TODO" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "TODO"       [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "TODO"       [' .. now:to_string() .. ']',
       '  :END:',
       '',
       '* TODO Another task',
@@ -282,7 +282,7 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "PHONECALL" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "PHONECALL"  [' .. now:to_string() .. ']',
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 2, 11, false))
   end)
@@ -318,7 +318,7 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "MEET" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "MEET"       [' .. now:to_string() .. ']',
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 2, 10, false))
   end)
@@ -361,7 +361,7 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "MEET" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "MEET"       [' .. now:to_string() .. ']',
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 2, 11, false))
   end)
@@ -404,7 +404,7 @@ describe('Todo mappings', function()
       '  :LAST_REPEAT: [' .. now:to_string() .. ']',
       '  :END:',
       '  :LOGBOOK:',
-      '  - State "DONE" from "MEET" [' .. now:to_string() .. ']',
+      '  - State "DONE"       from "MEET"       [' .. now:to_string() .. ']',
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 2, 11, false))
   end)


### PR DESCRIPTION
In emacs orgmode, the `org-log-note-headings` is defined as follows:

```lisp
(defcustom org-log-note-headings
  '((done .  "CLOSING NOTE %t")
    (state . "State %-12s from %-12S %t")
    (note .  "Note taken on %t")
    (reschedule .  "Rescheduled from %S on %t")
    (delschedule .  "Not scheduled, was %S on %t")
    (redeadline .  "New deadline from %S on %t")
    (deldeadline .  "Removed deadline, was %S on %t")
    (refile . "Refiled on %t")
    (clock-out . ""))
  "Headings for notes added to entries.

```

This commit changes the log state format so that it is aligned with emacs orgmode.