### PR TITLE
fix: Escape special regex chars in buffer lookup

### DIFF
--- a/lua/orgmode/api/file.lua
+++ b/lua/orgmode/api/file.lua
@@ -1,5 +1,6 @@
 ---@diagnostic disable: invisible
 local OrgHeadline = require('orgmode.api.headline')
+local utils = require('orgmode.utils')
 local org = require('orgmode')
 
 ---@class OrgApiFile
@@ -113,7 +114,7 @@ end
 --- @return string
 function OrgFile:get_link()
   local filename = self.filename
-  local bufnr = vim.fn.bufnr('^' .. filename .. '$')
+  local bufnr = utils.get_buffer_by_filename(filename)
 
   if bufnr == -1 or not vim.api.nvim_buf_is_loaded(bufnr) then
     -- do remote edit

--- a/lua/orgmode/api/headline.lua
+++ b/lua/orgmode/api/headline.lua
@@ -4,6 +4,7 @@ local PriorityState = require('orgmode.objects.priority_state')
 local Date = require('orgmode.objects.date')
 local Calendar = require('orgmode.objects.calendar')
 local Promise = require('orgmode.utils.promise')
+local utils = require('orgmode.utils')
 local org = require('orgmode')
 
 ---@class OrgApiHeadline
@@ -276,7 +277,7 @@ end
 --- @return string
 function OrgHeadline:get_link()
   local filename = self.file.filename
-  local bufnr = vim.fn.bufnr('^' .. filename .. '$')
+  local bufnr = utils.get_buffer_by_filename(filename)
 
   if bufnr == -1 or not vim.api.nvim_buf_is_loaded(bufnr) then
     -- do remote edit

--- a/lua/orgmode/api/init.lua
+++ b/lua/orgmode/api/init.lua
@@ -4,6 +4,7 @@ local OrgHeadline = require('orgmode.api.headline')
 local orgmode = require('orgmode')
 local validator = require('orgmode.utils.validator')
 local Promise = require('orgmode.utils.promise')
+local utils = require('orgmode.utils')
 
 ---@class OrgApiRefileOpts
 ---@field source OrgApiHeadline
@@ -81,7 +82,7 @@ function OrgApi.refile(opts)
     refile_opts.destination_headline = opts.destination._section
   end
 
-  local source_bufnr = vim.fn.bufnr('^' .. opts.source.file.filename .. '$') or -1
+  local source_bufnr = utils.get_buffer_by_filename(opts.source.file.filename)
   local is_capture = source_bufnr > -1 and vim.b[source_bufnr].org_capture
 
   if is_capture and orgmode.capture._window then

--- a/lua/orgmode/files/file.lua
+++ b/lua/orgmode/files/file.lua
@@ -60,7 +60,7 @@ end
 ---Load the file
 ---@return OrgPromise<OrgFile | false>
 function OrgFile.load(filename)
-  local bufnr = vim.fn.bufnr('^' .. filename .. '$') or -1
+  local bufnr = utils.get_buffer_by_filename(filename)
 
   if
     bufnr > -1
@@ -534,7 +534,7 @@ end
 
 ---@return number
 function OrgFile:bufnr()
-  local bufnr = vim.fn.bufnr('^' .. self.filename .. '$') or -1
+  local bufnr = utils.get_buffer_by_filename(self.filename)
   -- Do not consider unloaded buffers as valid
   -- Treesitter is not working in them
   if bufnr > -1 and vim.api.nvim_buf_is_loaded(bufnr) then
@@ -546,7 +546,7 @@ end
 ---Return valid buffer handle or throw an error if it's not valid
 ---@return number
 function OrgFile:get_valid_bufnr()
-  local bufnr = vim.fn.bufnr('^' .. self.filename .. '$') or -1
+  local bufnr = utils.get_buffer_by_filename(self.filename)
   if bufnr < 0 then
     error('[orgmode] No valid buffer for file ' .. self.filename .. ' to edit', 0)
   end

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -622,4 +622,11 @@ function utils.if_nil(...)
   return nil
 end
 
+---Get buffer number by filename with proper regex escaping
+---@param filename string The filename to search for
+---@return number Buffer number or -1 if not found/loaded
+function utils.get_buffer_by_filename(filename)
+  return vim.fn.bufnr('^' .. vim.fn.escape(filename, '^$.*?/\\[]~') .. '$')
+end
+
 return utils

--- a/tests/plenary/utils_spec.lua
+++ b/tests/plenary/utils_spec.lua
@@ -135,4 +135,59 @@ describe('Util', function()
       assert.are.equal(expected, err)
     end)
   end)
+
+  describe('get_buffer_by_filename', function()
+    it('should return -1 for non-existent files', function()
+      local result = utils.get_buffer_by_filename('/this/file/does/not/exist.org')
+      assert.are.same(-1, result)
+    end)
+
+    it('should return buffer number for loaded files', function()
+      local file = helpers.create_file({ '* Test headline' })
+      local result = utils.get_buffer_by_filename(file.filename)
+      assert.is.True(result > 0)
+    end)
+
+    it('should handle filenames with special regex characters', function()
+      -- Test various special characters that would break unescaped regex
+      local test_cases = {
+        '[test].org',
+        '(test).org',
+        'test[1].org',
+        'file.with.dots.org',
+        'file+plus.org',
+        'file*star.org',
+        'file?question.org',
+        'file$dollar.org',
+        'file^caret.org',
+      }
+
+      for _, special_filename in ipairs(test_cases) do
+        local full_filename = vim.fn.tempname() .. special_filename
+        vim.fn.writefile({ '* Test headline' }, full_filename)
+        vim.cmd('edit ' .. vim.fn.fnameescape(full_filename))
+
+        local result = utils.get_buffer_by_filename(full_filename)
+        assert.is.True(result > 0, 'Failed for filename: ' .. special_filename)
+
+        vim.cmd('bdelete')
+      end
+    end)
+
+    it('should return -1 for unloaded buffers', function()
+      local file = helpers.create_file({ '* Test headline' })
+      local filename = file.filename
+
+      -- First verify it works when loaded
+      local result_loaded = utils.get_buffer_by_filename(filename)
+      assert.is.True(result_loaded > 0)
+
+      -- Wipe the buffer (this actually unloads it from memory)
+      vim.cmd('bwipeout')
+
+      -- Should return -1 for wiped buffer
+      local result_unloaded = utils.get_buffer_by_filename(filename)
+      assert.are.same(-1, result_unloaded)
+    end)
+  end)
 end)


### PR DESCRIPTION
Buffer lookup failed for filenames containing [], (), . and other regex metacharacters.

- Add utils.get_buffer_by_filename() with proper Vim regex escaping
- Replace duplicate buffer lookup patterns across files

## Summary

This PR fixes buffer lookup failures when filenames contain regex special characters like `[]`, `()`, `.`, etc. The issue occurred because `vim.fn.bufnr()` patterns weren't properly escaped for Vim regex syntax, causing buffer operations (todo state, links, refiling) to fail.

## Related Issues

Closes #1021 

## Changes

- Add `utils.get_buffer_by_filename()` utility function with proper Vim regex escaping using `vim.fn.escape()`
- Replace 6 duplicate buffer lookup patterns across 4 files (`files/file.lua`, `api/init.lua`, `api/headline.lua`,
`api/file.lua`)
- Add comprehensive test coverage for special character scenarios in `tests/plenary/utils_spec.lua`

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
