### PR TITLE
fix(help): ignore disabled mappings

### DIFF
--- a/lua/orgmode/objects/help.lua
+++ b/lua/orgmode/objects/help.lua
@@ -96,10 +96,16 @@ function Help._generate_mappings(buffer_type, title)
       maps = table.concat(maps, ', ')
     end
 
+    if type(maps) == 'boolean' and not maps then
+      goto continue
+    end
+
     table.insert(
       content,
       string.format('  `%-12s` - %s', string.gsub(maps, '<prefix>', mappings.prefix), item.description)
     )
+
+    ::continue::
   end
   table.insert(content, '')
   return content


### PR DESCRIPTION
Hey :wave:

I have disabled a few keymaps in my config following [docs](https://github.com/nvim-orgmode/orgmode/blob/master/DOCS.md#mappings), and when I opened the help menu(`g?`), it was failing to open due to disabled keymaps.

