### PR TITLE
fix(buffers): Fix fallback for finding a buffer by filename

### DIFF
--- a/lua/orgmode/state/buffers.lua
+++ b/lua/orgmode/state/buffers.lua
@@ -29,11 +29,38 @@ function OrgBuffers.get_buffer_by_filename(filename)
     return OrgBuffers._bufs[resolved_filename]
   end
 
-  -- If filename does not have an org extension, try to find the buf number and return it if filetype is org
+  local bufnr = vim.fn.bufnr(resolved_filename)
+
+  if bufnr < 0 then
+    return -1
+  end
+
+  -- If filename does not have an org extension, return the buffer only if it has correct filetype
   if not OrgBuffers._is_valid_file_name(resolved_filename) then
-    local bufnr = vim.fn.bufnr(resolved_filename)
-    if bufnr > -1 and vim.bo[bufnr].filetype == 'org' then
+    if vim.bo[bufnr].filetype == 'org' then
       return bufnr
+    end
+
+    return -1
+  end
+
+  -- bufnr() can return wrong buffer number in cases when there are multiple files matching, for example:
+  -- * `/path/to/orgfiles/todos.org`
+  -- * `/path/to/orgfiles/todos.org_archive`
+  -- Doing `bufnr('/path/to/orgfiles/todos.org')` can return buffer number for `/path/to/orgfiles/todos.org_archive`.
+  -- Resolve the filename of the found buffer, and make sure it matches the resolved filename we are looking for
+  -- If not, fallback to nvim_list_bufs
+  local buffer_filename = OrgBuffers._resolve_filename(vim.api.nvim_buf_get_name(bufnr))
+
+  if buffer_filename == resolved_filename then
+    return OrgBuffers.add(bufnr)
+  end
+
+  local all_bufs = vim.api.nvim_list_bufs()
+  for _, buf in ipairs(all_bufs) do
+    local valid_buffer_name = OrgBuffers.get_valid_buffer_name(buf)
+    if valid_buffer_name and valid_buffer_name == resolved_filename then
+      return OrgBuffers.add(buf)
     end
   end
 
@@ -42,12 +69,16 @@ end
 
 ---Add the buffer to the list
 ---@param bufnr number
+---@return number bufnr if the buffer is valid and added, -1 otherwise
 function OrgBuffers.add(bufnr)
   local name = OrgBuffers.get_valid_buffer_name(bufnr)
 
   if name then
     OrgBuffers._bufs[name] = bufnr
+    return bufnr
   end
+
+  return -1
 end
 
 ---Remove the buffer from the list
@@ -63,13 +94,13 @@ end
 ---Get valid buffer name if the buffer is an org file
 ---@param bufnr number
 function OrgBuffers.get_valid_buffer_name(bufnr)
-  local name = OrgBuffers._resolve_filename(vim.api.nvim_buf_get_name(bufnr))
+  local bufname = vim.api.nvim_buf_get_name(bufnr)
 
-  if OrgBuffers._is_valid_file_name(name) then
-    return name
+  if not OrgBuffers._is_valid_file_name(bufname) then
+    return nil
   end
 
-  return nil
+  return OrgBuffers._resolve_filename(bufname)
 end
 
 ---Resolve and normalize the filename


### PR DESCRIPTION
## Summary

Correctly fallback to finding an org file buffer in case it is not loaded into the state.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #1121 

Closes #1121 

## Changes

<!-- List the major changes made in this PR. -->

- Use `bufnr` to find the buffer name
- Verify if the filename of the given buffer is actually the one we are looking for
- If not, use `nvim_list_bufs`

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [X] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [X] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [X] **Checked for breaking changes** and documented them, if any.
