### PR TITLE
fix: =$= and =0= motions for calendar view

### DIFF
--- a/lua/orgmode/objects/calendar.lua
+++ b/lua/orgmode/objects/calendar.lua
@@ -130,6 +130,12 @@ function Calendar:open()
   vim.keymap.set('n', '<Left>', function()
     return self:cursor_left()
   end, map_opts)
+  vim.keymap.set('n', '0', function()
+    return self:beginning()
+  end, map_opts)
+  vim.keymap.set('n', '$', function()
+    return self:ending()
+  end, map_opts)
   vim.keymap.set('n', '<Right>', function()
     return self:cursor_right()
   end, map_opts)
@@ -432,6 +438,26 @@ function Calendar:cursor_left()
       vim.fn.cursor(line, offset)
     end
   end
+  self.date = self:get_selected_date()
+  self:render()
+end
+
+function Calendar:beginning()
+  if self.select_state ~= SelState.DAY then
+    return
+  end
+  local line = vim.fn.line('.')
+  vim.fn.cursor(line, 2)
+  self.date = self:get_selected_date()
+  self:render()
+end
+
+function Calendar:ending()
+  if self.select_state ~= SelState.DAY then
+    return
+  end
+  local line = vim.fn.line('.')
+  vim.fn.cursor(line, vim.fn.winwidth(0) - 3)
   self.date = self:get_selected_date()
   self:render()
 end


### PR DESCRIPTION
## Summary


This PR configures the `$` and `0` motions for the calendar view, so they take us to the last/first day of the week.


I just hacked this together to make it work. I'm happy to address any direction this should be taken.

Thank you! 

## Related Issues

Closes #986 

## Changes

Configuring two new mappings for `$` and `0` on the calendar view. 
## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
