### PR TITLE
refactor:  move insert_item logic out of meta_return

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -663,7 +663,9 @@ function OrgMappings:meta_return(suffix)
   end
 end
 
-function OrgMappings:insert_item_below_this(listitem)
+---@private
+---@param listitem OrgListitem
+function OrgMappings:_insert_item_below(listitem)
   local line = vim.fn.getline(listitem:start() + 1)
   local srow, _, end_row, end_col = listitem:range()
   local is_multiline = (end_row - srow) > 1 or end_col == 0

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -659,7 +659,7 @@ function OrgMappings:meta_return(suffix)
     if not listitem or listitem:type() ~= 'listitem' then
       return
     end
-    return self:insert_item_below_this(listitem)
+    return self:_insert_item_below(listitem)
   end
 end
 


### PR DESCRIPTION
## Summary

Move insert_item logic out of meta_return into a reusable function. In a follow up, https://github.com/nvim-orgmode/orgmode/pull/943 will make meta_return logic even cleaner. This will make it easy for one to customize meta_return's behavior in their config. 


## Changes

<!-- List the major changes made in this PR. -->

- As title.

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
