### PR TITLE
refactor(utils): replace utils.open() with vim.open()

### DIFF
--- a/lua/orgmode/export/init.lua
+++ b/lua/orgmode/export/init.lua
@@ -42,7 +42,7 @@ function Export._exporter(cmd, target, on_success, on_error)
         label = 'Yes',
         key = 'y',
         action = function()
-          return utils.open(target)
+          return vim.ui.open(target)
         end,
       })
       menu:add_option({ label = 'No', key = 'n' })

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -94,23 +94,6 @@ function utils.system_notification(message)
   end
 end
 
-function utils.open(target)
-  if vim.fn.executable('xdg-open') == 1 then
-    vim.system({ 'xdg-open', target }, { text = false })
-    return 0
-  end
-
-  if vim.fn.executable('open') == 1 then
-    vim.system({ 'open', target }, { text = false })
-    return 0
-  end
-
-  if vim.fn.has('win32') == 1 then
-    vim.system({ 'start', target }, { text = false })
-    return 0
-  end
-end
-
 ---@param msg string|table
 ---@param additional_msg? table
 ---@param store_in_history? boolean


### PR DESCRIPTION
## Summary

This PR removes the function [`utils.open()`][1] and replaces it with [`vim.ui.open()`][2].

[1]: https://github.com/nvim-orgmode/orgmode/blob/3583faceee01ef684645476a1feb07ab3688f6d1/lua/orgmode/utils/init.lua#L97-L112
[2]: https://github.com/neovim/neovim/blob/e4a58a7ca03457668492f8f41189ea2f23700172/runtime/lua/vim/ui.lua#L136-L172

As far as I can tell, this helper was only used in `export.lua`. Hyperlinks used `vim.ui.open()` from the start.

The utils function does basically the same as the built-in, except:
1. doesn't return an awaitable object
2. doesn't search for executables as thoroughly.

## Related Issues

Extracted from #878 

## Changes

- replaced `utils.open()` in export.lua with `vim.ui.open()`
- removed the function itself

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
