### PR TITLE
fix: respect priority case

### DIFF
--- a/lua/orgmode/objects/priority_state.lua
+++ b/lua/orgmode/objects/priority_state.lua
@@ -35,7 +35,11 @@ function PriorityState:prompt_user()
     return nil
   end
 
-  choice = string.upper(choice)
+  if self.high_priority:match('%u') then
+    choice = string.upper(choice)
+  elseif self.high_priority:match('%l') then
+    choice = string.lower(choice)
+  end
   if #choice > 1 and tonumber(choice) == nil then
     utils.echo_warning(string.format('Only numeric priorities can be multiple characters long'))
     return nil

--- a/tests/plenary/ui/mappings/priority_spec.lua
+++ b/tests/plenary/ui/mappings/priority_spec.lua
@@ -18,6 +18,14 @@ describe('Priority mappings', function()
     })
   end
 
+  local lowercase_config = function()
+    config:extend({
+      org_priority_highest = 'a',
+      org_priority_default = 'b',
+      org_priority_lowest = 'c',
+    })
+  end
+
   after_each(function()
     vim.cmd([[silent! %bw!]])
   end)
@@ -124,5 +132,16 @@ describe('Priority mappings', function()
     assert.are.same('* [#10] Test orgmode', vim.fn.getline(1))
     vim.cmd('norm ciR')
     assert.are.same('* [#9] Test orgmode', vim.fn.getline(1))
+  end)
+
+  it('should set the priority based on the input key when using lowercase priorities', function()
+    lowercase_config()
+    helpers.create_file({
+      '* TODO [#b] Test orgmode',
+    })
+    vim.fn.cursor(1, 1)
+    assert.are.same('* TODO [#b] Test orgmode', vim.fn.getline(1))
+    vim.cmd('norm ,o,a\r')
+    assert.are.same('* TODO [#a] Test orgmode', vim.fn.getline(1))
   end)
 end)


### PR DESCRIPTION
## Summary

<!-- Give a brief description of what your PR does. -->

Let the user specify priorities in lowercase `[#a]` instead of `[#A]`, which needs less keys when setting the priority directly in capture templates.

The current codebase supports this and it works well when using `org_priority_up` and `org_priority_down`. However the `org_priority` did nothing.

This small change makes it work.

## Changes

<!-- List the major changes made in this PR. -->

- List changes here

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
