### PR TITLE
docs: fix absences of line break

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -1097,7 +1097,7 @@ after headline text, with only one space in between.
 :END:
 - Type: =boolean=
 - Default: =true=
-  When set to =true=, tags are
+When set to =true=, tags are
 inherited from parents for purposes of searching. Which means that if
 you have this structure:
 

--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -78,6 +78,7 @@ require('blink.cmp').setup({
 :CUSTOM_ID: nvim-cmp
 :END:
 Link: [[https://github.com/hrsh7th/nvim-cmp][nvim-cmp]]
+
 Add the =orgmode= source to =nvim-cmp= ~sources~ list.
 #+BEGIN_SRC lua
 require('cmp').setup({


### PR DESCRIPTION
Thanks for always maintaining `nvim-orgmode/orgmode`!
I started using orgmode with this plugin, and it makes my task management easier!
Thank you so much!

## Summary

<!-- Give a brief description of what your PR does. -->

This PR fixes the absences of line break in the document website.

https://nvim-orgmode.github.io/configuration#org_use_tag_inheritance
![image](https://github.com/user-attachments/assets/5d9c86df-928d-4f0b-8da3-48d6ca1a4bf7)


https://nvim-orgmode.github.io/plugins#nvim-cmp
![image](https://github.com/user-attachments/assets/1af4e23c-f6c8-4b0b-9577-521f8804064f)

## Related Issues
N/A
<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

## Changes

<!-- List the major changes made in this PR. -->

- The absences of line break in the document website are fixed.

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [ ] ~Thoroughly tested my changes.~ I couldn't find how to test changes related to website locally.
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
