### PR TITLE
fix(set_tags): better tag parsing for hyphens and whitespaces

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -272,8 +272,7 @@ function Headline:set_tags(tags)
   local text = ''
   tags = vim
     .trim(tags)
-    :gsub('-', '_') -- Replace hyphens with underscores
-    :gsub('[%s:]+', ':') -- Convert all whitespace and existing colons into a single colon
+    :gsub('[%s:-]+', ':') -- Convert all whitespace, existing colons and hyphens into a single colon
     :gsub('^:', '')
     :gsub(':$', '')
 

--- a/tests/plenary/api/api_spec.lua
+++ b/tests/plenary/api/api_spec.lua
@@ -103,14 +103,14 @@ describe('Api', function()
     assert.are.same('Second level', current_file.headlines[2].title)
     assert.are.same({ 'WORK', 'OFFICE', 'NESTEDTAG' }, current_file.headlines[2].all_tags)
 
-    current_file.headlines[2]:set_tags({ 'PERSONAL', 'HEALTH', 'TAG1 TAG2', 'MY-HYPHEN-TAG' }):wait()
+    current_file.headlines[2]:set_tags({ 'PERSONAL', 'HEALTH', 'TAG1 TAG2', 'TAG3-TAG4-TAG5' }):wait()
 
-    assert.are.same({ 'PERSONAL', 'HEALTH', 'TAG1', 'TAG2', 'MY_HYPHEN_TAG' }, cur_file().headlines[2].tags)
+    assert.are.same({ 'PERSONAL', 'HEALTH', 'TAG1', 'TAG2', 'TAG3', 'TAG4', 'TAG5' }, cur_file().headlines[2].tags)
     assert.are.same(
-      { 'WORK', 'OFFICE', 'PERSONAL', 'HEALTH', 'TAG1', 'TAG2', 'MY_HYPHEN_TAG' },
+      { 'WORK', 'OFFICE', 'PERSONAL', 'HEALTH', 'TAG1', 'TAG2', 'TAG3', 'TAG4', 'TAG5' },
       cur_file().headlines[2].all_tags
     )
-    assert.is.True(vim.fn.getline(5):match(':PERSONAL:HEALTH:TAG1:TAG2:MY_HYPHEN_TAG:$') ~= nil)
+    assert.is.True(vim.fn.getline(5):match(':PERSONAL:HEALTH:TAG1:TAG2:TAG3:TAG4:TAG5:$') ~= nil)
   end)
 
   it('should handle edge cases in tag input', function()
@@ -122,8 +122,8 @@ describe('Api', function()
 
     current_file.headlines[1]:set_tags({ ':  -tag1- : tag2:::tag3    tag_4 : @tag5 :' }):wait()
 
-    assert.are.same({ '_tag1_', 'tag2', 'tag3', 'tag_4', '@tag5' }, cur_file().headlines[1].all_tags)
-    assert.is.True(vim.fn.getline(1):match(':_tag1_:tag2:tag3:tag_4:@tag5:') ~= nil)
+    assert.are.same({ 'tag1', 'tag2', 'tag3', 'tag_4', '@tag5' }, cur_file().headlines[1].all_tags)
+    assert.is.True(vim.fn.getline(1):match(':tag1:tag2:tag3:tag_4:@tag5:') ~= nil)
   end)
 
   it('should cycle upwards through priorities, starting with default', function()


### PR DESCRIPTION
## Summary

Tweak in the [tag parsing](https://github.com/nvim-orgmode/orgmode/blob/0e8cba32f85ba95c9164bcf145598e9fb23b551c/lua/orgmode/files/headline.lua#L271) in the [set_tags](https://github.com/nvim-orgmode/orgmode/blob/HEAD/lua/orgmode/files/headline.lua#L250-L250) prompt editor.
Now:
1. hyphens are replaced with underscores
2. whitespaces are treated as separators between multiple tags

### Example

If a user enters something like this in the `set_tags` prompt: 
```
OFFICE WORK PROJECT-1
```

**before**:
```
:OFFICE WORK PROJECT-1:
```

**after**:
```
:OFFICE:WORK:PROJECT:1:
```


## Related Issues

Closes #1097

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
