### PR TITLE
feat: support updating a headline's cookie from multiple lists

### DIFF
--- a/lua/orgmode/files/elements/listitem.lua
+++ b/lua/orgmode/files/elements/listitem.lua
@@ -71,7 +71,7 @@ function Listitem:update_checkbox(action)
   else
     local parent_headline = self.file:get_closest_headline_or_nil()
     if parent_headline then
-      parent_headline:update_cookie(parent_list)
+      parent_headline:update_cookie()
     end
   end
 end

--- a/tests/plenary/ui/mappings/checkbox_spec.lua
+++ b/tests/plenary/ui/mappings/checkbox_spec.lua
@@ -151,4 +151,25 @@ describe('Checkbox mappings', function()
       '- [ ] checkbox item',
     }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
   end)
+
+  it('should update headline cookies from multiple lists', function()
+    helpers.create_file({
+      '* Test orgmode [/]',
+      'First List',
+      '- [ ] checkbox item',
+      '- [ ] checkbox item',
+      'Second List',
+      '- [ ] checkbox item',
+    })
+    vim.fn.cursor(4, 1)
+    vim.cmd([[exe "norm \<C-space>"]])
+    assert.are.same({
+      '* Test orgmode [1/3]',
+      'First List',
+      '- [ ] checkbox item',
+      '- [X] checkbox item',
+      'Second List',
+      '- [ ] checkbox item',
+    }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
+  end)
 end)


### PR DESCRIPTION
## Summary

On master if a headline has multiple lists, the cookie is only updated for the current list. In emacs org, the cookie reflects information about all lists under the headline. This PR just makes it so. 

## Changes

<!-- List the major changes made in this PR. -->
![Screenshot from 2025-03-08 06-55-34](https://github.com/user-attachments/assets/e5da6f06-54c1-437e-9e2a-960e568ac42f)

On master the headline would show either 2/3 or 1/1 depending where the last update happens. 

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
