### PR TITLE
docs: typo fix in config link to official documentation

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -840,7 +840,7 @@ Templates have the following fields:
   capture content will be added. If no headline is specified, the
   content will be appended to the end of the file
 - =datetree (boolean | { time_prompt?: boolean, reversed?: boolean, tree_type: 'day' | 'month' | 'week' | 'custom' })=
-  Create a [[https://orgmode.org/manual/Template-elements.hml#FOOT84][date tree]] with current day in the target file and put the capture content there.
+  Create a [[https://orgmode.org/manual/Template-elements.html#FOOT84][date tree]] with current day in the target file and put the capture content there.
   - =true= - Create ascending datetree (newer dates go to end) with the current date
   - ~{ time_prompt = true, reversed?: boolean }~ open up a date picker to select a date before opening up a capture buffer
   - ={ reversed: true }= add entries in reversed order (newer dates comes first)


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

This PR fixes a typo in the configuration docs linking to the date tree footnote in the official orgmode.org manual. 

## Related Issues

Not applicable.

## Changes

<!-- List the major changes made in this PR. -->

- `.hml` -> `.html` in the link to [https://orgmode.org/manual/Template-elements.html#FOOT84](https://orgmode.org/manual/Template-elements.html#FOOT84)

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [X] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [-] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [X] **Checked for breaking changes** and documented them, if any.
