### PR TITLE
feat(mappings): open at point opens files

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -882,6 +882,11 @@ function OrgMappings:open_at_point()
   local link = OrgHyperlink.at_cursor()
 
   if link then
+    local url = link.url:to_string()
+    if url:find("^[/~.]") then
+      vim.ui.open(url)
+      return true
+    end
     return self.links:follow(link.url:to_string())
   end
 


### PR DESCRIPTION
## Summary

Suppose you want to link to a PDF file on your system. If the (relative) file path does not include spaces, you can use `gx` mapping from neovim. However, when we have a nice url handler in orgmode.nvim, we can leverage that and pass the parsed url to `vim.ui.open` (same function that `gx` calls).
Currently, only urls that start with `/` or `~` or `.` are considered "files".

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #

Closes #

## Changes

No changes in the api or the url finding mechanism. Only in `open_at_point` function of the `OrgMappings` object.

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
