### PR TITLE
fix(ts): correctly highlight table headings

### DIFF
--- a/queries/org/highlights.scm
+++ b/queries/org/highlights.scm
@@ -40,7 +40,7 @@
 (directive) @org.directive
 (row "|" @org.table.delimiter)
 (cell "|" @org.table.delimiter)
-(table (row (cell (contents) @org.table.heading)))
+(table . (row (cell (contents) @org.table.heading)))
 (table (hr) @org.table.delimiter)
 (fndef label: (expr) @org.footnote (#offset! @org.footnote 0 -4 0 1))
 (link) @org.hyperlink


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->
Ensures a org table only has its heading get the `@org.table.heading` highlight/group applied.

Prior to this, it seems the relevant highlight query accidentally applied to the body of tables as well.

_Before this change:_
![image](https://github.com/user-attachments/assets/dad3f60a-a371-4947-94e4-ee92c86d52d5)

_After this change:_
![image](https://github.com/user-attachments/assets/fce29d8c-54e5-4fc2-b655-c48c7c3dc062)

## Changes

<!-- List the major changes made in this PR. -->

- Updates the TS query for table heading highlights to restrict them to _only_ the first heading

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
