### PR TITLE
docs: fix link to orgmode_api.txt

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -681,7 +681,7 @@ require('orgmode').setup({
           type = 'agenda',
           org_agenda_overriding_header = 'Whole week overview',
           org_agenda_span = 'week', -- 'week' is default, so it's not necessary here, just an example
-          org_agenda_start_on_weekday = 1 -- Start on Monday
+          org_agenda_start_on_weekday = 1, -- Start on Monday
           org_agenda_remove_tags = true -- Do not show tags only for this view
         },
       }

--- a/docs/index.org
+++ b/docs/index.org
@@ -48,7 +48,7 @@ that demonstrates how the similar Orgmode clone [[https://github.com/dhruvasagar
 :PROPERTIES:
 :CUSTOM_ID: api-docs
 :END:
-Nvim-orgmode exposes a Lua API that can be used to interact with the orgmode. To view it, check [[file:../docs/orgmode-api.txt][orgmode-api.txt]]
+Nvim-orgmode exposes a Lua API that can be used to interact with the orgmode. To view it, check [[file:../doc/orgmode_api.txt][orgmode_api.txt]]
 or do =:h OrgApi= in Neovim.
 
 ** Globals and commands


### PR DESCRIPTION
## Summary

36aa2f2 docs: fix lua code for combined agenda view config
bfbd30f docs: fix link to orgmode_api.txt

Currently the link to the txt file results in 404 on the docs:
https://nvim-orgmode.github.io/#api-docs

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

n/a

## Changes

Just docs tweaks
## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [ ] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
