### PR TITLE
fix(template): Use env variable USERNAME in Windows

### DIFF
--- a/lua/orgmode/capture/template/init.lua
+++ b/lua/orgmode/capture/template/init.lua
@@ -6,8 +6,6 @@ local Calendar = require('orgmode.objects.calendar')
 local Promise = require('orgmode.utils.promise')
 local Input = require('orgmode.ui.input')
 
-local is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
-
 local expansions = {
   ['%%f'] = function()
     return vim.fn.expand('%')
@@ -16,7 +14,10 @@ local expansions = {
     return vim.fn.expand('%:p')
   end,
   ['%%n'] = function()
-    return is_windows and os.getenv('USERNAME') or os.getenv('USER')
+    if vim.fn.has('win32') == 1 then
+      return os.getenv('USERNAME')
+    end
+    return os.getenv('USER')
   end,
   ['%%x'] = function()
     return vim.fn.getreg('+')

--- a/lua/orgmode/capture/template/init.lua
+++ b/lua/orgmode/capture/template/init.lua
@@ -6,6 +6,8 @@ local Calendar = require('orgmode.objects.calendar')
 local Promise = require('orgmode.utils.promise')
 local Input = require('orgmode.ui.input')
 
+local is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
+
 local expansions = {
   ['%%f'] = function()
     return vim.fn.expand('%')
@@ -14,7 +16,7 @@ local expansions = {
     return vim.fn.expand('%:p')
   end,
   ['%%n'] = function()
-    return os.getenv('USER')
+    return is_windows and os.getenv('USERNAME') or os.getenv('USER')
   end,
   ['%%x'] = function()
     return vim.fn.getreg('+')


### PR DESCRIPTION
## Summary

When creating capturing templates we can un the `%n` variable to insert the current user. It is done by using the environment variable `USER`. However, in Windows the variable is called `USERNAME`. This PR fixes this issue.

This PR adds..

## Related Issues

Related #

Closes #

## Changes

- Check whether it is being run in Windows.
- If is running in Windows it uses the environment variable `USERNAME` to query the current user name, otherwise it uses the `USER` variable.

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
