### PR TITLE
chore(docs): fix `org_todo_repeat_to_state` description

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -65,8 +65,6 @@ NOTE: Make sure fast access keys do not overlap. If that happens, first entry in
 :END:
 - Type: =string | nil=
 - Default: =nil=
-Path to a file that will be used as a default target file when refiling.
-
 Set an entry from [[#org_todo_keywords][org_todo_keywords]] to use as the "starting" state for repeatable todos.
 
 If provided value does not exist in [[#org_todo_keywords][org_todo_keywords]], first entry from that list is used.
@@ -179,7 +177,7 @@ require('orgmode').setup({
   }
 })
 #+end_src
-***
+
 *** org_archive_location
 :PROPERTIES:
 :CUSTOM_ID: org_archive_location


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

This PR fix `org_todo_repeat_to_state` description and remove redundant `***` heading lines above `org_archive_location`

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #

Closes #

## Changes

<!-- List the major changes made in this PR. -->

- fix `org_todo_repeat_to_state` description
- remove redundant `***` heading lines above `org_archive_location`

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [X] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [X] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [X] **Checked for breaking changes** and documented them, if any.
