### PR TITLE
chore: remove usage of deprecated neovim functions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,7 @@ jobs:
           - v0.10.2
           - v0.10.3
           - v0.10.4
+          - v0.11.0
           - nightly
     runs-on: ${{ matrix.os }}
     steps:

--- a/lua/orgmode/files/init.lua
+++ b/lua/orgmode/files/init.lua
@@ -372,7 +372,7 @@ function OrgFiles:_files(skip_resolve)
     end, vim.fn.glob(vim.fn.fnamemodify(file, ':p'), false, true))
   end, self.paths)
 
-  all_files = vim.tbl_flatten(all_files)
+  all_files = utils.flatten(all_files)
 
   return vim.tbl_filter(function(file)
     if not utils.is_org_file(file) then


### PR DESCRIPTION
## Summary

Remove deprecation warnings with nvim 0.11.
