### PR TITLE
fix(windows): fix folds getting messed up when changing todo state

### DIFF
--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -492,6 +492,7 @@ function OrgFile:set_node_text(node, text, front_trim)
     end_col = vim.api.nvim_buf_get_lines(bufnr, end_row, end_row + 1, false)[1]:len()
   end
   local ok = pcall(vim.api.nvim_buf_set_text, bufnr, start_row, start_col, end_row, end_col, replacement)
+  vim.cmd('normal! zX') -- Refresh folds
   return ok
 end
 


### PR DESCRIPTION
## Summary

Problem: when changing todo state in an orgfile using `orgmode-org_todo_prev` or `orgmode-org_todo_next`, the last line in the fold seems to exit the fold. This happens when using `nvim_buf_set_text` to change the TODO state. It also happens when using `nvim_buf_get_lines` to add the closing timestamp.

I think it's a neovim issue.
https://github.com/neovim/neovim/issues/30352 might be related.


## Changes
Solution: `:help zX`
Run fold recomputation. `zx` runs `zv` which opens the fold after recomputation. `zX` does not this do. Changing TODO state should not change fold state.

## Checklist

I confirm that I have:

- [ x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [ x] **My PR title also follows the conventional commits specification.**
- [ x] **Updated relevant documentation,** if necessary.
- [ x] **Thoroughly tested my changes.**
- [ x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ x] **Checked for breaking changes** and documented them, if any.
