### PR TITLE
Update installation.org

### DIFF
--- a/docs/installation.org
+++ b/docs/installation.org
@@ -7,7 +7,7 @@ Here are few examples:
 
 1. [[https://github.com/folke/lazy.nvim][lazy.nvim]] (Recommended)
    #+begin_src lua
-   {
+   return {
      'nvim-orgmode/orgmode',
      event = 'VeryLazy',
      config = function()


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

This pull request fixes the issue: Missing return block - which is where in the lazy.nvim installation of nvim orgmode it has a missing <exp> error in the plugin file

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #
https://github.com/nvim-orgmode/orgmode/issues/995
Closes #
https://github.com/nvim-orgmode/orgmode/issues/995
## Changes

<!-- List the major changes made in this PR. -->

- added missing return block - which is where in the lazy.nvim installation of nvim orgmode it has a missing <exp> error in the plugin file 

## Checklist

I confirm that I have:

- [*] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [*] **My PR title also follows the conventional commits specification.**
- [*] **Updated relevant documentation,** if necessary.
- [*] **Thoroughly tested my changes.**
- [*] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [*] **Checked for breaking changes** and documented them, if any.
