### PR TITLE
fix: indent an item's content when entering a new line from normal mode

### DIFF
--- a/tests/plenary/org/indent_spec.lua
+++ b/tests/plenary/org/indent_spec.lua
@@ -237,6 +237,19 @@ local function test_add_line_breaks_to_existing_file()
   expect_whole_buffer(expected)
 end
 
+local function test_insertion_from_normal_mode()
+  helpers.create_file({ '- first item' })
+  vim.cmd([[normal! o]])
+  local user_input = vim.api.nvim_replace_termcodes('i- second item<Esc>ocontent', true, true, true)
+  vim.api.nvim_feedkeys(user_input, 'ntix', false)
+  local expected = {
+    '- first item',
+    '- second item',
+    '  content',
+  }
+  expect_whole_buffer(expected)
+end
+
 -- The actual tests are here.
 
 describe('with "indent",', function()
@@ -258,6 +271,10 @@ describe('with "indent",', function()
 
   it('adding line breaks to list items maintains indent', function()
     test_add_line_breaks_to_existing_file()
+  end)
+
+  it('inserting content from nomral mode is well indented', function()
+    test_insertion_from_normal_mode()
   end)
 end)
 


### PR DESCRIPTION
## Summary

 At the end of a `listitem`, if we hit Enter in insert mode, the cursor will be indented in the following line; if we hit o to enter the new line from normal mode, the cursor will not be indented. The added test is failing on master. This PR fixes that.


Closes #940

## Changes


## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
