### PR TITLE
fix(images): add svg to list of supported image types

### DIFF
--- a/queries/org/images.scm
+++ b/queries/org/images.scm
@@ -1,6 +1,6 @@
 (link url: (expr) @image.src
   (#gsub! @image.src "^file:" "")
-  (#match? @image.src "(png|jpg|jpeg|gif|bmp|webp|tiff|heic|avif|mp4|mov|avi|mkv|webm|pdf)$")
+  (#match? @image.src "(png|jpg|jpeg|gif|bmp|webp|tiff|heic|avif|mp4|mov|avi|mkv|webm|pdf|svg)$")
 )
 
 (block


### PR DESCRIPTION
## Summary

This PR adds `svg` to the list of supported image types. It seems that this was missed during the first implementation.

### Before
![2025-04-21-113405_hyprshot](https://github.com/user-attachments/assets/476752a5-aa72-490b-aff4-a0a6bf2a947d)

### After
![2025-04-21-113444_hyprshot](https://github.com/user-attachments/assets/701e47bc-d8ff-40eb-afd6-fc3dbd74c927)

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

- Related https://github.com/folke/snacks.nvim/issues/1276 
- Related https://github.com/nvim-orgmode/orgmode/pull/907

Closes #

## Changes

<!-- List the major changes made in this PR. -->

- Simply added `svg` to the list in `queries/org/images.scm`.

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
