### PR TITLE
Name Change: rolodex.nvim -> RLDX.nvim

### DIFF
--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -87,7 +87,7 @@ require('cmp').setup({
 })
 #+END_SRC
 
-*** rolodex-nvim
+*** rolodex.nvim
 :PROPERTIES:
 :CUSTOM_ID: rolodex-nvim
 :END:

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -12,6 +12,7 @@ Orgmode supports various plugins to extend its functionality or make it more pre
 - [[#completion-plugins][Completion plugins]]
   - [[#blinkcmp][blink.cmp]]
   - [[#nvim-cmp][nvim-cmp]]
+  - [[#rolodex.nvim][rolodex.nvim]]
 - [[#aesthetics][Aestehtics]]
   - [[#org-bulletsnvim][org-bullets.nvim]]
   - [[#headlinesnvim][headlines.nvim]]
@@ -82,6 +83,21 @@ Add the =orgmode= source to =nvim-cmp= ~sources~ list.
 require('cmp').setup({
   sources = {
     { name = 'orgmode' }
+  }
+})
+#+END_SRC
+
+*** rolodex.nvim
+:PROPERTIES:
+:CUSTOM_ID: rolodex.nvim
+:END:
+Link: [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]]
+1. Add [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]] plugin to Neovim.
+2. Add the =cmp_rolodex= source to =nvim-cmp= ~sources~ list.
+#+BEGIN_SRC lua
+require('cmp').setup({
+  sources = {
+    { name = 'cmp_rolodex' }
   }
 })
 #+END_SRC

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -12,7 +12,7 @@ Orgmode supports various plugins to extend its functionality or make it more pre
 - [[#completion-plugins][Completion plugins]]
   - [[#blinkcmp][blink.cmp]]
   - [[#nvim-cmp][nvim-cmp]]
-  - [[#rolodexnvim][rolodex.nvim]]
+  - [[#rldxnvim][RLDX.nvim]]
 - [[#aesthetics][Aestehtics]]
   - [[#org-bulletsnvim][org-bullets.nvim]]
   - [[#headlinesnvim][headlines.nvim]]
@@ -87,12 +87,12 @@ require('cmp').setup({
 })
 #+END_SRC
 
-*** rolodex.nvim
+*** RLDX.nvim
 :PROPERTIES:
-:CUSTOM_ID: rolodexnvim
+:CUSTOM_ID: rldxnvim
 :END:
-Link: [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]]
-1. Add [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]] plugin to Neovim.
+Link: [[https://github.com/michhernand/RLDX.nvim][RLDX.nvim]]
+1. Add [[https://github.com/michhernand/RLDX.nvim][RLDX.nvim]] plugin to Neovim.
 2. Add the =cmp_rolodex= source to =nvim-cmp= ~sources~ list.
 #+BEGIN_SRC lua
 require('cmp').setup({

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -12,7 +12,7 @@ Orgmode supports various plugins to extend its functionality or make it more pre
 - [[#completion-plugins][Completion plugins]]
   - [[#blinkcmp][blink.cmp]]
   - [[#nvim-cmp][nvim-cmp]]
-  - [[#rolodex-nvim][rolodex.nvim]]
+  - [[#rolodexnvim][rolodex.nvim]]
 - [[#aesthetics][Aestehtics]]
   - [[#org-bulletsnvim][org-bullets.nvim]]
   - [[#headlinesnvim][headlines.nvim]]
@@ -89,7 +89,7 @@ require('cmp').setup({
 
 *** rolodex.nvim
 :PROPERTIES:
-:CUSTOM_ID: rolodex-nvim
+:CUSTOM_ID: rolodexnvim
 :END:
 Link: [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]]
 1. Add [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]] plugin to Neovim.

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -12,7 +12,7 @@ Orgmode supports various plugins to extend its functionality or make it more pre
 - [[#completion-plugins][Completion plugins]]
   - [[#blinkcmp][blink.cmp]]
   - [[#nvim-cmp][nvim-cmp]]
-  - [[#rolodex.nvim][rolodex.nvim]]
+  - [[#rolodex-nvim][rolodex.nvim]]
 - [[#aesthetics][Aestehtics]]
   - [[#org-bulletsnvim][org-bullets.nvim]]
   - [[#headlinesnvim][headlines.nvim]]
@@ -89,7 +89,7 @@ require('cmp').setup({
 
 *** rolodex.nvim
 :PROPERTIES:
-:CUSTOM_ID: rolodex.nvim
+:CUSTOM_ID: rolodex-nvim
 :END:
 Link: [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]]
 1. Add [[https://github.com/michhernand/rolodex.nvim][rolodex.nvim]] plugin to Neovim.

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -87,7 +87,7 @@ require('cmp').setup({
 })
 #+END_SRC
 
-*** rolodex.nvim
+*** rolodex-nvim
 :PROPERTIES:
 :CUSTOM_ID: rolodex-nvim
 :END:


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

Rolodex is changing its name to RLDX to avoid any down-the-road trademark issues. Updating those changes here too.