### PR TITLE
fix(edit_file): Hide tmp buffer window

### DIFF
--- a/lua/orgmode/utils/init.lua
+++ b/lua/orgmode/utils/init.lua
@@ -524,12 +524,13 @@ function utils.edit_file(filename)
       vim.api.nvim_open_win(bufnr, true, {
         relative = 'editor',
         width = 1,
-        -- TODO: Revert to 1 once the https://github.com/neovim/neovim/issues/19464 is fixed
-        height = 2,
+        height = 1,
         row = 99999,
         col = 99999,
         zindex = 1,
         style = 'minimal',
+        focusable = false,
+        hide = true,
       })
       vim.api.nvim_set_option_value('swapfile', false, { buf = bufnr })
     end,


### PR DESCRIPTION
## Summary

This is a small tweak to the [tmp_edit_window](https://github.com/nvim-orgmode/orgmode/blob/tweak/edit_file-hide_tmp_edit_buffer/lua/orgmode/utils/init.lua#L523) in `utils.edit_file` to make it hidden and not focusable.
I don't think this is strictly needed, but I think it makes sense, and makes the agenda a bit cleaner.

I came across this due to a really obscure issue where the tmp edit window would not close after [Agenda._remote_edit](https://github.com/celsobenedetti/orgmode/blob/tweak/edit_file-hide_tmp_edit_buffer/lua/orgmode/agenda/init.lua#L563) actions.
Then, when I would try to `goto_item` (`<tab>`), the tmp window would be focused (hence, `focusable=false`).

I think the changes here make the UX a bit cleaner, since we don't even see the tmp edit window, and won't risk accidentally focusing it for some reason.

## Related Issues

N/A

## Changes

- Added `hide=true` and `focusable=false` to `vim.api.nvim_open_win` args
- Removed existing TODO comment

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
