### PR TITLE
feat: expose store_link to agenda .

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -454,6 +454,13 @@ function Agenda:set_tags()
   })
 end
 
+function Agenda:store_link()
+  return self:_remote_edit({
+    action = 'org_mappings.org_store_link',
+    update_in_place = true,
+  })
+end
+
 function Agenda:set_deadline()
   return self:_remote_edit({
     action = 'org_mappings.org_deadline',


### PR DESCRIPTION
## Summary

As title, this PR exposes `store_link` to the Agenda API, so that one can create link to headlines while in the agenda view.

## Changes

<!-- List the major changes made in this PR. -->

- List changes here

## Checklist

I confirm that I have:

- [ ] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [ ] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [ ] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
