### PR TITLE
feat(edit_src): Add `org_edit_src_filetype_map` for custom src block filetypes.

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -364,6 +364,16 @@ The indent value for content within =SRC= block types beyond the
 existing indent of the block itself. Only applied when exiting from an
 =org_edit_special= action on a =SRC= block.
 
+*** org_edit_src_filetype_map
+:PROPERTIES:
+:CUSTOM_ID: org_edit_src_filetype_map
+:END:
+- Type: =table<string, string>=
+- Default: ={}=
+This filetype map associates the language name from an Org source block
+with the corresponding Vim filetype, which is then applied to the temporary
+buffer.
+
 *** org_custom_exports
 :PROPERTIES:
 :CUSTOM_ID: org_custom_exports

--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -61,6 +61,7 @@ local DefaultConfig = {
   },
   org_src_window_setup = 'top 16new',
   org_edit_src_content_indentation = 0,
+  org_edit_src_filetype_map = {},
   org_id_uuid_program = 'uuidgen',
   org_id_ts_format = '%Y%m%d%H%M%S',
   org_id_method = 'uuid',

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -564,6 +564,7 @@ end
 ---@param skip_ftmatch? boolean
 ---@return string
 function utils.detect_filetype(name, skip_ftmatch)
+  local config = require('orgmode.config')
   local map = {
     ['emacs-lisp'] = 'lisp',
     elisp = 'lisp',
@@ -576,6 +577,7 @@ function utils.detect_filetype(name, skip_ftmatch)
     shell = 'bash',
     uxn = 'uxntal',
   }
+  map = vim.tbl_deep_extend('force', map, config.org_edit_src_filetype_map)
   if not skip_ftmatch then
     local filename = '__org__detect_filetype__.' .. (map[name] or name)
     local ft = vim.filetype.match({ filename = filename })


### PR DESCRIPTION
We have implemented a hard-coded filetype map for common language aliases used in Org mode source blocks.

I propose making this map a user-configurable option. This would empower users to extend it with their own aliases.

A use case involves Emacs users who employ `emacs-jupyter`. This package uses the language alias `jupyter-python` for Python source blocks, which differs from the standard `python` alias. User-configurable aliases would seamlessly support such workflows.