### PR TITLE
fix(ui): allow built-in completions in orgmode.ui.input

### DIFF
--- a/lua/orgmode/ui/input.lua
+++ b/lua/orgmode/ui/input.lua
@@ -7,7 +7,7 @@ local OrgInput = {}
 
 ---@param prompt string
 ---@param default? string
----@param completion? fun(arg_lead: string): string[]
+---@param completion? string | fun(arg_lead: string): string[]
 ---@return OrgPromise<string>
 function OrgInput.open(prompt, default, completion)
   _G.orgmode.__input_completion = completion
@@ -15,7 +15,9 @@ function OrgInput.open(prompt, default, completion)
     prompt = prompt,
     default = default or '',
   }
-  if completion then
+  if type(completion) == 'string' then
+    opts.completion = completion
+  elseif completion then
     opts.completion = 'customlist,v:lua.orgmode.__input_completion'
   end
 


### PR DESCRIPTION
## Summary

Allow `ui.input` to take not only functions for custom completion, but also strings for buil-in completion.

The org-attach feature uses both the `dir` built-in completion (to choose a directory to attach) and the `buffer` built-in completion (to choose a buffer whose contents are to be attached).

## Related Issues

Extracted from #878

## Changes

- adjust type signature of `orgmode.ui.input.open()` to allow string-type completion arguments
- special-case on `type(completion)` being a string.

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
