### PR TITLE
feat(utils): add optional flag to `utils.writefile()` for exclusive writes

### DIFF
--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -55,10 +55,12 @@ end
 
 ---@param file string
 ---@param data string|string[]
+---@param opts? {excl?: boolean}
 ---@return OrgPromise<integer> bytes
-function utils.writefile(file, data)
+function utils.writefile(file, data, opts)
   return Promise.new(function(resolve, reject)
-    uv.fs_open(file, 'w', 438, function(err1, fd)
+    local flags = opts and opts.excl and 'wx' or 'w'
+    uv.fs_open(file, flags, 438, function(err1, fd)
       if err1 then
         return reject(err1)
       end

--- a/tests/plenary/org/fold_spec.lua
+++ b/tests/plenary/org/fold_spec.lua
@@ -1,0 +1,17 @@
+local helpers = require('tests.plenary.helpers')
+
+describe('folding', function()
+  it('works', function()
+    helpers.create_file({
+      '* First',
+      '** Second',
+      '*** Third',
+      '**** Fourth',
+      '***** Fifth',
+      'text',
+    })
+    vim.cmd.normal({ 'GzM', bang = true })
+    local foldlevel = vim.fn.foldlevel(6)
+    assert.are.same(5, foldlevel)
+  end)
+end)

--- a/tests/plenary/utils_spec.lua
+++ b/tests/plenary/utils_spec.lua
@@ -124,5 +124,15 @@ describe('Util', function()
       local msg = err:sub(#err - #expected)
       assert.are.equal(expected, msg)
     end)
+
+    it('allows no-clobber writes', function()
+      local promise = utils.writefile(filename, contents, { excl = true })
+      ---@type boolean, string?
+      local ok, err = pcall(promise.wait, promise)
+      assert.is.False(ok)
+      assert(err)
+      local expected = 'EEXIST: file already exists: ' .. filename
+      assert.are.equal(expected, err)
+    end)
   end)
 end)


### PR DESCRIPTION
## Summary

This PR adds an optional flag to `utils.writefile()` to enable exclusive writes. Such a write fails if a file with the given name already exists.

The org-attach feature requires functionality like this because it is really adamant about not overwriting attachments that the user might not be aware of. [Example here](https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L559-L560).

## Related Issues

Extracted from #878 

Slowly getting there …

## Changes

- Add new optional parameter `opts` to `utils.writefile()`. Right now, the only option is a boolean flag `excl`.
- Add tests for `utils.writefile()`
- Add tests for `utils.readfile()`
- Also add a tiny test for folds; I was debugging an issue with folding earlier (turns out lazy loading was the culprit) and since there are no tests of folding at all rn, I didn't want to throw it away :slightly_smiling_face: 

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
