### PR TITLE
feat(properties): add option `org_use_property_inheritance`

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -533,6 +533,22 @@ Prefix added to the generated id when [[#org_id_method][org_id_method]] is set t
 If =true=, generate ID with the Org ID module and append it to the
 headline as property. More info on [[#org_store_link][org_store_link]]
 
+*** =org_use_property_inheritance=
+:PROPERTIES:
+:CUSTOM_ID: org_use_property_inheritance
+:END:
+- Type: =boolean | string | string[]=
+- Default: =false=
+Determine whether properties of one headline are inherited by sub-headlines.
+
+- =false= - properties only pertain to the file or headline that defines them
+- =true= - properties of a headlines also pertain to all its sub-headlines
+- =string[]= - only the properties named in the given list are inherited
+- =string= - only properties matching the given regex are inherited
+
+Note that for a select few properties, the inheritance behavior is hard-coded withing their special applications.
+See [[https://orgmode.org/manual/Property-Inheritance.html][Property Inheritance]] for details.
+
 *** =org_babel_default_header_args=
 :PROPERTIES:
 :CUSTOM_ID: org_babel_default_header_args

--- a/lua/orgmode/api/headline.lua
+++ b/lua/orgmode/api/headline.lua
@@ -64,7 +64,7 @@ end
 ---@private
 function OrgHeadline._build_from_internal_headline(section, index)
   local todo, _, type = section:get_todo()
-  local properties = section:get_properties()
+  local properties = section:get_own_properties()
   return OrgHeadline:_new({
     title = section:get_title(),
     line = section:get_headline_line_content(),

--- a/lua/orgmode/clock/init.lua
+++ b/lua/orgmode/clock/init.lua
@@ -118,7 +118,7 @@ function Clock:get_statusline()
     return ''
   end
 
-  local effort = self.clocked_headline:get_property('effort')
+  local effort = self.clocked_headline:get_property('effort', false)
   local total = self.clocked_headline:get_logbook():get_total_with_active():to_string()
   if effort then
     return string.format('(Org) [%s/%s] (%s)', total, effort or '', self.clocked_headline:get_title())

--- a/lua/orgmode/config/_meta.lua
+++ b/lua/orgmode/config/_meta.lua
@@ -235,6 +235,7 @@
 ---@field org_id_method? 'uuid' | 'ts' | 'org' What method to use to generate ids via org.id module. Default: 'uuid'
 ---@field org_id_prefix? string | nil Prefix to apply to id when `org_id_method = 'org'`. Default: nil
 ---@field org_id_link_to_org_use_id? boolean If true, Storing a link to the headline will automatically generate ID for that headline. Default: false
+---@field org_use_property_inheritance boolean | string | string[] If true, properties are inherited by sub-headlines; may also be a regex or list of property names. Default: false
 ---@field org_babel_default_header_args? table<string, string> Default header args for org-babel blocks: Default: { [':tangle'] = 'no', [':noweb'] = 'no' }
 ---@field win_split_mode? 'horizontal' | 'vertical' | 'auto' | 'float' | string[] How to open agenda and capture windows. Default: 'horizontal'
 ---@field win_border? 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | string[] Border configuration for `win_split_mode = 'float'`. Default: 'single'

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -66,6 +66,7 @@ local DefaultConfig = {
   org_id_method = 'uuid',
   org_id_prefix = nil,
   org_id_link_to_org_use_id = false,
+  org_use_property_inheritance = false,
   org_babel_default_header_args = {
     [':tangle'] = 'no',
     [':noweb'] = 'no',

--- a/lua/orgmode/config/init.lua
+++ b/lua/orgmode/config/init.lua
@@ -539,6 +539,25 @@ function Config:parse_header_args(args)
   return results
 end
 
+---@param property_name string
+---@return boolean uses_inheritance
+function Config:use_property_inheritance(property_name)
+  property_name = string.lower(property_name)
+
+  local use_inheritance = self.opts.org_use_property_inheritance or false
+
+  if type(use_inheritance) == 'table' then
+    return vim.tbl_contains(use_inheritance, function(value)
+      return vim.stricmp(value, property_name) == 0
+    end, { predicate = true })
+  elseif type(use_inheritance) == 'string' then
+    local regex = vim.regex(use_inheritance)
+    return regex:match_str(property_name) and true or false
+  else
+    return use_inheritance and true or false
+  end
+end
+
 ---@type OrgConfig
 instance = Config:new()
 return instance

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -278,7 +278,7 @@ function OrgFile:apply_search(search, todo_only)
     local deadline = item:get_deadline_date()
     local scheduled = item:get_scheduled_date()
     local closed = item:get_closed_date()
-    local properties = item:get_properties()
+    local properties = item:get_own_properties()
     local priority = item:get_priority()
 
     return search:check({

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -576,7 +576,7 @@ memoize('get_tags')
 function Headline:get_tags()
   local tags, own_tags_node = self:get_own_tags()
   if not config.org_use_tag_inheritance then
-    return config:exclude_tags(tags), own_tags_node
+    return tags, own_tags_node
   end
 
   local parent_tags = {}

--- a/lua/orgmode/org/hyperlinks/init.lua
+++ b/lua/orgmode/org/hyperlinks/init.lua
@@ -57,7 +57,7 @@ function Hyperlinks.as_custom_id_anchors(url)
   return function(headlines)
     return vim.tbl_map(function(headline)
       ---@cast headline OrgHeadline
-      local custom_id = headline:get_property('custom_id')
+      local custom_id = headline:get_property('custom_id', false)
       return ('%s#%s'):format(prefix, custom_id)
     end, headlines)
   end

--- a/lua/orgmode/org/links/types/custom_id.lua
+++ b/lua/orgmode/org/links/types/custom_id.lua
@@ -60,7 +60,7 @@ function OrgLinkCustomId:autocomplete(link)
   local prefix = opts.type == 'internal' and '' or opts.link_url:get_path_with_protocol() .. '::'
 
   return vim.tbl_map(function(headline)
-    local custom_id = headline:get_property('custom_id')
+    local custom_id = headline:get_property('custom_id', false)
     return prefix .. '#' .. custom_id
   end, headlines)
 end

--- a/lua/orgmode/org/links/types/id.lua
+++ b/lua/orgmode/org/links/types/id.lua
@@ -56,7 +56,7 @@ end
 
 ---@private
 ---@param link string
----@return string
+---@return string?
 function OrgLinkId:_parse(link)
   return link:match('^id:(.+)$')
 end

--- a/lua/orgmode/ui/menu.lua
+++ b/lua/orgmode/ui/menu.lua
@@ -23,6 +23,7 @@ local config = require('orgmode.config')
 local Menu = {}
 
 ---@param data OrgMenuOpts
+---@return OrgMenu
 function Menu:new(data)
   self:_validate_data(data)
 

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -53,6 +53,9 @@ function utils.readfile(file, opts)
   end)
 end
 
+---@param file string
+---@param data string|string[]
+---@return OrgPromise<integer> bytes
 function utils.writefile(file, data)
   return Promise.new(function(resolve, reject)
     uv.fs_open(file, 'w', 438, function(err1, fd)
@@ -502,6 +505,7 @@ function utils.is_list(value)
   if vim.islist then
     return vim.islist(value)
   end
+  ---@diagnostic disable-next-line: deprecated
   return vim.tbl_islist(value)
 end
 

--- a/tests/plenary/files/headline_spec.lua
+++ b/tests/plenary/files/headline_spec.lua
@@ -97,6 +97,29 @@ describe('Headline', function()
       assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir'))
       assert.is.Nil(file:get_headlines()[2]:get_property('dir', false))
     end)
+    it('does not affect get_own_properties', function()
+      config:extend({ org_use_property_inheritance = true })
+      file.metadata.mtime = file.metadata.mtime + 1 -- invalidate cache
+      assert.are.same({}, file:get_headlines()[2]:get_own_properties())
+    end)
+    it('affects get_properties', function()
+      config:extend({ org_use_property_inheritance = true })
+      file.metadata.mtime = file.metadata.mtime + 1 -- invalidate cache
+      local expected = { dir = 'some/dir/', thing = '0', columns = '' }
+      assert.are.same(expected, file:get_headlines()[2]:get_properties())
+    end)
+    it('makes get_properties selective if a list', function()
+      config:extend({ org_use_property_inheritance = { 'dir' } })
+      file.metadata.mtime = file.metadata.mtime + 1 -- invalidate cache
+      local expected = { dir = 'some/dir/' }
+      assert.are.same(expected, file:get_headlines()[2]:get_properties())
+    end)
+    it('makes get_properties selective if a regex', function()
+      config:extend({ org_use_property_inheritance = '^th...$' })
+      file.metadata.mtime = file.metadata.mtime + 1 -- invalidate cache
+      local expected = { thing = '0' }
+      assert.are.same(expected, file:get_headlines()[2]:get_properties())
+    end)
   end)
 
   describe('get_all_dates', function()

--- a/tests/plenary/files/headline_spec.lua
+++ b/tests/plenary/files/headline_spec.lua
@@ -1,4 +1,5 @@
 local helpers = require('tests.plenary.helpers')
+local config = require('orgmode.config')
 
 describe('Headline', function()
   describe('get_category', function()
@@ -51,6 +52,50 @@ describe('Headline', function()
       file:reload_sync()
 
       assert.are.same('headline_2_category', file:get_headlines()[2]:get_category())
+    end)
+  end)
+
+  describe('use_property_inheritance', function()
+    local file = helpers.create_file_instance({
+      '#+CATEGORY: file_category',
+      '* Headline 1',
+      ':PROPERTIES:',
+      ':DIR: some/dir/',
+      ':THING: 0',
+      ':COLUMNS:',
+      ':END:',
+      '** Headline 2',
+      '   some body text',
+    }, 'category.org')
+    after_each(function()
+      config:extend({ org_use_property_inheritance = false })
+    end)
+    it('is false by default', function()
+      assert.is.Nil(file:get_headlines()[2]:get_property('dir'))
+    end)
+    it('is active if true', function()
+      config:extend({ org_use_property_inheritance = true })
+      assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir'))
+      assert.are.same('0', file:get_headlines()[2]:get_property('thing'))
+    end)
+    it('is selective if a list', function()
+      config:extend({ org_use_property_inheritance = { 'dir' } })
+      assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir'))
+      assert.is.Nil(file:get_headlines()[2]:get_property('thing'))
+    end)
+    it('is selective if a regex', function()
+      config:extend({ org_use_property_inheritance = '^di.$' })
+      assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir'))
+      assert.is.Nil(file:get_headlines()[2]:get_property('thing'))
+    end)
+    it('can be overridden with true', function()
+      assert.is.Nil(file:get_headlines()[2]:get_property('dir'))
+      assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir', true))
+    end)
+    it('can be overridden with false', function()
+      config:extend({ org_use_property_inheritance = true })
+      assert.are.same('some/dir/', file:get_headlines()[2]:get_property('dir'))
+      assert.is.Nil(file:get_headlines()[2]:get_property('dir', false))
     end)
   end)
 


### PR DESCRIPTION
## Summary

This PR adds the option `org_use_property_inheritance` and allows using [property inheritance](https://orgmode.org/manual/Property-Inheritance.html) in searches and via the external API.

## Related Issues

Extracted from #878 

## Changes

The code to search for a property recursively was already there, it's just that the default behavior couldn't be configured.

I've changed the behavior of `get_property()`'s parameter `search_parents` from two-state (truthy=yes, falsy=no) to tri-state (`true`=yes, `false`=no, `nil`=use config).

For the config itself, I've added the option itself and also a method `OrgConfig:use_property_inheritance()`, which evaluates it for a given property name.

I've adjusted the special cases where we want to always ignore (or always use) inheritance by grepping the code base for `get_property` and evaluating them one by one. I'm reasonably sure I got all uses, but it doesn't hurt to double check.

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.