### PR TITLE
feat(tests): add tests for `utils.fs` and `utils.current_file_path()`

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -57,7 +57,7 @@ function OrgMappings:set_tags(tags)
         end)
       end
       if type(tags) == 'table' then
-        tags = string.format(':%s:', table.concat(tags, ':'))
+        tags = utils.tags_to_string(tags)
       end
 
       return tags

--- a/tests/plenary/helpers.lua
+++ b/tests/plenary/helpers.lua
@@ -3,6 +3,30 @@ local orgmode = require('orgmode')
 
 local M = {}
 
+---Temporarily change a variable.
+---@param ctx table<string, any>
+---@param name string
+---@param value any
+---@param inner fun()
+function M.with_var(ctx, name, value, inner)
+  local old = ctx[name]
+  ctx[name] = value
+  local ok, err = pcall(inner)
+  ctx[name] = old
+  assert(ok, err)
+end
+
+---Temporarily change the working directory.
+---@param new_path string
+---@param inner fun()
+function M.with_cwd(new_path, inner)
+  local old_path = vim.fn.getcwd()
+  vim.cmd.cd(new_path)
+  local ok, err = pcall(inner)
+  vim.cmd.cd(old_path)
+  assert(ok, err)
+end
+
 ---@param path string
 function M.load_file(path)
   vim.cmd.edit(path)

--- a/tests/plenary/helpers.lua
+++ b/tests/plenary/helpers.lua
@@ -1,19 +1,25 @@
 local OrgFile = require('orgmode.files.file')
 local orgmode = require('orgmode')
 
-local function load_file(path)
-  vim.cmd(string.format('e %s', path))
+local M = {}
+
+---@param path string
+function M.load_file(path)
+  vim.cmd.edit(path)
   return orgmode.files:get(path)
 end
 
-local function create_file(lines)
+---@param lines string[]
+function M.create_file(lines)
   local fname = vim.fn.tempname() .. '.org'
   vim.fn.writefile(lines or {}, fname)
-  return load_file(fname)
+  return M.load_file(fname)
 end
 
+---@param lines string[]
+---@param config? table
 ---@return OrgFile
-local function create_agenda_file(lines, config)
+function M.create_agenda_file(lines, config)
   local fname = vim.fn.tempname() .. '.org'
   vim.fn.writefile(lines or {}, fname)
 
@@ -22,11 +28,13 @@ local function create_agenda_file(lines, config)
   }, config or {})
   local org = orgmode.setup(cfg)
   org:init()
-  return load_file(fname)
+  return M.load_file(fname)
 end
 
+---@param lines string[]
+---@param filename string
 ---@return OrgFile
-local function create_file_instance(lines, filename)
+function M.create_file_instance(lines, filename)
   local file = OrgFile:new({
     filename = filename or vim.fn.tempname() .. '.org',
     lines = lines,
@@ -36,9 +44,9 @@ local function create_file_instance(lines, filename)
 end
 
 ---@param fixtures {filename: string, content: string[] }[]
----@param config table?
+---@param config? table
 ---@return table
-local function create_agenda_files(fixtures, config)
+function M.create_agenda_files(fixtures, config)
   -- NOTE: content is only 1 line for 1 file
   local temp_fname = vim.fn.tempname()
   local temp_dir = vim.fn.fnamemodify(temp_fname, ':p:h')
@@ -65,10 +73,4 @@ local function create_agenda_files(fixtures, config)
   return files
 end
 
-return {
-  load_file = load_file,
-  create_file = create_file,
-  create_file_instance = create_file_instance,
-  create_agenda_file = create_agenda_file,
-  create_agenda_files = create_agenda_files,
-}
+return M

--- a/tests/plenary/utils/fs_spec.lua
+++ b/tests/plenary/utils/fs_spec.lua
@@ -1,0 +1,88 @@
+local fs_utils = require('orgmode.utils.fs')
+local helpers = require('tests.plenary.helpers')
+
+local uv = vim.uv or vim.loop
+local file = helpers.create_file({})
+
+describe('get_current_file_dir', function()
+  it('gives the dirname of current_file_path', function()
+    assert.are.same(vim.fs.dirname(file.filename), fs_utils.get_current_file_dir())
+  end)
+
+  it('always gives an absolute path', function()
+    local tempdir = vim.fs.dirname(file.filename)
+    helpers.with_cwd(tempdir, function()
+      assert.are.same('.', vim.fs.dirname(vim.fn.bufname()))
+      local dir = fs_utils.get_current_file_dir()
+      assert.are.same(dir .. '/', vim.fn.fnamemodify(dir, ':p'))
+    end)
+  end)
+end)
+
+describe('substitute_path', function()
+  it('leaves absolute paths untouched', function()
+    assert.are.same('/a/b/c', fs_utils.substitute_path('/a/b/c'))
+  end)
+
+  it('expands ~ to HOME', function()
+    local output
+    helpers.with_var(vim.env, 'HOME', '/home/org', function()
+      output = fs_utils.substitute_path('~/foobar')
+    end)
+    assert.are.same('/home/org/foobar', output)
+  end)
+
+  it('expands . to the current file dir', function()
+    local output = fs_utils.substitute_path('./a/b')
+    assert(output)
+    assert(vim.startswith(output, vim.fs.dirname(file.filename)))
+  end)
+
+  it('expands .. to the current file dir plus ..', function()
+    local output = fs_utils.substitute_path('../a/b')
+    assert(output)
+    assert(vim.startswith(output, vim.fs.dirname(file.filename)))
+    local normalized = vim.fs.normalize(output)
+    assert.are.Not.same(output, normalized, "normalize didn't remove ..")
+  end)
+
+  it('fails on all other relative paths', function()
+    assert.is.False(fs_utils.substitute_path('a/b/c'))
+  end)
+end)
+
+describe('get_real_path', function()
+  local link_name = nil
+
+  before_each(function()
+    if not link_name then
+      link_name = vim.fn.tempname()
+      assert(uv.fs_symlink(file.filename, link_name))
+    end
+  end)
+
+  it('resolves symlinks', function()
+    assert(link_name)
+    assert.are.same(file.filename, fs_utils.get_real_path(link_name))
+  end)
+
+  it('resolves relative paths', function()
+    assert(link_name)
+    local relpath = vim.fs.joinpath('.', vim.fs.basename(link_name))
+    assert.are.same(file.filename, fs_utils.get_real_path(relpath))
+  end)
+
+  it('keeps trailing slash if it is there', function()
+    local path = fs_utils.get_real_path('././')
+    assert.are.same(vim.fs.dirname(file.filename) .. '/', path)
+  end)
+
+  it('keeps trailing slash away if it is not there', function()
+    local path = fs_utils.get_real_path('./.')
+    assert.are.same(vim.fs.dirname(file.filename), path)
+  end)
+
+  it('fails on bare dot "."', function()
+    assert.is.False(fs_utils.get_real_path('.'))
+  end)
+end)

--- a/tests/plenary/utils_spec.lua
+++ b/tests/plenary/utils_spec.lua
@@ -1,17 +1,41 @@
 local utils = require('orgmode.utils')
+local helpers = require('tests.plenary.helpers')
 
-describe('Utils', function()
-  it('should properly reduce', function()
+describe('Util', function()
+  describe('reduce', function()
     local nums = { 1, 2, 3 }
-    local sum = utils.reduce(nums, function(acc, num)
-      return acc + num
-    end, 0)
-    assert.are.same(6, sum)
 
-    local multiplied = utils.reduce(nums, function(acc, num)
-      table.insert(acc, num * 2)
-      return acc
-    end, {})
-    assert.are.same({ 2, 4, 6 }, multiplied)
+    it('works on sums', function()
+      local sum = utils.reduce(nums, function(acc, num)
+        return acc + num
+      end, 0)
+      assert.are.same(6, sum)
+    end)
+
+    it('works on products', function()
+      local multiplied = utils.reduce(nums, function(acc, num)
+        table.insert(acc, num * 2)
+        return acc
+      end, {})
+      assert.are.same({ 2, 4, 6 }, multiplied)
+    end)
+  end)
+
+  describe('current_file_path', function()
+    it('returns the buffer name', function()
+      local file = helpers.create_file({})
+      assert.are.Not.same('', file.filename)
+      assert.are.same(file.filename, utils.current_file_path())
+    end)
+    it('always returns the full path', function()
+      local file = helpers.create_file({})
+      local dirname = vim.fs.dirname(file.filename)
+      helpers.with_cwd(dirname, function()
+        local relpath = vim.fn.bufname()
+        local abspath = utils.current_file_path()
+        assert(vim.endswith(abspath, relpath))
+        assert.are.Not.same(abspath, relpath)
+      end)
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary

These are some tests I wrote while wrapping my head around how the path-handling utils work. :slightly_smiling_face: 

## Related Issues

Extracted from #878 

## Changes

I've split things into multiple commits to make the review a bit easier.

- changed one function in `mappings.lua` from formatting headline tags manually to using `utils.tags_to_string()`
- changed one occurrence of `vim.cmd(("edit %s"):format(file))` to `vim.cmd.edit(file)`
- refactored `tests/plenary/helpers.lua` to declare its exported functions the same way all other modules do
- added functions `with_var()` and `with_cwd()` to `helpers.lua` to temporarily change global state
- added tests for `utils.current_file_path()` function
- added tests for `utils.fs` module

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
