### PR TITLE
fix: meta_return on a link item

### DIFF
--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -618,19 +618,7 @@ end
 
 function OrgMappings:meta_return(suffix)
   suffix = suffix or ''
-  local item = ts_utils.get_node_at_cursor()
-
-  if not item then
-    return
-  end
-
-  if item:type() == 'expr' then
-    item = item:parent()
-  end
-
-  if item and item:parent() and item:parent():type() == 'headline' then
-    item = item:parent()
-  end
+  local item = ts_utils.closest_item_or_headline_node()
 
   if not item then
     return
@@ -646,21 +634,8 @@ function OrgMappings:meta_return(suffix)
     return true
   end
 
-  if item:type() == 'list' or item:type() == 'listitem' then
-    vim.cmd([[normal! ^]])
-    item = ts_utils.get_node_at_cursor()
-  end
-  if not item then
-    return
-  end
-  local type = item:type()
-  if vim.tbl_contains({ 'paragraph', 'bullet', 'checkbox', 'status' }, type) then
-    local listitem = item:parent()
-    if not listitem or listitem:type() ~= 'listitem' then
-      return
-    end
-    return self:_insert_item_below(listitem)
-  end
+  -- item is a listitem here
+  return self:_insert_item_below(item)
 end
 
 ---@private

--- a/lua/orgmode/utils/treesitter/init.lua
+++ b/lua/orgmode/utils/treesitter/init.lua
@@ -52,6 +52,37 @@ function M.find_headline(node)
   return nil
 end
 
+-- walks the tree to find an item or headline
+---@param node TSNode | nil
+---@return TSNode | nil
+function M.find_item_or_headline(node)
+  if not node then
+    return nil
+  end
+
+  local node_type = node:type()
+  if node_type == 'headline' or node_type == 'listitem' then
+    return node
+  end
+
+  if node_type == 'list' then
+    -- Move right one character to pick up the current listitem
+    vim.cmd([[norm l]])
+    return M.find_item_or_headline(M.get_node_at_cursor())
+  end
+
+  if node_type == 'section' then
+    -- The headline is always the first child of a section
+    return node:field('headline')[1]
+  end
+  return M.find_item_or_headline(node:parent())
+end
+
+-- returns the nearest item or headline
+function M.closest_item_or_headline_node(cursor)
+  return M.find_item_or_headline(M.get_node_at_cursor(cursor))
+end
+
 -- returns the nearest headline
 function M.closest_headline_node(cursor)
   local node = M.get_node_at_cursor(cursor)

--- a/tests/plenary/ui/mappings/meta_return_spec.lua
+++ b/tests/plenary/ui/mappings/meta_return_spec.lua
@@ -522,4 +522,24 @@ describe('Meta return mappings', function()
       }, vim.api.nvim_buf_get_lines(0, 3, 10, false))
     end
   )
+
+  it('should add list item after a link with Enter (org_meta_return)', function()
+    helpers.create_agenda_file({
+      '#TITLE: Test',
+      '',
+      '* TODO Test orgmode',
+      '  - Regular item',
+      '  - [[http://www.com][a link]]',
+      '  - [x] Checkbox item',
+    })
+
+    vim.fn.cursor(5, 14)
+    vim.cmd([[exe "norm ,\<CR>"]])
+    assert.are.same({
+      '  - Regular item',
+      '  - [[http://www.com][a link]]',
+      '  - ',
+      '  - [x] Checkbox item',
+    }, vim.api.nvim_buf_get_lines(0, 3, 10, false))
+  end)
 end)


### PR DESCRIPTION
## Summary

Meta return doesn't work when the cursor is on a link because currently we don't handle link in the logic to find a headline or listitem node (the added test would be failing on master).

This PR factor out that logic into a reusable `find_item_or_headline` function and make it a bit more general. 

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
