### PR TITLE
feat(images): add support for image previewing with Snacks

### DIFF
--- a/lua/orgmode/colors/highlighter/init.lua
+++ b/lua/orgmode/colors/highlighter/init.lua
@@ -7,7 +7,6 @@
 ---@field private _ephemeral boolean
 ---@field private buffers table<number, { language_tree: vim.treesitter.LanguageTree, tree: TSTree }>
 local OrgHighlighter = {}
-local config = require('orgmode.config')
 
 function OrgHighlighter:new()
   local data = {

--- a/lua/orgmode/colors/highlighter/markup/init.lua
+++ b/lua/orgmode/colors/highlighter/markup/init.lua
@@ -260,4 +260,12 @@ function OrgMarkup:use_ephemeral()
   return self.highlighter._ephemeral
 end
 
+function OrgMarkup:get_links_for_line(bufnr, line)
+  local cache = self.cache[bufnr]
+  if not cache or not cache[line] then
+    return
+  end
+  return cache[line].highlights.link
+end
+
 return OrgMarkup

--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -1,0 +1,1 @@
+((expr "[") @image (#org-set-link! @image))


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

Add support for rendering images using [snacks.image ](https://github.com/folke/snacks.nvim/blob/main/docs/image.md)

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related: https://github.com/folke/snacks.nvim/issues/1276

## Changes

<!-- List the major changes made in this PR. -->

- Add `images.scm` that is read by Snacks to render images
- Add custom directive that sets metadata for the node to render the image

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
