### PR TITLE
fix(windows): handle Windows file paths correctly in refile

### DIFF
--- a/lua/orgmode/utils/fs.lua
+++ b/lua/orgmode/utils/fs.lua
@@ -111,7 +111,12 @@ function M.trim_common_root(paths)
     end, paths)
   end
 
-  local root = '/' .. table.concat(common_root, '/') .. '/'
+  local root
+  if vim.fn.has('win32') == 1 then
+    root = table.concat(common_root, '/') .. '/'
+  else
+    root = '/' .. table.concat(common_root, '/') .. '/'
+  end
   local result = {}
   for _, path in ipairs(paths) do
     local relative_path = path:sub(#root + 1)

--- a/lua/orgmode/utils/fs.lua
+++ b/lua/orgmode/utils/fs.lua
@@ -111,11 +111,9 @@ function M.trim_common_root(paths)
     end, paths)
   end
 
-  local root
-  if vim.fn.has('win32') == 1 then
-    root = table.concat(common_root, '/') .. '/'
-  else
-    root = '/' .. table.concat(common_root, '/') .. '/'
+  local root = table.concat(common_root, '/') .. '/'
+  if vim.fn.has('win32') == 0 then
+    root = '/' .. root
   end
   local result = {}
   for _, path in ipairs(paths) do


### PR DESCRIPTION
## Summary

There was a bug on Windows where the first character of the file name was dropped during refile. This happened because an extra leading / was added to the beginning of the path, resulting in something like: `/C:/org/file.org` which was then displayed as: `ile.org`.

Some issue was reported in https://github.com/nvim-orgmode/orgmode/issues/911, but not fixed on Windows.

## Changes

Added OS check and fixed path construction

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
