### PR TITLE
refactor(events): use `vim.defaulttable` in `EventManager`

### DIFF
--- a/lua/orgmode/events/init.lua
+++ b/lua/orgmode/events/init.lua
@@ -6,7 +6,9 @@ local Listeners = require('orgmode.events.listeners')
 ---@field private _listeners table<string, fun(...:any)[]>
 local EventManager = {
   initialized = false,
-  _listeners = {},
+  _listeners = vim.defaulttable(function()
+    return {}
+  end),
   event = Events,
 }
 
@@ -22,11 +24,9 @@ end
 ---@param event OrgEvent
 ---@param listener fun(...)
 function EventManager.listen(event, listener)
-  if not EventManager._listeners[event.type] then
-    EventManager._listeners[event.type] = {}
-  end
-  if not vim.tbl_contains(EventManager._listeners[event.type], listener) then
-    table.insert(EventManager._listeners[event.type], listener)
+  local listeners = EventManager._listeners[event.type]
+  if not vim.tbl_contains(listeners, listener) then
+    table.insert(listeners, listener)
   end
 end
 

--- a/lua/orgmode/events/init.lua
+++ b/lua/orgmode/events/init.lua
@@ -32,7 +32,7 @@ end
 
 function EventManager.init()
   if EventManager.initialized then
-    return
+    return EventManager
   end
   for event, listeners in pairs(Listeners) do
     for _, listener in ipairs(listeners) do


### PR DESCRIPTION
## Summary

Minor clean-up of `EventManager` by using `vim.defaulttable` instead of custom logic.

## Related Issues

Extracted from #878 

## Changes

- fix a minor type issue in `EventManager.init`
- replace custom logic in `EventManager.listen` with `vim.defaulttable`

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
