### PR TITLE
feat(agenda): Add custom agenda commands

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -506,8 +506,18 @@ Determine on which day the week will start in calendar modal (ex: [changing the 
 #### **emacs_config**
 
 _type_: `table`<br />
-_default value_: `{ executable_path = 'emacs', config_path='$HOME/.emacs.d/init.el' }`<br />
+_default value_: `{ executable_path = 'emacs', config_path=nil }`<br />
 Set configuration for your emacs. This is useful for having the emacs export properly pickup your emacs config and plugins.
+If `config_path` is not provided, exporter tries to find a configuration file from these locations:
+
+1. `~/.config/emacs/init.el`
+2. `~/.emacs.d/init.el`
+3. `~/.emacs.el`
+
+If there is no configuration found, it will still process the export.
+
+If it finds a configuration and export attempt fails because of the configuration issue, there will be a prompt to
+attempt the same export without the configuration file.
 
 ### Agenda settings
 
@@ -547,6 +557,107 @@ offset to apply to the agenda start date.<br />
 Example:<br />
 If `org_agenda_start_on_weekday` is `false`, and `org_agenda_start_day` is `-2d`,<br />
 agenda will always show current week from today - 2 days
+
+#### **org_agenda_custom_commands**
+
+_type_: `table<string, OrgAgendaCustomCommand>`<br />
+_default value_: `{}`<br />
+
+Define custom agenda views that are available through the (org_agenda)[#org_agenda] mapping.
+It is possible to combine multiple agenda types into single view.
+An example:
+
+```lua
+require('orgmode').setup({
+  org_agenda_files = {'~/org/**/*'},
+  org_agenda_custom_commands = {
+    -- "c" is the shortcut that will be used in the prompt
+    c = {
+      description = 'Combined view', -- Description shown in the prompt for the shortcut
+      types = {
+        {
+          type = 'tags_todo', -- Type can be agenda | tags | tags_todo
+          match = '+PRIORITY="A"', --Same as providing a "Match:" for tags view <leader>oa + m, See: https://orgmode.org/manual/Matching-tags-and-properties.html
+          org_agenda_overriding_header = 'High priority todos',
+          org_agenda_todo_ignore_deadlines = 'far', -- Ignore all deadlines that are too far in future (over org_deadline_warning_days). Possible values: all | near | far | past | future
+        },
+        {
+          type = 'agenda',
+          org_agenda_overriding_header = 'My daily agenda',
+          org_agenda_span = 'day' -- can be any value as org_agenda_span
+        },
+        {
+          type = 'tags',
+          match = 'WORK', --Same as providing a "Match:" for tags view <leader>oa + m, See: https://orgmode.org/manual/Matching-tags-and-properties.html
+          org_agenda_overriding_header = 'My work todos',
+          org_agenda_todo_ignore_scheduled = 'all', -- Ignore all headlines that are scheduled. Possible values: past | future | all
+        },
+        {
+          type = 'agenda',
+          org_agenda_overriding_header = 'Whole week overview',
+          org_agenda_span = 'week', -- 'week' is default, so it's not necessary here, just an example
+          org_agenda_start_on_weekday = 1 -- Start on Monday
+          org_agenda_remove_tags = true -- Do not show tags only for this view
+        },
+      }
+    },
+    p = {
+      description = 'Personal agenda',
+      types = {
+        {
+          type = 'tags_todo',
+          org_agenda_overriding_header = 'My personal todos',
+          org_agenda_category_filter_preset = 'todos', -- Show only headlines from `todos` category. Same value providad as when pressing `/` in the Agenda view
+          org_agenda_sorting_strategy = {'todo-state-up', 'priority-down'} -- See all options available on org_agenda_sorting_strategy
+        },
+        {
+          type = 'agenda',
+          org_agenda_overriding_header = 'Personal projects agenda',
+          org_agenda_files = {'~/my-projects/**/*'}, -- Can define files outside of the default org_agenda_files
+        },
+        {
+          type = 'tags',
+          org_agenda_overriding_header = 'Personal projects notes',
+          org_agenda_files = {'~/my-projects/**/*'},
+          org_agenda_tag_filter_preset = 'NOTES-REFACTOR' -- Show only headlines with NOTES tag that does not have a REFACTOR tag. Same value providad as when pressing `/` in the Agenda view
+        },
+      }
+    }
+  }
+})
+```
+
+#### **org_agenda_sorting_strategy**
+_type_: `table<'agenda' | 'todo' | 'tags', OrgAgendaSortingStrategy[]><`<br />
+default value: `{ agenda = {'time-up', 'priority-down', 'category-keep'}, todo = {'priority-down', 'category-keep'}, tags = {'priority-down', 'category-keep'}}`<br />
+List of sorting strategies to apply to a given view.
+Available strategies:
+
+- `time-up` - Sort entries by time of day. Applicable only in `agenda` view
+- `time-down` - Opposite of `time-up`
+- `priority-down` - Sort by priority, from highest to lowest
+- `priority-up` - Sort by priority, from lowest to highest
+- `tag-up` - Sort by sorted tags string, ascending
+- `tag-down` - Sort by sorted tags string, descending
+- `todo-state-up` - Sort by todo keyword by position (example: 'TODO, PROGRESS, DONE' has a sort value of 1, 2 and 3), ascending
+- `todo-state-down` - Sort by todo keyword, descending
+- `clocked-up` - Show clocked in headlines first
+- `clocked-down` - Show clocked in headines last
+- `category-up` - Sort by category name, ascending
+- `category-down` - Sort by category name, descending
+- `category-keep` - Keep default category sorting, as it appears in org-agenda-files
+
+
+#### **org_agenda_block_separator**
+_type_: `string`<br />
+default value: `-`<br />
+Separator used to separate multiple agenda views generated by org_agenda_custom_commands.<br />
+To change the highlight, override `@org.agenda.separator` hl group.
+
+#### **org_agenda_remove_tags**
+_type_: `boolean`<br />
+default value: `false`<br />
+Should tags be hidden from all agenda views.
 
 #### **org_capture_templates**
 

--- a/lua/orgmode/agenda/agenda_item.lua
+++ b/lua/orgmode/agenda/agenda_item.lua
@@ -20,6 +20,7 @@ end
 ---@field is_in_date_range boolean
 ---@field date_range_days number
 ---@field label string
+---@field index number
 local AgendaItem = {}
 
 ---@param headline_date OrgDate single date in a headline

--- a/lua/orgmode/agenda/sorting_strategy.lua
+++ b/lua/orgmode/agenda/sorting_strategy.lua
@@ -1,0 +1,218 @@
+local utils = require('orgmode.utils')
+---@alias OrgAgendaSortingStrategy
+---| 'time-up'
+---| 'time-down'
+---| 'priority-down'
+---| 'priority-up'
+---| 'tag-up'
+---| 'tag-down'
+---| 'todo-state-up'
+---| 'todo-state-down'
+---| 'clocked-up'
+---| 'clocked-down'
+---| 'category-up'
+---| 'category-down'
+---| 'category-keep'
+local SortingStrategy = {}
+
+---@class SortableEntry
+---@field date OrgDate Available only in agenda view
+---@field headline OrgHeadline
+---@field index number Index of the entry in the fetched list
+---@field is_day_match? boolean Is this entry a match for the given day. Available only in agenda view
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.time_up(a, b)
+  if a.is_day_match and b.is_day_match then
+    if a.date:has_time() and b.date:has_time() then
+      if a.date.timestamp ~= b.date.timestamp then
+        return a.date.timestamp < b.date.timestamp
+      end
+      return
+    end
+  end
+  if a.is_day_match and a.date:has_time() then
+    return true
+  end
+
+  if b.is_day_match and b.date:has_time() then
+    return false
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.time_down(a, b)
+  local time_up = SortingStrategy.time_up(a, b)
+  if type(time_up) == 'boolean' then
+    return not time_up
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.priority_down(a, b)
+  if a.headline:get_priority_sort_value() ~= b.headline:get_priority_sort_value() then
+    return a.headline:get_priority_sort_value() > b.headline:get_priority_sort_value()
+  end
+  if a.date and b.date then
+    local is_same = a.date:is_same(b.date)
+    if not is_same then
+      return a.date:is_before(b.date)
+    end
+    if a.date.type ~= b.date.type then
+      return a.date:get_type_sort_value() < b.date:get_type_sort_value()
+    end
+  end
+end
+
+function SortingStrategy.priority_up(a, b)
+  local priority_down = SortingStrategy.priority_down(a, b)
+  if type(priority_down) == 'boolean' then
+    return not priority_down
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.tag_up(a, b)
+  local a_tags = a.headline:tags_to_string(true)
+  local b_tags = b.headline:tags_to_string(true)
+  if a_tags == '' and b_tags == '' then
+    return
+  end
+  if a_tags == b_tags then
+    return
+  end
+  if a_tags == '' then
+    return false
+  end
+  if b_tags == '' then
+    return true
+  end
+  return a_tags < b_tags
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.tag_down(a, b)
+  local tag_up = SortingStrategy.tag_up(a, b)
+  if type(tag_up) == 'boolean' then
+    return not tag_up
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.todo_state_up(a, b)
+  local _, _, _, a_index = a.headline:get_todo()
+  local _, _, _, b_index = b.headline:get_todo()
+  if a_index and b_index then
+    if a_index ~= b_index then
+      return a_index < b_index
+    end
+    return nil
+  end
+  if a_index then
+    return true
+  end
+  if b_index then
+    return false
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.todo_state_down(a, b)
+  local todo_state_up = SortingStrategy.todo_state_up(a, b)
+  if type(todo_state_up) == 'boolean' then
+    return not todo_state_up
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.category_up(a, b)
+  if a.headline.file:get_category() ~= b.headline.file:get_category() then
+    return a.headline.file:get_category() < b.headline.file:get_category()
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.category_down(a, b)
+  local category_up = SortingStrategy.category_up(a, b)
+  if type(category_up) == 'boolean' then
+    return not category_up
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.category_keep(a, b)
+  if a.headline.file.index ~= b.headline.file.index then
+    return a.headline.file.index < b.headline.file.index
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.clocked_up(a, b)
+  if a.headline:is_clocked_in() and not b.headline:is_clocked_in() then
+    return true
+  end
+  if not a.headline:is_clocked_in() and b.headline:is_clocked_in() then
+    return false
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+function SortingStrategy.clocked_down(a, b)
+  local clocked_up = SortingStrategy.clocked_up(a, b)
+  if type(clocked_up) == 'boolean' then
+    return not clocked_up
+  end
+end
+
+---@param a SortableEntry
+---@param b SortableEntry
+local fallback_sort = function(a, b)
+  if a.headline.file.index ~= b.headline.file.index then
+    return a.headline.file.index < b.headline.file.index
+  end
+
+  return a.index < b.index
+end
+
+---@generic T
+---@param items T[]
+---@param strategies OrgAgendaSortingStrategy[]
+---@param make_entry fun(item: T): SortableEntry
+local function sort(items, strategies, make_entry)
+  table.sort(items, function(a, b)
+    local entry_a = make_entry(a)
+    local entry_b = make_entry(b)
+
+    for _, fn in ipairs(strategies) do
+      local sorting_fn = SortingStrategy[fn:gsub('-', '_')]
+      if not sorting_fn then
+        utils.echo_error('Unknown sorting strategy: ' .. fn)
+        break
+      end
+      local result = sorting_fn(entry_a, entry_b)
+      if result ~= nil then
+        return result
+      end
+    end
+
+    return fallback_sort(entry_a, entry_b)
+  end)
+
+  return items
+end
+
+return {
+  sort = sort,
+}

--- a/lua/orgmode/agenda/types/search.lua
+++ b/lua/orgmode/agenda/types/search.lua
@@ -31,9 +31,9 @@ function OrgAgendaSearchType:get_search_term()
   return vim.fn.OrgmodeInput('Enter search term: ', self.headline_query or '')
 end
 
-function OrgAgendaSearchType:redo()
+function OrgAgendaSearchType:redraw()
   -- Skip prompt for custom views
-  if self.is_custom then
+  if self.id then
     return self
   end
   self.headline_query = self:get_search_term()

--- a/lua/orgmode/agenda/types/tags.lua
+++ b/lua/orgmode/agenda/types/tags.lua
@@ -1,21 +1,35 @@
 ---@diagnostic disable: inject-field
+local Date = require('orgmode.objects.date')
+local config = require('orgmode.config')
 local utils = require('orgmode.utils')
+local validator = require('orgmode.utils.validator')
 local Search = require('orgmode.files.elements.search')
 local OrgAgendaTodosType = require('orgmode.agenda.types.todo')
 
+---@alias OrgAgendaTodoIgnoreDeadlinesTypes 'all' | 'near' | 'far' | 'past' | 'future'
+---@alias OrgAgendaTodoIgnoreScheduledTypes 'all' | 'past' | 'future'
+
 ---@class OrgAgendaTagsTypeOpts:OrgAgendaTodosTypeOpts
 ---@field match_query? string
+---@field todo_ignore_deadlines OrgAgendaTodoIgnoreDeadlinesTypes
+---@field todo_ignore_scheduled OrgAgendaTodoIgnoreScheduledTypes
 
 ---@class OrgAgendaTagsType:OrgAgendaTodosType
+---@field match_query string
+---@field todo_ignore_deadlines OrgAgendaTodoIgnoreDeadlinesTypes
+---@field todo_ignore_scheduled OrgAgendaTodoIgnoreScheduledTypes
 local OrgAgendaTagsType = {}
 OrgAgendaTagsType.__index = OrgAgendaTagsType
 
 ---@param opts OrgAgendaTagsTypeOpts
 function OrgAgendaTagsType:new(opts)
   opts.todo_only = opts.todo_only or false
-  opts.subheader = 'Press "r" to update search'
+  opts.sorting_strategy = opts.sorting_strategy or vim.tbl_get(config.org_agenda_sorting_strategy, 'tags') or {}
+  if not opts.id then
+    opts.subheader = 'Press "r" to update search'
+  end
   local match_query = opts.match_query
-  if not match_query or match_query == '' then
+  if not opts.id and (not match_query or match_query == '') then
     match_query = self:get_tags(opts.files)
     if not match_query then
       return nil
@@ -25,13 +39,60 @@ function OrgAgendaTagsType:new(opts)
   setmetatable(self, { __index = OrgAgendaTodosType })
   local obj = OrgAgendaTodosType:new(opts)
   setmetatable(obj, self)
-  obj.match_query = match_query
+  obj.match_query = match_query or ''
+  obj.todo_ignore_deadlines = opts.todo_ignore_deadlines
+  obj.todo_ignore_scheduled = opts.todo_ignore_scheduled
   obj.header = 'Headlines with TAGS match: ' .. obj.match_query
   return obj
 end
 
 function OrgAgendaTagsType:get_file_headlines(file)
-  return file:apply_search(Search:new(self.match_query or ''), self.todo_only)
+  local headlines = file:apply_search(Search:new(self.match_query), self.todo_only)
+  if self.todo_ignore_deadlines then
+    headlines = vim.tbl_filter(function(headline) ---@cast headline OrgHeadline
+      local deadline_date = headline:get_deadline_date()
+      if not deadline_date then
+        return true
+      end
+      if self.todo_ignore_deadlines == 'all' then
+        return false
+      end
+      if self.todo_ignore_deadlines == 'near' then
+        local diff = deadline_date:diff(Date.now())
+        return diff > config.org_deadline_warning_days
+      end
+      if self.todo_ignore_deadlines == 'far' then
+        local diff = deadline_date:diff(Date.now())
+        return diff <= config.org_deadline_warning_days
+      end
+      if self.todo_ignore_deadlines == 'past' then
+        return not deadline_date:is_same_or_before(Date.today(), 'day')
+      end
+      if self.todo_ignore_deadlines == 'future' then
+        return not deadline_date:is_after(Date.today(), 'day')
+      end
+      return true
+    end, headlines)
+  end
+  if self.todo_ignore_scheduled then
+    headlines = vim.tbl_filter(function(headline) ---@cast headline OrgHeadline
+      local scheduled_date = headline:get_scheduled_date()
+      if not scheduled_date then
+        return true
+      end
+      if self.todo_ignore_scheduled == 'all' then
+        return false
+      end
+      if self.todo_ignore_scheduled == 'past' then
+        return scheduled_date:is_same_or_before(Date.today(), 'day')
+      end
+      if self.todo_ignore_scheduled == 'future' then
+        return scheduled_date:is_after(Date.today(), 'day')
+      end
+      return true
+    end, headlines)
+  end
+  return headlines
 end
 
 ---@param files? OrgFiles
@@ -45,9 +106,9 @@ function OrgAgendaTagsType:get_tags(files)
   return tags
 end
 
-function OrgAgendaTagsType:redo()
+function OrgAgendaTagsType:redraw()
   -- Skip prompt for custom views
-  if self.is_custom then
+  if self.id then
     return self
   end
   self.match_query = self:get_tags() or ''

--- a/lua/orgmode/agenda/view/init.lua
+++ b/lua/orgmode/agenda/view/init.lua
@@ -2,13 +2,14 @@ local colors = require('orgmode.colors')
 
 ---@class OrgAgendaView
 ---@field bufnr number
+---@field highlighter OrgHighlighter
 ---@field start_line number
 ---@field line_counter number
 ---@field lines OrgAgendaLine[]
 local OrgAgendaView = {}
 OrgAgendaView.__index = OrgAgendaView
 
----@param opts { bufnr: number }
+---@param opts { bufnr: number, highlighter: OrgHighlighter }
 ---@return OrgAgendaView
 function OrgAgendaView:new(opts)
   local line_nr = vim.api.nvim_buf_line_count(opts.bufnr)
@@ -19,6 +20,7 @@ function OrgAgendaView:new(opts)
   end
   return setmetatable({
     bufnr = opts.bufnr,
+    highlighter = opts.highlighter,
     start_line = line_nr,
     end_line = line_nr,
     lines = {},
@@ -29,6 +31,7 @@ end
 function OrgAgendaView:add_line(line)
   line.line_nr = self.end_line
   line.view = self
+  line.highlighter = self.highlighter
   table.insert(self.lines, line)
   self.end_line = self.end_line + 1
 end
@@ -45,6 +48,7 @@ end
 function OrgAgendaView:replace_line(old_line, new_line)
   new_line.line_nr = old_line.line_nr
   new_line.view = self
+  new_line.highlighter = self.highlighter
   for i, line in ipairs(self.lines) do
     if line.line_nr == old_line.line_nr then
       self.lines[i] = new_line

--- a/lua/orgmode/agenda/view/token.lua
+++ b/lua/orgmode/agenda/view/token.lua
@@ -1,9 +1,12 @@
+local Range = require('orgmode.files.elements.range')
 ---@class OrgAgendaLineTokenOpts
 ---@field content string
+---@field highlighter? OrgHighlighter
 ---@field range? OrgRange
 ---@field virt_text_pos? string
 ---@field hl_group? string
 ---@field trim_for_hl? boolean
+---@field add_markup_to_headline? OrgHeadline
 
 ---@class OrgAgendaLineToken: OrgAgendaLineTokenOpts
 local OrgAgendaLineToken = {}
@@ -15,30 +18,55 @@ function OrgAgendaLineToken:new(opts)
   local data = {
     content = opts.content,
     range = opts.range,
+    highlighter = opts.highlighter,
     hl_group = opts.hl_group,
     virt_text_pos = opts.virt_text_pos,
     trim_for_hl = opts.trim_for_hl,
+    add_markup_to_headline = opts.add_markup_to_headline,
   }
   return setmetatable(data, OrgAgendaLineToken)
 end
 
 function OrgAgendaLineToken:get_highlights()
-  if not self.hl_group or self.virt_text_pos then
-    return nil
-  end
-  local range = self.range
-  if self.trim_for_hl then
-    range = self.range:clone()
-    local start_offset = self.content:match('^%s*')
-    local end_offset = self.content:match('%s*$')
-    range.start_col = range.start_col + (start_offset and #start_offset or 0)
-    range.end_col = range.end_col - (end_offset and #end_offset or 0)
+  local highlights = {}
+  if self.hl_group and not self.virt_text_pos then
+    local range = self.range
+    if self.trim_for_hl then
+      range = self.range:clone()
+      local start_offset = self.content:match('^%s*')
+      local end_offset = self.content:match('%s*$')
+      range.start_col = range.start_col + (start_offset and #start_offset or 0)
+      range.end_col = range.end_col - (end_offset and #end_offset or 0)
+    end
+
+    table.insert(highlights, {
+      hlgroup = self.hl_group,
+      range = range,
+    })
   end
 
-  return {
-    hlgroup = self.hl_group,
-    range = range,
-  }
+  if self.add_markup_to_headline and self.highlighter then
+    local markup_highlights = self.highlighter.markup:get_prepared_headline_highlights(self.add_markup_to_headline)
+    local _, offset = self.add_markup_to_headline:get_title()
+
+    for _, hl in ipairs(markup_highlights) do
+      table.insert(highlights, {
+        hlgroup = hl.hl_group,
+        extmark = true,
+        range = Range:new({
+          start_line = self.range.start_line,
+          end_line = self.range.end_line,
+          start_col = self.range.start_col + hl.start_col - offset,
+          end_col = self.range.start_col + hl.end_col - offset,
+        }),
+        priority = hl.priority,
+        conceal = hl.conceal,
+        spell = hl.spell,
+        url = hl.url,
+      })
+    end
+  end
+  return highlights
 end
 
 return OrgAgendaLineToken

--- a/lua/orgmode/clock/report.lua
+++ b/lua/orgmode/clock/report.lua
@@ -68,6 +68,8 @@ function ClockReport:generate_report()
   }
 end
 
+---@private
+---@param orgfile OrgFile
 function ClockReport:_get_clock_report_for_file(orgfile)
   local total_duration = 0
   local headlines = {}

--- a/lua/orgmode/colors/highlighter/init.lua
+++ b/lua/orgmode/colors/highlighter/init.lua
@@ -1,11 +1,11 @@
 ---@class OrgHighlighter
 ---@field namespace number
+---@field markup OrgMarkupHighlighter
 ---@field private stars OrgStarsHighlighter
----@field private markup OrgMarkupHighlighter
 ---@field private todos OrgTodosHighlighter
 ---@field private foldtext OrgFoldtextHighlighter
 ---@field private _ephemeral boolean
----@field private buffers table<number, { language_tree: LanguageTree, tree: TSTree }>
+---@field private buffers table<number, { language_tree: vim.treesitter.LanguageTree, tree: TSTree }>
 local OrgHighlighter = {}
 local config = require('orgmode.config')
 

--- a/lua/orgmode/colors/highlighter/markup/_meta.lua
+++ b/lua/orgmode/colors/highlighter/markup/_meta.lua
@@ -18,8 +18,20 @@
 ---@field to OrgMarkupRange
 ---@field char string
 
+---@class OrgMarkupPreparedHighlight
+---@field start_line number
+---@field start_col number
+---@field end_col number
+---@field hl_group string
+---@field spell? boolean
+---@field priority number
+---@field conceal? boolean
+---@field ephemeral boolean
+---@field url? string
+
 ---@class OrgMarkupHighlighter
 ---@field parse_node fun(self: OrgMarkupHighlighter, node: TSNode): OrgMarkupNode | false
 ---@field is_valid_start_node fun(self: OrgMarkupHighlighter, entry: OrgMarkupNode, bufnr: number): boolean
 ---@field is_valid_end_node fun(self: OrgMarkupHighlighter, entry: OrgMarkupNode, bufnr: number): boolean
 ---@field highlight fun(self: OrgMarkupHighlighter, highlights: OrgMarkupHighlight[], bufnr: number)
+---@field prepare_highlights fun(self: OrgMarkupHighlighter, highlights: OrgMarkupHighlight[], source: number | string): OrgMarkupPreparedHighlight[]

--- a/lua/orgmode/colors/highlighter/markup/dates.lua
+++ b/lua/orgmode/colors/highlighter/markup/dates.lua
@@ -141,6 +141,24 @@ function OrgDates:highlight(highlights, bufnr)
   end
 end
 
+---@param highlights OrgMarkupHighlight[]
+---@return OrgMarkupPreparedHighlight[]
+function OrgDates:prepare_highlights(highlights)
+  local ephemeral = self.markup:use_ephemeral()
+  local extmarks = {}
+  for _, entry in ipairs(highlights) do
+    table.insert(extmarks, {
+      start_line = entry.from.line,
+      start_col = entry.from.start_col,
+      end_col = entry.to.end_col,
+      ephemeral = ephemeral,
+      hl_group = entry.char == '>' and '@org.timestamp.active' or '@org.timestamp.inactive',
+      priority = 110,
+    })
+  end
+  return extmarks
+end
+
 ---@param item OrgMarkupNode
 ---@return boolean
 function OrgDates:has_valid_parent(item)

--- a/lua/orgmode/colors/highlighter/markup/emphasis.lua
+++ b/lua/orgmode/colors/highlighter/markup/emphasis.lua
@@ -88,6 +88,54 @@ function OrgEmphasis:highlight(highlights, bufnr)
   end
 end
 
+---@param highlights OrgMarkupHighlight[]
+---@return OrgMarkupPreparedHighlight[]
+function OrgEmphasis:prepare_highlights(highlights)
+  local hide_markers = config.org_hide_emphasis_markers
+  local ephemeral = self.markup:use_ephemeral()
+  local conceal = hide_markers and '' or nil
+  local extmarks = {}
+
+  for _, entry in ipairs(highlights) do
+    -- Leading delimiter
+    table.insert(extmarks, {
+      start_line = entry.from.line,
+      start_col = entry.from.start_col,
+      end_col = entry.from.end_col,
+      ephemeral = ephemeral,
+      hl_group = markers[entry.char].hl_name .. '.delimiter',
+      spell = markers[entry.char].spell,
+      priority = 110 + entry.from.start_col,
+      conceal = conceal,
+    })
+
+    -- Closing delimiter
+    table.insert(extmarks, {
+      start_line = entry.from.line,
+      start_col = entry.to.start_col,
+      ephemeral = ephemeral,
+      end_col = entry.to.end_col,
+      hl_group = markers[entry.char].hl_name .. '.delimiter',
+      spell = markers[entry.char].spell,
+      priority = 110 + entry.from.start_col,
+      conceal = conceal,
+    })
+
+    -- Main body highlight
+    table.insert(extmarks, {
+      start_line = entry.from.line,
+      start_col = entry.from.start_col + 1,
+      ephemeral = ephemeral,
+      end_col = entry.to.end_col - 1,
+      hl_group = markers[entry.char].hl_name,
+      spell = markers[entry.char].spell,
+      priority = 110 + entry.from.start_col,
+    })
+  end
+
+  return extmarks
+end
+
 ---@param node TSNode
 ---@return OrgMarkupNode | false
 function OrgEmphasis:parse_node(node)
@@ -110,10 +158,10 @@ function OrgEmphasis:parse_node(node)
 end
 
 ---@param entry OrgMarkupNode
----@param bufnr number
+---@param source number | string
 ---@return boolean
-function OrgEmphasis:is_valid_start_node(entry, bufnr)
-  local start_text = self.markup:get_node_text(entry.node, bufnr, -1, 1)
+function OrgEmphasis:is_valid_start_node(entry, source)
+  local start_text = self.markup:get_node_text(entry.node, source, -1, 1)
   local start_len = start_text:len()
 
   return (start_len < 3 or vim.tbl_contains(valid_pre_marker_chars, start_text:sub(1, 1)))
@@ -121,10 +169,10 @@ function OrgEmphasis:is_valid_start_node(entry, bufnr)
 end
 
 ---@param entry OrgMarkupNode
----@param bufnr number
+---@param source number | string
 ---@return boolean
-function OrgEmphasis:is_valid_end_node(entry, bufnr)
-  local end_text = self.markup:get_node_text(entry.node, bufnr, -1, 1)
+function OrgEmphasis:is_valid_end_node(entry, source)
+  local end_text = self.markup:get_node_text(entry.node, source, -1, 1)
   return (end_text:len() < 3 or vim.tbl_contains(valid_post_marker_chars, end_text:sub(3, 3)))
     and end_text:sub(1, 1) ~= ' '
 end

--- a/lua/orgmode/colors/highlighter/markup/latex.lua
+++ b/lua/orgmode/colors/highlighter/markup/latex.lua
@@ -104,4 +104,23 @@ function OrgLatex:highlight(highlights, bufnr)
   end
 end
 
+---@param highlights OrgMarkupHighlight[]
+---@return OrgMarkupPreparedHighlight[]
+function OrgLatex:prepare_highlights(highlights)
+  local ephemeral = self.markup:use_ephemeral()
+  local extmarks = {}
+  for _, entry in ipairs(highlights) do
+    table.insert(extmarks, {
+      start_line = entry.from.line,
+      start_col = entry.from.start_col,
+      end_col = entry.to.end_col,
+      ephemeral = ephemeral,
+      hl_group = '@org.latex',
+      spell = false,
+      priority = 110 + entry.from.start_col,
+    })
+  end
+  return extmarks
+end
+
 return OrgLatex

--- a/lua/orgmode/colors/init.lua
+++ b/lua/orgmode/colors/init.lua
@@ -85,6 +85,16 @@ M.highlight = function(highlights, clear, bufnr)
         end_line = hl.range.start_line,
         hl_eol = true,
       })
+    elseif hl.extmark then
+      vim.api.nvim_buf_set_extmark(bufnr, namespace, hl.range.start_line - 1, hl.range.start_col - 1, {
+        hl_group = hl.hlgroup,
+        end_line = hl.range.end_line - 1,
+        end_col = hl.range.end_col - 1,
+        spell = hl.spell,
+        priority = hl.priority,
+        conceal = hl.conceal,
+        url = hl.url,
+      })
     else
       vim.api.nvim_buf_add_highlight(
         bufnr,
@@ -128,11 +138,11 @@ M.clear_extmarks = function(bufnr, start_line, end_line)
   end
 end
 
-M.add_hr = function(bufnr, line)
+M.add_hr = function(bufnr, line, separator)
   vim.api.nvim_buf_set_lines(bufnr, line, line, false, { '' })
   local width = vim.api.nvim_win_get_width(0)
   vim.api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
-    virt_text = { { string.rep('-', width), '@org.agenda.separator' } },
+    virt_text = { { string.rep(separator, width), '@org.agenda.separator' } },
     virt_text_pos = 'overlay',
   })
 end

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -1,10 +1,38 @@
 ---@alias OrgAgendaSpan 'day' | 'week' | 'month' | 'year' | number
----
+
+---@class OrgAgendaCustomCommandTypeInterface
+---@field type? 'agenda' | 'tags' | 'tags_todo'
+---@field org_agenda_overriding_header? string
+---@field org_agenda_files? string[]
+---@field org_agenda_tag_filter_preset? string
+---@field org_agenda_category_filter_preset? string
+---@field org_agenda_sorting_strategy? OrgAgendaSortingStrategy[]
+---@field org_agenda_remove_tags? boolean
+
+---@class OrgAgendaCustomCommandAgenda:OrgAgendaCustomCommandTypeInterface
+---@field org_agenda_span? OrgAgendaSpan Default: 'week'
+---@field org_agenda_start_day? string Modifier from today, example '+1d'
+---@field org_agenda_start_on_weekday? number
+
+---@class OrgAgendaCustomCommandTags:OrgAgendaCustomCommandTypeInterface
+---@field match? string
+---@field org_agenda_todo_ignore_scheduled? OrgAgendaTodoIgnoreScheduledTypes
+---@field org_agenda_todo_ignore_deadlines? OrgAgendaTodoIgnoreDeadlinesTypes
+
+---@alias OrgAgendaCustomCommandType (OrgAgendaCustomCommandAgenda | OrgAgendaCustomCommandTags)
+
+---@class OrgAgendaCustomCommand
+---@field description string Description in prompt
+---@field types? OrgAgendaCustomCommandType[]
+
 ---@class OrgDefaultConfig
 ---@field org_id_method 'uuid' | 'ts' | 'org'
 ---@field org_agenda_span OrgAgendaSpan
 ---@field org_log_repeat 'time' | 'note' | false
 ---@field calendar { round_min_with_hours: boolean, min_big_step: number, min_small_step: number? }
+---@field org_agenda_custom_commands table<string, OrgAgendaCustomCommand>
+---@field org_agenda_sorting_strategy table<'agenda' | 'todo' | 'tags', OrgAgendaSortingStrategy[]>
+---@field org_agenda_remove_tags? boolean
 local DefaultConfig = {
   org_agenda_files = '',
   org_default_notes_file = '',
@@ -31,6 +59,14 @@ local DefaultConfig = {
   org_agenda_skip_scheduled_if_done = false,
   org_agenda_skip_deadline_if_done = false,
   org_agenda_text_search_extra_files = {},
+  org_agenda_custom_commands = {},
+  org_agenda_block_separator = '-',
+  org_agenda_sorting_strategy = {
+    agenda = { 'time-up', 'priority-down', 'category-keep' },
+    todo = { 'priority-down', 'category-keep' },
+    tags = { 'priority-down', 'category-keep' },
+  },
+  org_agenda_remove_tags = false,
   org_priority_highest = 'A',
   org_priority_default = 'B',
   org_priority_lowest = 'C',
@@ -201,7 +237,7 @@ local DefaultConfig = {
   },
   emacs_config = {
     executable_path = 'emacs',
-    config_path = '$HOME/.emacs.d/init.el',
+    config_path = nil,
   },
   ui = {
     folds = {

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -14,6 +14,7 @@ local Memoize = require('orgmode.utils.memoize')
 ---@class OrgHeadline
 ---@field headline TSNode
 ---@field file OrgFile
+---@field index? number
 local Headline = {}
 
 local memoize = Memoize:new(Headline, function(self)
@@ -326,8 +327,8 @@ end
 
 memoize('get_todo')
 --- Returns the headlines todo keyword, it's node,
---- and it's type (todo or done)
---- @return string | nil, TSNode | nil, string | nil
+--- it's type (todo or done) and it's index in the todo_keywords list
+--- @return string | nil, TSNode | nil, string | nil, number | nil
 function Headline:get_todo()
   -- A valid keyword can only be the first child
   local first_item_node = self:_get_child_node('item')
@@ -341,10 +342,10 @@ function Headline:get_todo()
   local text = self.file:get_node_text(todo_node)
   local keyword_by_value = todo_keywords:find(text)
   if not keyword_by_value then
-    return nil, nil, nil
+    return nil, nil, nil, nil
   end
 
-  return text, todo_node, keyword_by_value.type
+  return text, todo_node, keyword_by_value.type, keyword_by_value.index
 end
 
 ---@return boolean
@@ -360,18 +361,24 @@ function Headline:is_done()
 end
 
 memoize('get_title')
----@return string
+---@return string, number
 function Headline:get_title()
-  local title = self.file:get_node_text(self:_get_child_node('item')) or ''
+  local title_node = self:_get_child_node('item')
+  local title = self.file:get_node_text(title_node) or ''
   local word, todo_node = self:get_todo()
+  local offset = title_node and select(2, title_node:start()) or 0
   if todo_node and word then
-    title = title:gsub('^' .. vim.pesc(word) .. '%s*', '')
+    local new_title = title:gsub('^' .. vim.pesc(word) .. '%s*', '')
+    offset = offset + (title:len() - new_title:len())
+    title = new_title
   end
   local priority, priority_node = self:get_priority()
   if priority_node then
-    title = title:gsub('^' .. vim.pesc(('[#%s]'):format(priority)) .. '%s*', '')
+    local new_title = title:gsub('^' .. vim.pesc(('[#%s]'):format(priority)) .. '%s*', '')
+    offset = offset + title:len() - new_title:len()
+    title = new_title
   end
-  return title
+  return title, offset
 end
 
 function Headline:get_title_with_priority()
@@ -725,9 +732,11 @@ function Headline:get_non_plan_dates()
   return dates
 end
 
-function Headline:tags_to_string()
+---@param sorted? boolean
+---@return string, TSNode | nil
+function Headline:tags_to_string(sorted)
   local tags, node = self:get_tags()
-  return utils.tags_to_string(tags), node
+  return utils.tags_to_string(tags, sorted), node
 end
 
 ---@return boolean

--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -56,6 +56,7 @@ function Org:init()
   self.links = require('orgmode.org.links'):new({ files = self.files })
   self.agenda = require('orgmode.agenda'):new({
     files = self.files,
+    highlighter = self.highlighter,
   })
   self.capture = require('orgmode.capture'):new({
     files = self.files,

--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -713,6 +713,15 @@ function Date:get_date_range_end()
   return self:has_date_range_end() and self.related_date_range or nil
 end
 
+function Date:get_type_sort_value()
+  local types = {
+    DEADLINE = 1,
+    SCHEDULED = 2,
+    NONE = 3,
+  }
+  return types[self.type]
+end
+
 ---Return number of days for a date range
 ---@return number
 function Date:get_date_range_days()

--- a/lua/orgmode/org/links/init.lua
+++ b/lua/orgmode/org/links/init.lua
@@ -96,9 +96,9 @@ function OrgLinks:get_link_to_file(file)
 end
 
 ---@param link_location string
-function OrgLinks:insert_link(link_location)
+function OrgLinks:insert_link(link_location, desc)
   local selected_link = OrgHyperlink:new(link_location)
-  local desc = selected_link.url:get_target()
+  desc = desc or selected_link.url:get_target()
   if desc and (desc:match('^%*') or desc:match('^#')) then
     desc = desc:sub(2)
   end

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -785,7 +785,8 @@ end
 -- Inserts a new link after the cursor position or modifies the link the cursor is
 -- currently on
 function OrgMappings:insert_link()
-  local link_location = vim.fn.OrgmodeInput('Links: ', '', function(arg_lead)
+  local link = OrgHyperlink.at_cursor()
+  local link_location = vim.fn.OrgmodeInput('Links: ', link and link.url:to_string() or '', function(arg_lead)
     return self.links:autocomplete(arg_lead)
   end)
   if vim.trim(link_location) == '' then
@@ -793,7 +794,7 @@ function OrgMappings:insert_link()
     return
   end
 
-  self.links:insert_link(link_location)
+  self.links:insert_link(link_location, link and link.desc)
 end
 
 function OrgMappings:store_link()

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -252,9 +252,12 @@ function utils.parse_tags_string(tags)
   return parsed_tags
 end
 
-function utils.tags_to_string(taglist)
+function utils.tags_to_string(taglist, sorted)
   local tags = ''
   if #taglist > 0 then
+    if sorted then
+      table.sort(taglist)
+    end
     tags = ':' .. table.concat(taglist, ':') .. ':'
   end
   return tags


### PR DESCRIPTION
Add custom agenda commands.
Closes https://github.com/nvim-orgmode/orgmode/issues/478 and https://github.com/nvim-orgmode/orgmode/issues/135 .
Check `org_agenda_custom_commands` in the docs for more details.

Also fixes few other issues:
1. https://github.com/nvim-orgmode/orgmode/issues/849
2. https://github.com/nvim-orgmode/orgmode/issues/776

Few more notable features/bug fixes:
1. Agenda now renders any markup that is part of headline (bold, italic, date, link). Links are also clickable for Neovim 0.10.2 + due to OSC 8 control sequence.
2. Doing insert link mapping on the link was broken by not prompting to update the link under cursor. That is now fixed.
3. Unrelated to agenda, emacs export is updated to attempt to find a configuration file, and fallback to no file in case of an error