### PR TITLE
ci, doc: add semver workflow and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- Give a brief description of what your PR does. -->
+
+This PR adds..
+
+## Related Issues
+
+<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->
+
+Related #
+
+Closes #
+
+## Changes
+
+<!-- List the major changes made in this PR. -->
+
+- List changes here
+
+## Checklist
+
+I confirm that I have:
+
+- [ ] **Followed the
+      [Conventional Commits](https://www.conventionalcommits.org/)
+      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
+      `docs: update documentation`).
+- [ ] **My PR title also follows the conventional commits specification.**
+- [ ] **Updated relevant documentation,** if necessary.
+- [ ] **Thoroughly tested my changes.**
+- [ ] **Added tests** (if applicable) and verified existing tests pass with
+      `make test`.
+- [ ] **Checked for breaking changes** and documented them, if any.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          release-type: simple

--- a/docs/contributing.org
+++ b/docs/contributing.org
@@ -96,3 +96,9 @@ make test FILE=./tests/plenary/api/api_spec.lua
 :CUSTOM_ID: parser
 :END:
 Parsing is done via builtin treesitter parser and the [[https://github.com/milisims/tree-sitter-org][tree-sitter-org]] grammar.
+
+**** Commits
+:PROPERTIES:
+:CUSTOM_ID: commits
+:END:
+Ensure that you follow the [[https://www.conventionalcommits.org/][Conventional Commits]] specification (e.g., =feat: add new feature=, =fix: correct bug=, =docs: update documentation=).


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

This PR adds a GitHub actions workflow to automate the creation of semantically versioned releases with `release-please` and a PR template to encourage compliance with conventional commits.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Closes #828 

## Changes

<!-- List the major changes made in this PR. -->

- Added `release-please` workflow
- Added PR template
- Updated Contributing documentation to mention conventional commits

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.