### PR TITLE
feat(image): match latex code tag for math preview

### DIFF
--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -6,8 +6,22 @@
 (block
   name: (expr) @name
   parameter: (expr) @lang
-  contents: (contents (expr) @image.content)
+  contents: (contents) @image.content
   (#match? @name "(src|SRC)")
   (#match? @lang "(math|latex)")
   (#set! injection.language "latex")
   (#set! image.ext "math.tex"))
+
+
+(block
+  name: (expr) @name
+  contents: (contents) @image.content
+  (#match? @name "(equation|EQUATION)")
+  (#set! injection.language "latex")
+  (#set! image.ext "math.tex"))
+
+(latex_env
+  (contents) @image.content
+  (#set! injection.language "latex")
+  (#set! image.ext "math.tex"))
+

--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -8,6 +8,6 @@
   parameter: (expr) @lang
   contents: (contents (expr) @image.content)
   (#match? @name "(src|SRC)")
-  (#eq? @lang "math")
+  (#eq? @lang "(math|latex)")
   (#set! injection.language "latex")
   (#set! image.ext "math.tex"))

--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -8,6 +8,6 @@
   parameter: (expr) @lang
   contents: (contents (expr) @image.content)
   (#match? @name "(src|SRC)")
-  (#eq? @lang "(math|latex)")
+  (#match? @lang "(math|latex)")
   (#set! injection.language "latex")
   (#set! image.ext "math.tex"))


### PR DESCRIPTION
## Summary


Add latex preview image for common markups/blocks

![screenshot_20250325_032926](https://github.com/user-attachments/assets/2041ef89-fc2f-4bcb-82c0-9fd7b2b97db2)

Related PRs

- #935 
- #907 

## Changes


- Let the rendering match `latex` source 
- Let the rendering match `equation` block
- Let the rendering match `\[\]` block (`latex_env` in Org Treesitter)

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.

## Further TODOs?

For typst, the rendering is feasible and only just feasible, I did not commit that change, the snippet is below

```scheme
; NOTE: This is buggy
(block
  name: (expr) @name
  parameter: (expr) @lang
  contents: (contents) @image.content 
  (#match? @name "(src|SRC)")
  (#match? @lang "(typst|TYPST)")
  (#set! injection.language "typst")
  (#set! image.ext "math.typ"))
```


Maybe match other common blocks like `align`?