### PR TITLE
fix(folds): update fold boundaries after headline edits

### DIFF
--- a/lua/orgmode/colors/highlighter/foldtext.lua
+++ b/lua/orgmode/colors/highlighter/foldtext.lua
@@ -6,6 +6,7 @@ local config = require('orgmode.config')
 ---@field highlighter OrgHighlighter
 ---@field namespace number
 ---@field cache table<number, table<number, OrgFoldtextLineValue>>
+---@field cache_tick table<number, number>
 local OrgFoldtext = {}
 
 ---@param opts { highlighter: OrgHighlighter }
@@ -13,10 +14,22 @@ function OrgFoldtext:new(opts)
   local data = {
     highlighter = opts.highlighter,
     cache = setmetatable({}, { __mode = 'k' }),
+    cache_tick = {},
   }
   setmetatable(data, self)
   self.__index = self
   return data
+end
+
+---Invalidate cache for a buffer if its content has changed since the last render.
+---Call this once per redraw from on_win, not per line.
+---@param bufnr number
+function OrgFoldtext:check_cache(bufnr)
+  local tick = vim.api.nvim_buf_get_changedtick(bufnr)
+  if self.cache_tick[bufnr] ~= tick then
+    self.cache[bufnr] = nil
+    self.cache_tick[bufnr] = tick
+  end
 end
 
 ---@param bufnr number
@@ -101,6 +114,7 @@ end
 
 function OrgFoldtext:on_detach(bufnr)
   self.cache[bufnr] = nil
+  self.cache_tick[bufnr] = nil
 end
 
 return OrgFoldtext

--- a/lua/orgmode/colors/highlighter/init.lua
+++ b/lua/orgmode/colors/highlighter/init.lua
@@ -78,6 +78,7 @@ function OrgHighlighter:_on_win(_, win, bufnr, topline, botline)
       end,
     })
   else
+    self.foldtext:check_cache(bufnr)
     self:_parse_tree(bufnr, win, { topline, botline + 1 })
     if self.parsing[win] then
       for line = topline, botline do

--- a/lua/orgmode/org/mappings.lua
+++ b/lua/orgmode/org/mappings.lua
@@ -17,6 +17,25 @@ local Promise = require('orgmode.utils.promise')
 local Input = require('orgmode.ui.input')
 local Footnote = require('orgmode.objects.footnote')
 
+---Schedule a fold update for the given range. Call after buffer edits.
+---OrgRange is 1-indexed; vim._foldupdate expects 0-indexed lines.
+---@param range OrgRange
+local function schedule_fold_update(range)
+  local bufnr = vim.api.nvim_get_current_buf()
+  vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
+    local start_line = range.start_line - 1
+    local end_line = math.min(range.end_line, vim.api.nvim_buf_line_count(bufnr))
+    for _, win in ipairs(vim.fn.win_findbuf(bufnr)) do
+      if vim.wo[win].foldmethod == 'expr' then
+        vim._foldupdate(win, start_line, end_line)
+      end
+    end
+  end)
+end
+
 ---@class OrgMappings
 ---@field capture OrgCapture
 ---@field agenda OrgAgenda
@@ -50,6 +69,8 @@ function OrgMappings:set_tags(tags)
   local headline = self.files:get_closest_headline()
   local headline_tags = headline:get_own_tags()
   local current_tags = utils.tags_to_string(headline_tags)
+  -- Capture range before promise chain — TS nodes become stale after edits
+  local range = headline:get_range()
 
   return Promise.resolve()
     :next(function()
@@ -69,14 +90,17 @@ function OrgMappings:set_tags(tags)
         return
       end
 
-      return headline:set_tags(new_tags)
+      headline:set_tags(new_tags)
+      schedule_fold_update(range)
     end)
 end
 
 ---@return nil
 function OrgMappings:toggle_archive_tag()
   local headline = self.files:get_closest_headline()
+  local range = headline:get_range()
   headline:toggle_tag('ARCHIVE')
+  schedule_fold_update(range)
 end
 
 function OrgMappings:cycle()
@@ -344,7 +368,9 @@ function OrgMappings:set_priority(direction)
     end
   end
 
+  local range = headline:get_range()
   headline:set_priority(new_priority)
+  schedule_fold_update(range)
 end
 
 function OrgMappings:todo_next_state()
@@ -419,6 +445,9 @@ function OrgMappings:_todo_change_state(direction)
   local headline = self.files:get_closest_headline()
   local old_state = headline:get_todo()
   local was_done = headline:is_done()
+
+  local range = headline:get_range()
+
   local changed = self:_change_todo_state(direction, true)
 
   if not changed then
@@ -427,6 +456,8 @@ function OrgMappings:_todo_change_state(direction)
 
   local item = self.files:get_closest_headline()
   EventManager.dispatch(events.TodoChanged:new(item, old_state, was_done))
+
+  schedule_fold_update(range)
 
   local is_done = item:is_done() and not was_done
   local is_undone = not item:is_done() and was_done


### PR DESCRIPTION
## Summary

Fold boundaries go stale when editing folded headlines (TODO state, priority, tags, archive). Neovim's treesitter foldexpr only re-evaluates fold levels for the changed line, not the full section, so the fold end boundary is never updated.

Two commits:

1. **Foldtext cache invalidation**: Track `changedtick` per buffer and clear the foldtext highlight cache when content changes. Fixes stale ellipsis positions.

2. **Targeted fold update**: Capture the section range before the edit (TS nodes become stale after buffer changes), then schedule `vim._foldupdate()` for the full section after treesitter reparses. Covers TODO state changes, priority, tag and archive tag edits.

## What changed since the initial version

Dropped the `zx` approach entirely. It recomputed all folds in the buffer, resetting manually opened folds (as @kristijanhusak pointed out). Now using `vim._foldupdate(win, start, end)` to update only the affected section.

## Checklist

- [x] **Followed the [Conventional Commits](https://www.conventionalcommits.org/) specification**
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with `make test`.
- [x] **Checked for breaking changes** and documented them, if any.