### PR TITLE
fix(template): expandable variables in lua expr

### DIFF
--- a/lua/orgmode/capture/template/init.lua
+++ b/lua/orgmode/capture/template/init.lua
@@ -250,7 +250,6 @@ end
 ---@return OrgPromise<string | nil>
 function Template:_compile(content, content_type)
   content = self:_compile_dates(content)
-  content = self:_compile_expressions(content)
   if self._compile_hooks then
     for _, hook in ipairs(self._compile_hooks) do
       content = hook(content, content_type) --[[@as string]]
@@ -267,6 +266,7 @@ function Template:_compile(content, content_type)
       if not cnt then
         return nil
       end
+      cnt = self:_compile_expressions(cnt)
       return self:_compile_prompts(cnt)
     end)
   end)


### PR DESCRIPTION
This fixes the order which the template is compiled. Previously, the expressions `%()` were compiled _before_ expandable variables (such as `%x`). This made the example template in [1] to produce:
```org
* [[url][x]]
```
instead of
```org
* [[url][end part of the url]]
```
By doing the expression compilation _after_ expandable ones, this issue is resolved.

[1] https://github.com/nvim-orgmode/orgmode/wiki/Getting-Started#captures