### PR TITLE
feat(files): add method `OrgHeadline:toggle_tag()`

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -288,6 +288,49 @@ function Headline:set_tags(tags)
   vim.api.nvim_buf_set_text(bufnr, pred_end_row, pred_end_col, pred_end_row, end_col, { text })
 end
 
+---@param tag string
+---@return boolean newly_added
+function Headline:add_tag(tag)
+  local current_tags = self:get_own_tags()
+  local present = vim.tbl_contains(current_tags, tag)
+  if not present then
+    table.insert(current_tags, tag)
+  end
+  self:set_tags(utils.tags_to_string(current_tags))
+  return not present
+end
+
+---@param tag string
+---@return boolean newly_removed
+function Headline:remove_tag(tag)
+  local current_tags = self:get_own_tags()
+  ---@type string[]
+  local new_tags = vim.tbl_filter(function(i)
+    return i ~= tag
+  end, current_tags)
+  local present = #new_tags ~= #current_tags
+  if present then
+    self:set_tags(utils.tags_to_string(new_tags))
+  end
+  return present
+end
+
+---@param tag string
+---@return boolean newly_added
+function Headline:toggle_tag(tag)
+  local current_tags = self:get_own_tags()
+  local present = vim.tbl_contains(current_tags, tag)
+  if present then
+    current_tags = vim.tbl_filter(function(i)
+      return i ~= tag
+    end, current_tags)
+  else
+    table.insert(current_tags, tag)
+  end
+  self:set_tags(utils.tags_to_string(current_tags))
+  return not present
+end
+
 function Headline:align_tags()
   local own_tags, node = self:get_own_tags()
   if node then

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -71,19 +71,10 @@ function OrgMappings:set_tags(tags)
     end)
 end
 
+---@return nil
 function OrgMappings:toggle_archive_tag()
   local headline = self.files:get_closest_headline()
-  local current_tags = headline:get_own_tags()
-
-  if vim.tbl_contains(current_tags, 'ARCHIVE') then
-    current_tags = vim.tbl_filter(function(tag)
-      return tag ~= 'ARCHIVE'
-    end, current_tags)
-  else
-    table.insert(current_tags, 'ARCHIVE')
-  end
-
-  return headline:set_tags(utils.tags_to_string(current_tags))
+  headline:toggle_tag('ARCHIVE')
 end
 
 function OrgMappings:cycle()


### PR DESCRIPTION
## Summary

This PR adds a method `OrgHeadline:toggle_tag()`.

Right now, this simply moves the code of `OrgMappings.toggle_archive_tag()` into the `OrgHeadline` class. However, the org-attach module has a feature [org_attach_auto_tag][man], that enables, disables and toggles the tag `:ATTACH:` when managing attachments. It's used all over the place. ([1], [2], [3], [4], [5], [6], [7])

[man]: https://orgmode.org/manual/Attachment-options.html#index-org_002dattach_002dauto_002dtag
[1]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L529
[2]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L542
[3]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L562
[4]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L600
[5]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L644
[6]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L692
[7]: https://github.com/emacs-mirror/emacs/blob/4da38c632161867e914b3a13dc760f8019255f94/lisp/org/org-attach.el#L695

## Related Issues

Extracted from #878 

## Changes

- add method `OrgHeadline:toggle_tag(tag: string, onoff?: boolean)`
- use it in `OrgMappings:toggle_archive_tag()`
- add tests in `headline_spec.lua`

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
