### PR TITLE
fix(OrgCache): Cache miss failure on buffers with loaded org files

### DIFF
--- a/lua/orgmode/init.lua
+++ b/lua/orgmode/init.lua
@@ -126,7 +126,7 @@ function Org:setup_autocmds()
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'BufNew' }, {
+  vim.api.nvim_create_autocmd({ 'BufNew', 'BufRead' }, {
     pattern = { '*.org', '*.org_archive' },
     group = org_augroup,
     callback = function(event)

--- a/lua/orgmode/state/buffers.lua
+++ b/lua/orgmode/state/buffers.lua
@@ -29,12 +29,10 @@ function OrgBuffers.get_buffer_by_filename(filename)
     return OrgBuffers._bufs[resolved_filename]
   end
 
-  -- If filename does not have an org extension, try to find the buf number and return it if filetype is org
-  if not OrgBuffers._is_valid_file_name(resolved_filename) then
-    local bufnr = vim.fn.bufnr(resolved_filename)
-    if bufnr > -1 and vim.bo[bufnr].filetype == 'org' then
-      return bufnr
-    end
+  -- Fall back to buffer lookup in case the cache missed an existing org buffer.
+  local bufnr = vim.fn.bufnr(resolved_filename)
+  if bufnr > -1 and vim.bo[bufnr].filetype == 'org' then
+    return bufnr
   end
 
   return -1


### PR DESCRIPTION
## Summary

Org buffers opened via BufRead were not added to orgmode’s buffer cache. For .org files, OrgBuffers.get_buffer_by_filename() only consulted that cache and skipped the bufnr() fallback, so a command like 'cit' on a header could fail with “No valid buffer for file” even when the file was loaded.

  This fixes the issue in two places: org buffers are now registered on both BufNew and BufRead, and get_buffer_by_filename() now falls back to vim.fn.bufnr() for org files as well. That makes loaded org buffers resolvable even if the cache misses them.

The reason this could be an issue (and was for me) is that restoring a session did not trigger BufNew, and even when I closed the buffer with the org file, and re-opened it, it still was not added to the cache.

to verify this issue, I ran the following on the buffer:
```lua
:lua print("cur name:", vim.api.nvim_buf_get_name(0))
:lua print("cur bufnr:", vim.api.nvim_get_current_buf())
:lua print("loaded:", vim.api.nvim_buf_is_loaded(0))
:lua local B=require('orgmode.state.buffers'); print("cache hit:", vim.inspect(B._bufs[B._resolve_filename(vim.api.nvim_buf_get_name(0))]))
:lua local B=require('orgmode.state.buffers'); print("fallback bufnr:", vim.fn.bufnr(B._resolve_filename(vim.api.nvim_buf_get_name(0))))
```
and got the following results
```txt
cur name: /home/vir/git-repos/orgfiles/personal/calendar.org
cur bufnr: 79
loaded: true
cache hit: nil
fallback bufnr: 79
```

Closes #
Should I create a corresponding issue?


## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`. (tests fail on my NixOS machine)
- [x] **Checked for breaking changes** and documented them, if any.
