### PR TITLE
fix(statistics cookie): count only TODO headlines

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -946,14 +946,19 @@ function Headline:update_todo_cookie()
     return self
   end
 
-  -- Count done children headlines
+  -- Count done children headlines and total children with TODO keywords
   local children = self:get_child_headlines()
-  local dones = vim.tbl_filter(function(h)
-    return h:is_done()
+  local headlines_with_todo = vim.tbl_filter(function(h)
+    local todo, _, _ = h:get_todo()
+    return todo ~= nil
   end, children)
 
+  local dones = vim.tbl_filter(function(h)
+    return h:is_done()
+  end, headlines_with_todo)
+
   -- Set the cookie
-  return self:_set_cookie(cookie, #dones, #children)
+  return self:_set_cookie(cookie, #dones, #headlines_with_todo)
 end
 
 function Headline:update_parent_cookie()

--- a/tests/plenary/ui/mappings/todo_spec.lua
+++ b/tests/plenary/ui/mappings/todo_spec.lua
@@ -430,4 +430,25 @@ describe('Todo mappings', function()
       '** TODO item',
     }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
   end)
+  it('should update headline cookies when children todo state changes', function()
+    helpers.create_file({
+      '* Test orgmode [/]',
+      '** TODO item',
+      '** TODO item',
+      '** TODO item',
+      '** Non-todo item',
+    })
+    vim.fn.cursor(4, 1)
+    local now = Date.now()
+    -- Changing to DONE and adding closed date
+    vim.cmd([[norm citd]])
+    assert.are.same({
+      '* Test orgmode [1/3]',
+      '** TODO item',
+      '** TODO item',
+      '** DONE item',
+      '   CLOSED: [' .. now:to_string() .. ']',
+      '** Non-todo item',
+    }, vim.api.nvim_buf_get_lines(0, 0, 6, false))
+  end)
 end)


### PR DESCRIPTION
@kristijanhusak Sorry to open this again, I made a mistake when creating the original PR from Octo.nvim: The base branch selected was the master branch from my forked repository, not the original upstream repository. So the PR merge went into the wrong branch.

# Old PR message

Previously, the todo statistics cookie was counting all child headlines in its calculation, regardless of whether they had TODO keywords. This fix modifies the `update_todo_cookie` function to:

1. Filter child headlines to only those with valid TODO keywords
2. Calculate the ratio of DONE tasks to total tasks with TODO keywords
3. Update the cookie with the correct statistics

This ensures consistency with Org Mode's behavior where non-task headlines are excluded from statistics calculations.

## Summary

<!-- Give a brief description of what your PR does. -->

This PR adds..

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #

Closes #

## Changes

<!-- List the major changes made in this PR. -->

- List changes here

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
