### PR TITLE
feat: adds insert_drawer function and keymap

### DIFF
--- a/lua/orgmode/config/defaults.lua
+++ b/lua/orgmode/config/defaults.lua
@@ -194,6 +194,7 @@ local DefaultConfig = {
       org_time_stamp_inactive = '<prefix>i!',
       org_toggle_timestamp_type = '<prefix>d!',
       org_insert_drawer = '<prefix>iD',
+      org_insert_properties_drawer = '<prefix>ip',
       org_insert_link = '<prefix>li',
       org_store_link = '<prefix>ls',
       org_clock_in = '<prefix>xi',

--- a/lua/orgmode/config/mappings/init.lua
+++ b/lua/orgmode/config/mappings/init.lua
@@ -333,6 +333,10 @@ return {
       'org_mappings.insert_drawer',
       { opts = { desc = 'org insert drawer', help_desc = 'Insert drawer' } }
     ),
+    org_insert_properties_drawer = m.action(
+      'org_mappings.insert_properties_drawer',
+      { opts = { desc = 'org insert properties drawer', help_desc = 'Insert Properties drawer' } }
+    ),
     org_insert_link = m.action('org_mappings.insert_link', {
       modes = { 'n', 'x' },
       opts = {

--- a/tests/plenary/ui/mappings/insert_drawer_spec.lua
+++ b/tests/plenary/ui/mappings/insert_drawer_spec.lua
@@ -34,21 +34,20 @@ describe('Insert drawer mappings', function()
     assert.are.same({
       '* TODO heading',
       'content line',
-      '  :NOTES:',
-      '  ',
-      '  :END:',
+      ':NOTES:',
+      '',
+      ':END:',
     }, vim.api.nvim_buf_get_lines(0, 0, -1, false))
   end)
 
-  it('inserts PROPERTIES drawer under headline when count prefix is provided', function()
+  it('inserts PROPERTIES drawer under headline', function()
     helpers.create_file({
       '* TODO heading',
       'content line',
     })
 
     vim.fn.cursor(1, 1)
-    vim.cmd([[let v:count = 1]])
-    orgmode.action('org_mappings.insert_drawer')
+    orgmode.action('org_mappings.insert_properties_drawer')
     vim.wait(50, function()
       return false
     end)


### PR DESCRIPTION
## Summary

This PR adds [org-insert-drawer and org-insert-property-drawer](https://orgmode.org/org.html#Drawers) functionality to nvim-orgmode via new insert_drawer and insert_properties_drawer functions and keymaps: `<prefix>iD` & `<prefix>ip`

### org-insert-drawer
Inserting drawers using the keymap prompts the user to input a drawer name and places it below the cursor.

### org-insert-property-drawer
Emacs requires a prefix (e.g. count 1) by default to use org-insert-property-drawer. This is problematic for testing, and no other nvim-orgmode functions this way. Instead, this implementation uses a separate function and keymap to insert a property drawer below the current headline.

## Related Issues

Closes #519 

## Changes

- Adds insert_drawer function to mappings.lua
- Adds insert_property_drawer function to mappings.lua
- Adds function mappings to mappings/init.lua
- Adds keymaps `<prefix>iD` and `<prefix>ip` to defaults.lua
- Adds insert_drawer and insert_property_drawer tests to new file insert_drawer_spec.lua

## Checklist

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
