### PR TITLE
feat(images): add support for rendering latex math expressions

### DIFF
--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -2,3 +2,12 @@
   (#gsub! @image.src "^file:" "")
   (#match? @image.src "(png|jpg|jpeg|gif|bmp|webp|tiff|heic|avif|mp4|mov|avi|mkv|webm|pdf)$")
 )
+
+(block
+  name: (expr) @name
+  parameter: (expr) @lang
+  contents: (contents (expr) @image.content)
+  (#match? @name "(src|SRC)")
+  (#eq? @lang "math")
+  (#set! injection.language "latex")
+  (#set! image.ext "math.tex"))


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->
This PR adds support for rendering LaTeX math expressions in org files by using snacks.images.

<img width="234" alt="image" src="https://github.com/user-attachments/assets/6bce5a48-58ef-44d5-8e86-9b10fd152474" />

Related: #907

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->


## Changes

<!-- List the major changes made in this PR. -->

- Add a tree-sitter query for detecting latex math expressions

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
