### PR TITLE
fix(capture): Allow multiple capture buffers

### DIFF
--- a/lua/orgmode/api/init.lua
+++ b/lua/orgmode/api/init.lua
@@ -84,9 +84,12 @@ function OrgApi.refile(opts)
 
   local source_bufnr = utils.get_buffer_by_filename(opts.source.file.filename)
   local is_capture = source_bufnr > -1 and vim.b[source_bufnr].org_capture
-
-  if is_capture and orgmode.capture._window then
-    refile_opts.template = orgmode.capture._window.template
+  if is_capture then
+    local capture_window = orgmode.capture._windows[vim.b[source_bufnr].org_capture_window_id]
+    if capture_window then
+      refile_opts.template = capture_window.template
+      refile_opts.capture_window = capture_window
+    end
   end
 
   return Promise.resolve()

--- a/lua/orgmode/capture/_meta.lua
+++ b/lua/orgmode/capture/_meta.lua
@@ -8,6 +8,7 @@
 
 ---@class OrgProcessCaptureOpts
 ---@field template OrgCaptureTemplate
+---@field capture_window OrgCaptureWindow
 ---@field source_file OrgFile
 ---@field source_headline? OrgHeadline
 ---@field destination_file OrgFile

--- a/lua/orgmode/ui/menu.lua
+++ b/lua/orgmode/ui/menu.lua
@@ -86,7 +86,7 @@ function Menu:add_option(option)
   table.insert(self.items, option)
 end
 
----@param separator OrgMenuSeparator
+---@param separator? OrgMenuSeparator
 function Menu:add_separator(separator)
   self:_validate_separator(separator)
   table.insert(self.items, vim.tbl_deep_extend('force', self.separator, separator or {}))

--- a/tests/plenary/capture/capture_spec.lua
+++ b/tests/plenary/capture/capture_spec.lua
@@ -1,6 +1,7 @@
 local Capture = require('orgmode.capture')
 local Templates = require('orgmode.capture.templates')
 local Template = require('orgmode.capture.template')
+local CaptureWindow = require('orgmode.capture.window')
 local helpers = require('tests.plenary.helpers')
 local org = require('orgmode')
 
@@ -227,20 +228,23 @@ describe('Capture', function()
     local capture_lines = { '* foo' }
     local capture_file = helpers.create_file_instance(capture_lines)
     local item = capture_file:get_headlines()[1]
+    local template = Template:new({
+      properties = {
+        empty_lines = {
+          before = 2,
+          after = 1,
+        },
+      },
+    })
+    local capture_window = CaptureWindow:new({ template = template })
 
     ---@diagnostic disable-next-line: invisible
     org.capture:_refile_from_capture_buffer({
       destination_file = destination_file,
       source_file = capture_file,
       source_headline = item,
-      template = Template:new({
-        properties = {
-          empty_lines = {
-            before = 2,
-            after = 1,
-          },
-        },
-      }),
+      template = template,
+      capture_window = capture_window,
     })
     vim.cmd('edit ' .. vim.fn.fnameescape(destination_file.filename))
     assert.are.same({
@@ -262,6 +266,16 @@ describe('Capture', function()
 
     local capture_lines = { '** baz' }
     local capture_file = helpers.create_file(capture_lines)
+
+    local template = Template:new({
+      properties = {
+        empty_lines = {
+          before = 2,
+          after = 1,
+        },
+      },
+    })
+    local capture_window = CaptureWindow:new({ template = template })
     assert(capture_file)
     local item = capture_file:get_headlines()[1]
 
@@ -270,14 +284,8 @@ describe('Capture', function()
       destination_file = destination_file,
       source_file = capture_file,
       source_headline = item,
-      template = Template:new({
-        properties = {
-          empty_lines = {
-            before = 2,
-            after = 1,
-          },
-        },
-      }),
+      template = template,
+      capture_window = capture_window,
     })
     vim.cmd('edit ' .. vim.fn.fnameescape(destination_file.filename))
     assert.are.same({
@@ -304,6 +312,15 @@ describe('Capture', function()
     local capture_lines = { '** baz' }
     local capture_file = helpers.create_file_instance(capture_lines)
     local item = capture_file:get_headlines()[1]
+    local template = Template:new({
+      properties = {
+        empty_lines = {
+          before = 2,
+          after = 1,
+        },
+      },
+    })
+    local capture_window = CaptureWindow:new({ template = template })
 
     ---@diagnostic disable-next-line: invisible
     org.capture:_refile_from_capture_buffer({
@@ -311,14 +328,8 @@ describe('Capture', function()
       source_file = capture_file,
       source_headline = item,
       destination_headline = destination_file:get_headlines()[1],
-      template = Template:new({
-        properties = {
-          empty_lines = {
-            before = 2,
-            after = 1,
-          },
-        },
-      }),
+      template = template,
+      capture_window = capture_window,
     })
     vim.cmd('edit ' .. vim.fn.fnameescape(destination_file.filename))
     assert.are.same({
@@ -346,15 +357,18 @@ describe('Capture', function()
     local capture_lines = { '** baz' }
     local capture_file = helpers.create_file_instance(capture_lines)
     local item = capture_file:get_headlines()[1]
+    local template = Template:new({
+      regexp = 'appendhere',
+    })
+    local capture_window = CaptureWindow:new({ template = template })
 
     ---@diagnostic disable-next-line: invisible
     org.capture:_refile_from_capture_buffer({
       destination_file = destination_file,
       source_file = capture_file,
       source_headline = item,
-      template = Template:new({
-        regexp = 'appendhere',
-      }),
+      template = template,
+      capture_window = capture_window,
     })
     vim.cmd('edit ' .. vim.fn.fnameescape(destination_file.filename))
     assert.are.same({

--- a/tests/plenary/capture/datetree_spec.lua
+++ b/tests/plenary/capture/datetree_spec.lua
@@ -1,6 +1,7 @@
 ---@diagnostic disable: invisible
 local helpers = require('tests.plenary.helpers')
 local Template = require('orgmode.capture.template')
+local CaptureWindow = require('orgmode.capture.window')
 local Date = require('orgmode.objects.date')
 
 describe('Datetree', function()
@@ -12,16 +13,18 @@ describe('Datetree', function()
     local get_template = function(date, content)
       local filename = vim.fn.tempname() .. '.org'
       vim.fn.writefile(content or {}, filename)
+      local template = Template:new({
+        target = filename,
+        template = '* %?',
+        datetree = {
+          time_prompt = true,
+          date = date,
+        },
+      })
       return {
         destination_file = org.files:get(filename),
-        template = Template:new({
-          target = filename,
-          template = '* %?',
-          datetree = {
-            time_prompt = true,
-            date = date,
-          },
-        }),
+        capture_window = CaptureWindow:new({ template = template }),
+        template = template,
       }
     end
     describe('datetree does not exist', function()
@@ -382,17 +385,19 @@ describe('Datetree', function()
     local get_template = function(date, content)
       local filename = vim.fn.tempname() .. '.org'
       vim.fn.writefile(content or {}, filename)
+      local template = Template:new({
+        target = filename,
+        template = '* %?',
+        datetree = {
+          time_prompt = true,
+          date = date,
+          reversed = true,
+        },
+      })
       return {
         destination_file = org.files:get(filename),
-        template = Template:new({
-          target = filename,
-          template = '* %?',
-          datetree = {
-            time_prompt = true,
-            date = date,
-            reversed = true,
-          },
-        }),
+        capture_window = CaptureWindow:new({ template = template }),
+        template = template,
       }
     end
     describe('datetree does not exist', function()
@@ -751,34 +756,36 @@ describe('Datetree', function()
     local get_template = function(date, content)
       local filename = vim.fn.tempname() .. '.org'
       vim.fn.writefile(content or {}, filename)
-      return {
-        destination_file = org.files:get(filename),
-        template = Template:new({
-          target = filename,
-          template = '* %?',
-          datetree = {
-            time_prompt = true,
-            date = date,
-            tree_type = 'custom',
-            tree = {
-              {
-                format = '%Y',
-                pattern = '^(%d%d%d%d)$',
-                order = { 1 },
-              },
-              {
-                format = '%m/%Y %B',
-                pattern = '^(%d%d)%/(%d%d%d%d).*$',
-                order = { 2, 1 },
-              },
-              {
-                format = '%m/%d/%Y %A',
-                pattern = '^(%d%d)/(%d%d)/(%d%d%d%d).*$',
-                order = { 3, 1, 2 },
-              },
+      local template = Template:new({
+        target = filename,
+        template = '* %?',
+        datetree = {
+          time_prompt = true,
+          date = date,
+          tree_type = 'custom',
+          tree = {
+            {
+              format = '%Y',
+              pattern = '^(%d%d%d%d)$',
+              order = { 1 },
+            },
+            {
+              format = '%m/%Y %B',
+              pattern = '^(%d%d)%/(%d%d%d%d).*$',
+              order = { 2, 1 },
+            },
+            {
+              format = '%m/%d/%Y %A',
+              pattern = '^(%d%d)/(%d%d)/(%d%d%d%d).*$',
+              order = { 3, 1, 2 },
             },
           },
-        }),
+        },
+      })
+      return {
+        destination_file = org.files:get(filename),
+        capture_window = CaptureWindow:new({ template = template }),
+        template = template,
       }
     end
     describe('datetree does not exist', function()


### PR DESCRIPTION
## Summary

Fix the ability to open multiple capture buffers at once.

## Related Issues

Related #1019 

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [X] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [X] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [X] **Checked for breaking changes** and documented them, if any.
