### PR TITLE
fix: retain direct tags even if they are excluded from inheritance

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -556,9 +556,10 @@ function Headline:get_tags()
 
   local all_tags = utils.concat({}, file_tags)
   utils.concat(all_tags, utils.reverse(parent_tags), true)
+  all_tags = config:exclude_tags(all_tags)
   utils.concat(all_tags, tags, true)
 
-  return config:exclude_tags(all_tags), own_tags_node
+  return all_tags, own_tags_node
 end
 
 ---@return OrgHeadline | nil


### PR DESCRIPTION
If a tag is excluded from inheritance, then it gets excluded even from headlines that have it assigned directly. This is most noticable when searching in agenda view. This PR fixes it - you can now search by tags that are excluded from inheritance.

Fixes #830