### PR TITLE
feat(babel): add directory creation support with :mkdirp header argument

### DIFF
--- a/lua/orgmode/babel/tangle.lua
+++ b/lua/orgmode/babel/tangle.lua
@@ -57,7 +57,6 @@ function Tangle:tangle()
 
     if info.header_args[':mkdirp'] == 'yes' then
       local path = vim.fn.fnamemodify(info.filename, ':h')
-      utils.echo_info(('Should create the directory %s'):format(path))
       vim.fn.mkdir(path, "p")
     end
 

--- a/lua/orgmode/babel/tangle.lua
+++ b/lua/orgmode/babel/tangle.lua
@@ -57,7 +57,7 @@ function Tangle:tangle()
 
     if info.header_args[':mkdirp'] == 'yes' then
       local path = vim.fn.fnamemodify(info.filename, ':h')
-      vim.fn.mkdir(path, "p")
+      vim.fn.mkdir(path, 'p')
     end
 
     if info.name then

--- a/lua/orgmode/babel/tangle.lua
+++ b/lua/orgmode/babel/tangle.lua
@@ -54,6 +54,13 @@ function Tangle:tangle()
         end
       end
     end
+
+    if info.header_args[':mkdirp'] == 'yes' then
+      local path = vim.fn.fnamemodify(info.filename, ':h')
+      utils.echo_info(('Should create the directory %s'):format(path))
+      vim.fn.mkdir(path, "p")
+    end
+
     if info.name then
       block_content_by_name[info.name] = parsed_content
     end


### PR DESCRIPTION
When tangling code blocks to files, automatically create parent directories when the :mkdirp header argument is set to 'yes'.

## Summary

The ‘mkdirp’ header argument creates parent directories for tangled files if the directory does not exist. A ‘yes’ value enables directory creation whereas ‘no’ inhibits it.


https://github.com/nvim-orgmode/orgmode/issues/927
