### PR TITLE
feat: add edit and tabnew to win_split_mode

### DIFF
--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -117,6 +117,8 @@ Available `string` values:
 - `vertical` - Always split vertically
 - `auto` - Determine between horizontal and vertical split depending on the current window size
 - `float` - Open in float window that has width of 70% of the screen centered
+- `edit` - Open in the current window
+- `tabnew` - Open in a new tab
 - `{'float', 0.9}` - Open in float window and provide custom scale (in this case it's 90% of screen size), must be value between `0` and `1`
 
 If none of the options above suit your needs, there are 2 other ways to

--- a/lua/orgmode/config/_meta.lua
+++ b/lua/orgmode/config/_meta.lua
@@ -254,7 +254,7 @@
 ---@field org_id_link_to_org_use_id? boolean If true, Storing a link to the headline will automatically generate ID for that headline. Default: false
 ---@field org_use_property_inheritance boolean | string | string[] If true, properties are inherited by sub-headlines; may also be a regex or list of property names. Default: false
 ---@field org_babel_default_header_args? table<string, string> Default header args for org-babel blocks: Default: { [':tangle'] = 'no', [':noweb'] = 'no' }
----@field win_split_mode? 'horizontal' | 'vertical' | 'auto' | 'float' | string[] How to open agenda and capture windows. Default: 'horizontal'
+---@field win_split_mode? 'horizontal' | 'vertical' | 'auto' | 'float' | 'edit' | 'tabnew' | string[] How to open agenda and capture windows. Default: 'horizontal'
 ---@field win_border? 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | string[] Border configuration for `win_split_mode = 'float'`. Default: 'single'
 ---@field notifications? OrgNotificationsConfig Notification settings
 ---@field mappings? OrgMappingsConfig Mappings configuration

--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -368,12 +368,14 @@ end
 
 ---@param name string
 ---@param height number
----@param split_mode string|function|table
+---@param split_mode 'horizontal'|'vertical'|'auto'|'float'|'edit'|'tabnew'|string|function|{string,number}
 ---@param border string|table
 function utils.open_window(name, height, split_mode, border)
   local cmd_by_split_mode = {
     horizontal = string.format('%dsplit %s', height, name),
     vertical = string.format('vsplit %s', name),
+    edit = string.format('edit %s', name),
+    tabnew = string.format('tabnew %s', name),
   }
 
   if cmd_by_split_mode[split_mode] then


### PR DESCRIPTION
## Summary

Add `tabnew` and `edit` to `win_split_mode` option.

## Related Issues

Related #398 

## Changes

- added `tabnew` and `edit` to `win_split_mode` enum in _meta.lua

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
