### PR TITLE
fix: disable spell-check in URLs

### DIFF
--- a/queries/org/highlights.scm
+++ b/queries/org/highlights.scm
@@ -43,8 +43,8 @@
 (table . (row (cell (contents) @org.table.heading)))
 (table (hr) @org.table.delimiter)
 (fndef label: (expr) @org.footnote (#offset! @org.footnote 0 -4 0 1))
-(link url: (expr) @org.hyperlink.url) @org.hyperlink
-(link_desc url: (expr) @org.hyperlink.url desc: (expr) @org.hyperlink.desc) @org.hyperlink
+(link url: (expr) @org.hyperlink.url @nospell) @org.hyperlink
+(link_desc url: (expr) @org.hyperlink.url @nospell desc: (expr) @org.hyperlink.desc) @org.hyperlink
 (link "[[" @_link_open "]]" @_link_close (#set! conceal ""))
 (link_desc "[[" @_link_open "][" @_link_separator "]]" @_link_close (#set! conceal ""))
 ((link_desc url: (expr)+ @_link_url (#set! @_link_url conceal "")) @_link (#set! @_link url @_link_url))


### PR DESCRIPTION
## Summary

Back when hyperlinks still used extmarks, we disabled spell-checking for the URL part (d383f5c514c1ac10ae2f76c4d427c702fa1e5d8e). This must've gotten lost when switching over to treesitter queries.

This PR disables spell-checking again in `highlights.scm`.

## Related Issues

Related to #547 

## Changes

- Annotate the URL portion of the two relevant queries (`[[url]]` and `[[url][description]]`) with `@nospell`.

## Checklist

I confirm that I have:

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification** (e.g., `feat: add new feature`, `fix: correct bug`, `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
