### PR TITLE
fix: fuzzy autocompletion with blink

### DIFF
--- a/lua/orgmode/org/autocompletion/init.lua
+++ b/lua/orgmode/org/autocompletion/init.lua
@@ -55,10 +55,15 @@ end
 
 function OrgCompletion:_get_valid_results(results, context)
   local base = context.base or ''
+  local framework = context.framework or 'nvim-cmp'
 
   local valid_results = {}
   for _, item in ipairs(results) do
-    if base == '' or item:find('^' .. vim.pesc(base)) then
+    -- For blink.cmp, skip prefix filtering and return all results
+    -- Let blink.cmp's fuzzy matcher handle the filtering
+    local should_include = framework == 'blink' or base == '' or item:find('^' .. vim.pesc(base))
+
+    if should_include then
       table.insert(valid_results, {
         word = item,
         menu = self.menu,

--- a/tests/plenary/org/autocompletion_spec.lua
+++ b/tests/plenary/org/autocompletion_spec.lua
@@ -436,8 +436,8 @@ describe('Blink completion', function()
 
     assert(directive_item, 'Should find a directive completion item')
     assert(
-      directive_item.insertText:match('^#%+'),
-      string.format("insertText should start with '+#', got: %s", directive_item.insertText)
+      directive_item.insertText and directive_item.insertText:match('^#%+'),
+      string.format("completion text should start with '#+', got: %s", directive_item.insertText or 'nil')
     )
 
     assert(line:sub(1, 4) == '#+fi', "Original line should contain '#+fi'")


### PR DESCRIPTION
## Summary

This PR fixes fuzzy matching for blink.cmp in orgmode completion. Previously blink.cmp only did prefix matching like nvim-cmp, now it
actually uses its fuzzy matcher.

## Related Issues

Related #977 

## Changes

- Let blink.cmp get all completion results instead of pre-filtering them
- Added `filterText` field so blink.cmp knows what to fuzzy match against
- Fixed base extraction to not break completion context

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.

