### PR TITLE
feat(treesitter): nvim-treesitter-context support

### DIFF
--- a/queries/org/context.scm
+++ b/queries/org/context.scm
@@ -1,0 +1,1 @@
+(section) @context


### PR DESCRIPTION
## Summary

This is a simple PR adding a new TS query to add [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) support.
The idea is to show the parent headings in the TS context when the cursor is inside the heading.


https://github.com/user-attachments/assets/8d9fd2da-b9f1-4fbc-bdf0-aaf4f0388d26



## Related Issues

N/A

## Changes

- Added new `queries/org/context.scm` query

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
