### PR TITLE
feat: support  headline's cookie from TODOs

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -357,12 +357,14 @@ end
 function Headline:set_todo(keyword)
   local todo, node = self:get_todo()
   if todo then
-    return self:_set_node_text(node, keyword)
+    self:_set_node_text(node, keyword)
+    return self:update_parent_cookie()
   end
 
   local stars = self:_get_child_node('stars')
   local _, level = stars:end_()
-  return self:_set_node_text(stars, ('%s %s'):format(('*'):rep(level), keyword))
+  self:_set_node_text(stars, ('%s %s'):format(('*'):rep(level), keyword))
+  return self:update_parent_cookie()
 end
 
 memoize('get_todo')
@@ -891,35 +893,53 @@ function Headline:get_cookie()
 end
 
 function Headline:update_cookie()
-  local section = self:node():parent()
-  if not section then
+  -- Return early if the headline doesn't have a cookie
+  local cookie = self:get_cookie()
+  if not cookie then
     return self
   end
 
-  -- Go through all the lists in this headline and gather checked_boxes
-  local num_boxes, num_checked_boxes = 0, 0
-  local body = section:field('body')[1]
-  for node in body:iter_children() do
-    if node:type() == 'list' then
-      local boxes = self:child_checkboxes(node)
-      num_boxes = num_boxes + #boxes
-      local checked_boxes = vim.tbl_filter(function(box)
-        return box:match('%[%w%]')
-      end, boxes)
-      num_checked_boxes = num_checked_boxes + #checked_boxes
+  local num, denum = 0, 0
+  -- Count checked boxes from all lists
+  local section = self:node():parent()
+  if section then
+    local body = section:field('body')[1]
+    if body then
+      for node in body:iter_children() do
+        if node:type() == 'list' then
+          local boxes = self:child_checkboxes(node)
+          denum = denum + #boxes
+          local checked_boxes = vim.tbl_filter(function(box)
+            return box:match('%[%w%]')
+          end, boxes)
+          num = num + #checked_boxes
+        end
+      end
     end
   end
 
+  -- Count done children headlines
+  local children = self:get_child_headlines()
+  local dones = vim.tbl_filter(function(h)
+    return h:is_done()
+  end, children)
+  num = num + #dones
+  denum = denum + #children
+
   -- Update the cookie
-  local cookie = self:get_cookie()
-  if cookie then
-    local new_cookie_val
-    if self.file:get_node_text(cookie):find('%%') then
-      new_cookie_val = ('[%d%%]'):format((num_checked_boxes / num_boxes) * 100)
-    else
-      new_cookie_val = ('[%d/%d]'):format(num_checked_boxes, num_boxes)
-    end
-    return self:_set_node_text(cookie, new_cookie_val)
+  local new_cookie_val
+  if self.file:get_node_text(cookie):find('%%') then
+    new_cookie_val = ('[%d%%]'):format((num / denum) * 100)
+  else
+    new_cookie_val = ('[%d/%d]'):format(num, denum)
+  end
+  return self:_set_node_text(cookie, new_cookie_val)
+end
+
+function Headline:update_parent_cookie()
+  local parent = self:get_parent_headline()
+  if parent and parent.headline then
+    parent:update_cookie()
   end
   return self
 end

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -929,7 +929,18 @@ function Headline:update_cookie()
     end
   end
 
+  -- Update the cookie
+  return self:set_cookie(cookie, num, denum)
+end
+
+function Headline:update_todo_cookie()
   -- Count done children headlines
+  -- Return early if the headline doesn't have a cookie
+  local cookie = self:get_cookie()
+  if not cookie then
+    return self
+  end
+  local num, denum = 0, 0
   local children = self:get_child_headlines()
   local dones = vim.tbl_filter(function(h)
     return h:is_done()
@@ -944,7 +955,7 @@ end
 function Headline:update_parent_cookie()
   local parent = self:get_parent_headline()
   if parent and parent.headline then
-    parent:update_cookie()
+    parent:update_todo_cookie()
   end
   return self
 end

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -892,7 +892,7 @@ function Headline:get_cookie()
   return self:_parse_title_part('%[%d?%d?%d?%%%]')
 end
 
-function Headline:set_cookie(cookie, num, denum)
+function Headline:_set_cookie(cookie, num, denum)
   -- Update the cookie
   local new_cookie_val
   if self.file:get_node_text(cookie):find('%%') then
@@ -933,8 +933,8 @@ function Headline:update_cookie()
     end
   end
 
-  -- Update the cookie
-  return self:set_cookie(cookie, num_checked_boxes, num_boxes)
+  -- Set the cookie
+  return self:_set_cookie(cookie, num_checked_boxes, num_boxes)
 end
 
 function Headline:update_todo_cookie()
@@ -952,8 +952,8 @@ function Headline:update_todo_cookie()
     return h:is_done()
   end, children)
 
-  -- Update the cookie
-  return self:set_cookie(cookie, #dones, #children)
+  -- Set the cookie
+  return self:_set_cookie(cookie, #dones, #children)
 end
 
 function Headline:update_parent_cookie()

--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -892,6 +892,17 @@ function Headline:get_cookie()
   return self:_parse_title_part('%[%d?%d?%d?%%%]')
 end
 
+function Headline:set_cookie(cookie, num, denum)
+  -- Update the cookie
+  local new_cookie_val
+  if self.file:get_node_text(cookie):find('%%') then
+    new_cookie_val = ('[%d%%]'):format((num / denum) * 100)
+  else
+    new_cookie_val = ('[%d/%d]'):format(num, denum)
+  end
+  return self:_set_node_text(cookie, new_cookie_val)
+end
+
 function Headline:update_cookie()
   -- Return early if the headline doesn't have a cookie
   local cookie = self:get_cookie()
@@ -927,13 +938,7 @@ function Headline:update_cookie()
   denum = denum + #children
 
   -- Update the cookie
-  local new_cookie_val
-  if self.file:get_node_text(cookie):find('%%') then
-    new_cookie_val = ('[%d%%]'):format((num / denum) * 100)
-  else
-    new_cookie_val = ('[%d/%d]'):format(num, denum)
-  end
-  return self:_set_node_text(cookie, new_cookie_val)
+  return self:set_cookie(cookie, num, denum)
 end
 
 function Headline:update_parent_cookie()

--- a/tests/plenary/ui/mappings/todo_spec.lua
+++ b/tests/plenary/ui/mappings/todo_spec.lua
@@ -408,4 +408,26 @@ describe('Todo mappings', function()
       '  :END:',
     }, vim.api.nvim_buf_get_lines(0, 2, 11, false))
   end)
+
+  it('should update headline cookies when children todo state changes', function()
+    helpers.create_file({
+      '* Test orgmode [/]',
+      '** TODO item',
+      '** TODO item',
+      '** TODO item',
+      '** TODO item',
+    })
+    vim.fn.cursor(4, 1)
+    local now = Date.now()
+    -- Changing to DONE and adding closed date
+    vim.cmd([[norm citd]])
+    assert.are.same({
+      '* Test orgmode [1/4]',
+      '** TODO item',
+      '** TODO item',
+      '** DONE item',
+      '   CLOSED: [' .. now:to_string() .. ']',
+      '** TODO item',
+    }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
+  end)
 end)


### PR DESCRIPTION
## Summary

Add function `update_todo_cookie` to update a headline's cookie from a TODO state change.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Closes #305


## Changes

<!-- List the major changes made in this PR. -->
![Screenshot from 2025-03-15 21-25-54](https://github.com/user-attachments/assets/ea45a48a-7e72-45e1-8e80-6d9c54f704e4)




## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
