### PR TITLE
docs: fix minor typos

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -544,7 +544,7 @@ Determine whether properties of one headline are inherited by sub-headlines.
 - =string[]= - only the properties named in the given list are inherited
 - =string= - only properties matching the given regex are inherited
 
-Note that for a select few properties, the inheritance behavior is hard-coded withing their special applications.
+Note that for a select few properties, the inheritance behavior is hard-coded within their special applications.
 See [[https://orgmode.org/manual/Property-Inheritance.html][Property Inheritance]] for details.
 
 *** org_babel_default_header_args
@@ -566,7 +566,7 @@ Available options:
 - =0= - start week on Sunday
 - =1= - start week on Monday
 
-Determine on which day the week will start in calendar modal (ex:[[#org_change_date][changing the date under cursor]])
+Determine on which day the week will start in calendar modal (ex: [[#org_change_date][changing the date under cursor]])
 
 *** emacs_config
 :PROPERTIES:
@@ -736,7 +736,7 @@ These arguments are shared between all of the agenda types:
 :CUSTOM_ID: org_agenda_sorting_strategy
 :END:
 - Type:
-=table<'agenda' | 'todo' | 'tags', OrgAgendaSortingStrategy[]><=
+=table<'agenda' | 'todo' | 'tags', OrgAgendaSortingStrategy[]>=
 - Default:
 ~{ agenda = {'time-up', 'priority-down', 'category-keep'}, todo = {'priority-down', 'category-keep'}, tags = {'priority-down', 'category-keep'}}~
 List of sorting strategies to apply to a given view. Available

--- a/docs/index.org
+++ b/docs/index.org
@@ -26,7 +26,7 @@ To view this documentation offline in Neovim, run =:Org help=. More info in [[#g
     end,
   }
   #+end_src
-- Capture youf first note with =<leader>oc=
+- Capture your first note with =<leader>oc=
 - Open up the prompt for agenda with =<leader>oa=
 
 For more details about the installation and usage, check [[./installation.org][Installation page]].


### PR DESCRIPTION
## Summary

Fixes a few minor typos in `/docs`

## Changes
- Spelling fix in index.org (youf -> your)
- Spacing fix in configuration.org
- Spelling fix in configuration.org (withing -> within)
- Fix data type in configuration.org (extraneous `<`)

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
