### PR TITLE
feat: add ability to search on LEVEL

### DIFF
--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -315,6 +315,7 @@ function OrgFile:apply_search(search, todo_only)
     local closed = item:get_closed_date()
     local properties = item:get_own_properties()
     local priority = item:get_priority()
+    local level = item:get_level()
 
     return search:check({
       props = vim.tbl_extend('keep', {}, properties, {
@@ -324,6 +325,7 @@ function OrgFile:apply_search(search, todo_only)
         closed = closed and closed:to_wrapped_string(false),
         priority = priority,
         todo = item:get_todo() or '',
+        level = level,
       }),
       tags = item:get_tags(),
       todo = item:get_todo() or '',


### PR DESCRIPTION

## Summary

Emacs org-mode allows for matching based on a variable LEVEL which represents the level of the headline. This change enables this feature.

See https://orgmode.org/manual/Matching-tags-and-properties.html

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #

Closes #

## Changes


- Adds LEVEL variable to predicate searches

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
