### PR TITLE
refactor: replace deprecated vim.loop with vim.uv

### DIFF
--- a/lua/orgmode/capture/init.lua
+++ b/lua/orgmode/capture/init.lua
@@ -291,7 +291,7 @@ function Capture:refile_file_headline_to_archive(headline)
   if vim.fn.isdirectory(archive_directory) == 0 then
     vim.fn.mkdir(archive_directory, 'p')
   end
-  if not vim.loop.fs_stat(archive_location) then
+  if not vim.uv.fs_stat(archive_location) then
     vim.fn.writefile({}, archive_location)
   end
 

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -40,7 +40,7 @@ end)
 ---@param opts OrgFileOpts
 ---@return OrgFile
 function OrgFile:new(opts)
-  local stat = vim.loop.fs_stat(opts.filename)
+  local stat = vim.uv.fs_stat(opts.filename)
   local data = {
     filename = opts.filename,
     lines = opts.lines,
@@ -72,7 +72,7 @@ function OrgFile.load(filename)
     }))
   end
 
-  if not vim.loop.fs_stat(filename) or not utils.is_org_file(filename) then
+  if not vim.uv.fs_stat(filename) or not utils.is_org_file(filename) then
     return Promise.resolve(false)
   end
 
@@ -146,7 +146,7 @@ function OrgFile:is_modified()
     local cur_changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
     return cur_changedtick ~= self.metadata.changedtick
   end
-  local stat = vim.loop.fs_stat(self.filename)
+  local stat = vim.uv.fs_stat(self.filename)
   if not stat then
     return false
   end
@@ -865,7 +865,7 @@ function OrgFile:_update_lines(lines, bufnr)
   if bufnr then
     self.metadata.changedtick = vim.api.nvim_buf_get_changedtick(bufnr)
   end
-  local stat = vim.loop.fs_stat(self.filename)
+  local stat = vim.uv.fs_stat(self.filename)
   if stat then
     self.metadata.mtime = stat.mtime.nsec
   end

--- a/lua/orgmode/files/init.lua
+++ b/lua/orgmode/files/init.lua
@@ -376,7 +376,7 @@ function OrgFiles:_files(skip_resolve)
       return false
     end
 
-    local stat = vim.loop.fs_stat(file)
+    local stat = vim.uv.fs_stat(file)
     return stat and stat.type == 'file' or false
   end, all_files)
 end

--- a/lua/orgmode/notifications/init.lua
+++ b/lua/orgmode/notifications/init.lua
@@ -23,7 +23,7 @@ end
 
 function Notifications:start_timer()
   self:stop_timer()
-  self.timer = vim.loop.new_timer()
+  self.timer = vim.uv.new_timer()
   self:notify(Date.now())
   self.timer:start(
     (60 - os.date('%S')) * 1000,

--- a/lua/orgmode/utils/fs.lua
+++ b/lua/orgmode/utils/fs.lua
@@ -29,7 +29,7 @@ function M.get_real_path(filepath)
   if not substituted then
     return false
   end
-  local real = vim.loop.fs_realpath(substituted)
+  local real = vim.uv.fs_realpath(substituted)
   if real and filepath:sub(-1, -1) == '/' then
     -- make sure if filepath gets a trailing slash, the realpath gets one, too.
     real = real .. '/'

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -1,5 +1,5 @@
 local Promise = require('orgmode.utils.promise')
-local uv = vim.loop
+local uv = vim.uv
 local utils = {}
 local debounce_timers = {}
 local tmp_window_augroup = vim.api.nvim_create_augroup('OrgTmpWindow', { clear = true })
@@ -86,11 +86,11 @@ end
 
 function utils.system_notification(message)
   if vim.fn.executable('notify-send') == 1 then
-    vim.loop.spawn('notify-send', { args = { message } })
+    uv.spawn('notify-send', { args = { message } })
   end
 
   if vim.fn.executable('terminal-notifier') == 1 then
-    vim.loop.spawn('terminal-notifier', { args = { '-message', message } })
+    uv.spawn('terminal-notifier', { args = { '-message', message } })
   end
 end
 
@@ -332,9 +332,9 @@ end
 ---@param name string
 ---@return function
 function utils.profile(name)
-  local start_time = vim.loop.hrtime()
+  local start_time = uv.hrtime()
   return function()
-    return print(name, string.format('%.2f', (vim.loop.hrtime() - start_time) / 1000000))
+    return print(name, string.format('%.2f', (uv.hrtime() - start_time) / 1000000))
   end
 end
 

--- a/lua/orgmode/utils/treesitter/install.lua
+++ b/lua/orgmode/utils/treesitter/install.lua
@@ -1,7 +1,7 @@
 local Promise = require('orgmode.utils.promise')
 local utils = require('orgmode.utils')
 local ts_revision = 'f8c6b1e72f82f17e41004e04e15f62a83ecc27b0'
-local uv = vim.loop
+local uv = vim.uv
 local M = {
   compilers = { vim.fn.getenv('CC'), 'cc', 'gcc', 'clang', 'cl', 'zig' },
 }

--- a/scripts/minimal_init.lua
+++ b/scripts/minimal_init.lua
@@ -3,12 +3,12 @@ local nvim_root = tmp_dir .. '/nvim_orgmode'
 local lazy_root = nvim_root .. '/lazy'
 local lazypath = lazy_root .. '/lazy.nvim'
 
-for _, name in ipairs({ "config", "data", "state", "cache" }) do
-  vim.env[("XDG_%s_HOME"):format(name:upper())] = nvim_root .. "/" .. name
+for _, name in ipairs({ 'config', 'data', 'state', 'cache' }) do
+  vim.env[('XDG_%s_HOME'):format(name:upper())] = nvim_root .. '/' .. name
 end
 
 -- Install lazy.nvim if not already installed
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system({
     'git',
     'clone',

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -23,12 +23,12 @@ function M.load_plugin(plugin_name, plugin_url)
   local install_destination = package_root .. plugin_name
   vim.opt.runtimepath:append(install_destination)
 
-  if not vim.loop.fs_stat(package_root) then
+  if not vim.uv.fs_stat(package_root) then
     vim.fn.mkdir(package_root, 'p')
   end
 
   -- If the plugin install path already exists, we don't need to clone it again.
-  if not vim.loop.fs_stat(install_destination) then
+  if not vim.uv.fs_stat(install_destination) then
     print(string.format('>> Downloading plugin "%s" to "%s"', plugin_name, install_destination))
     vim.fn.system({
       'git',

--- a/tests/plenary/babel/tangle_spec.lua
+++ b/tests/plenary/babel/tangle_spec.lua
@@ -12,7 +12,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Nil(vim.uv.fs_stat(tangled_file))
     end)
 
     it('should tangle a file when enabled in config', function()
@@ -30,7 +30,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("test first line")',
         'print("test first second line")',
@@ -54,7 +54,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("test first line")',
         'print("test first second line")',
@@ -74,7 +74,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("test first line")',
         'print("test first second line")',
@@ -91,7 +91,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("test first line")',
         'print("test first second line")',
@@ -109,7 +109,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Nil(vim.uv.fs_stat(tangled_file))
     end)
   end)
 
@@ -131,7 +131,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("Headline first line")',
         'print("Headline second line")',
@@ -158,7 +158,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("Other headline first line")',
         'print("Other headline second line")',
@@ -184,7 +184,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
 
-      assert.is.Not.Nil(vim.loop.fs_stat(abs_path))
+      assert.is.Not.Nil(vim.uv.fs_stat(abs_path))
       assert.are.same({
         'print("Headline first line")',
         'print("Headline second line")',
@@ -212,7 +212,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
 
-      assert.is.Not.Nil(vim.loop.fs_stat(abs_path))
+      assert.is.Not.Nil(vim.uv.fs_stat(abs_path))
       assert.are.same({
         'print("Headline first line")',
         'print("Headline second line")',
@@ -240,7 +240,7 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
 
-      assert.is.Not.Nil(vim.loop.fs_stat(abs_path))
+      assert.is.Not.Nil(vim.uv.fs_stat(abs_path))
       assert.are.same({
         'print("Headline first line")',
         'print("Headline second line")',
@@ -269,8 +269,8 @@ describe('Tangle', function()
       })
       vim.cmd('norm ,obt')
 
-      assert.is.Not.Nil(vim.loop.fs_stat(abs_path))
-      assert.is.Not.Nil(vim.loop.fs_stat(single_block_abs_path))
+      assert.is.Not.Nil(vim.uv.fs_stat(abs_path))
+      assert.is.Not.Nil(vim.uv.fs_stat(single_block_abs_path))
       assert.are.same({
         'print("Headline first line")',
         'print("Headline second line")',
@@ -302,7 +302,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("Other headline first line")',
         'print("Other headline second line")',
@@ -333,7 +333,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("Other headline first line")',
         'print("Other headline second line")',
@@ -361,7 +361,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         '<<otherblock>>',
         'print("Headline first line")',
@@ -391,7 +391,7 @@ describe('Tangle', function()
       vim.cmd('norm ,obt')
 
       local tangled_file = vim.fn.fnamemodify(file.filename, ':r') .. '.lua'
-      assert.is.Not.Nil(vim.loop.fs_stat(tangled_file))
+      assert.is.Not.Nil(vim.uv.fs_stat(tangled_file))
       assert.are.same({
         'print("Other headline first line")',
         'print("Other headline second line")',

--- a/tests/plenary/files/file_spec.lua
+++ b/tests/plenary/files/file_spec.lua
@@ -18,7 +18,7 @@ describe('OrgFile', function()
       assert.are.same(filename, file.filename)
       assert.are.same({ '* Headline 1' }, file.lines)
       assert.are.same('* Headline 1', file.content)
-      local stat = vim.loop.fs_stat(filename) or {}
+      local stat = vim.uv.fs_stat(filename) or {}
       assert.are.same(stat.mtime.nsec, file.metadata.mtime)
       assert.are.same(0, file.metadata.changedtick)
     end)
@@ -37,7 +37,7 @@ describe('OrgFile', function()
       assert.are.same(filename, file.filename)
       assert.are.same({ '* Headline 2' }, file.lines)
       assert.are.same('* Headline 2', file.content)
-      local stat = vim.loop.fs_stat(filename) or {}
+      local stat = vim.uv.fs_stat(filename) or {}
       assert.are.same(stat.mtime.nsec, file.metadata.mtime)
       assert.are.same(0, file.metadata.changedtick)
       vim.cmd('write!')

--- a/tests/plenary/state/state_spec.lua
+++ b/tests/plenary/state/state_spec.lua
@@ -14,7 +14,7 @@ describe('State', function()
   end)
 
   it("should create a state file if it doesn't exist", function()
-    local stat = vim.loop.fs_stat(cache_path)
+    local stat = vim.uv.fs_stat(cache_path)
     if stat then
       error('Cache file existed before it should! Ensure it is deleted before each test run!')
     end
@@ -27,7 +27,7 @@ describe('State', function()
       return state._ctx.saved
     end, 10)
 
-    local stat, err, _ = vim.loop.fs_stat(cache_path)
+    local stat, err, _ = vim.uv.fs_stat(cache_path)
     if not stat then
       error(err)
     end


### PR DESCRIPTION
## Summary

Replace `vim.loop` with `vim.uv`. The former has been [deprecated ][1] since 0.10, which is our minimum version, as far as I can tell.

[1]: https://neovim.io/doc/user/deprecated.html#vim.loop

## Related Issues

None

## Changes

- replaced `vim.loop` with `vim.uv` in manual search & replace
- `scripts/minimal_init.lua` also had its quotes changed by Stylua
- Running `Stylua` inside `scripts/` produced *a lot* of changes; I left those in other files out to avoid cluttering the diff.
- There are two files[^2] with lines `local uv = vim.loop` at the top, that now read `local uv = vim.uv`. I'm not sure about the purpose of these (in Python, you'd do this to avoid repeated attribute lookups, which can be costly), so I left them as is.
- where those files still used `vim.loop`, I replaced it with `uv`, not `vim.uv` for consistency

[^2]: `lua/orgmode/utils/fs.lua` and `lua/orgmode/utils/treesitter/install.lua`

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
