### PR TITLE
fix: preserve prefix in blink.cmp org directive completions

### DIFF
--- a/lua/orgmode/org/autocompletion/blink.lua
+++ b/lua/orgmode/org/autocompletion/blink.lua
@@ -41,6 +41,9 @@ function Source:get_completions(ctx, callback)
   local triggers = { '#', '+', ':', '*', '/' }
 
   local getInsertTextOffset = function(word)
+    if #word > 1 and word:sub(1, 2) == '#+' then
+      return 0
+    end
     local word_length = #word + 1
     while word_length > 0 do
       local char = word:sub(word_length - 1, word_length - 1)


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

This PR fixes a bug where blink.cmp autocompletion incorrectly removes the `#+` prefix when completing org directives. When typing `#+fi` and selecting `#+filetype` from the completion menu, the completion would incorrectly insert just `filetype` instead of `#+filetype`.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

This PR addresses the bug described in my bug report #977 .

## Changes

<!-- List the major changes made in this PR. -->

- Fixed the `get_completions` function in `lua/orgmode/org/autocompletion/blink.lua` to preserve the `#+` prefix for org directives
- Added a test case in `tests/plenary/org/autocompletion_spec.lua` to verify that `#+` prefixes are preserved when completing org directives
- The fix ensures that other completion types (tags, headlines, etc.) continue to work as before while only affecting org directive completions

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.