### PR TITLE
feat(agenda): add `@org.agenda.weekend.today` highlight

### DIFF
--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -2991,6 +2991,7 @@ The following highlight groups are used:
 - `@org.agenda.day`: Highlight for all days in Agenda view - linked to `Statement`
 - `@org.agenda.today`: Highlight for today in Agenda view - linked to `@org.bold`
 - `@org.agenda.weekend`: Highlight for weekend days in Agenda view - linked to `@org.bold`
+- `@org.agenda.weekend.today`: Highlight for today when it is a weekend day in Agenda view - linked to `@org.bold`
 
 📝 NOTE: Colors used for todo keywords and agenda states (deadline, schedule
 ok, schedule warning) are parsed from the current colorscheme from several

--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -2966,6 +2966,7 @@ The following highlight groups are used:
 - =@org.agenda.day=: Highlight for all days in Agenda view - linked to =Statement=
 - =@org.agenda.today=: Highlight for today in Agenda view - linked to =@org.bold=
 - =@org.agenda.weekend=: Highlight for weekend days in Agenda view - linked to =@org.bold=
+- =@org.agenda.weekend.today=: Highlight for today when it is a weekend day in Agenda view - linked to =@org.bold=
 
 📝 NOTE:
 Colors used for todo keywords and agenda states (deadline, schedule ok,

--- a/lua/orgmode/agenda/types/agenda.lua
+++ b/lua/orgmode/agenda/types/agenda.lua
@@ -259,7 +259,9 @@ function OrgAgendaType:render(bufnr, current_line)
 
     agendaView:add_line(AgendaLine:single_token({
       content = self:_format_day(agenda_day.day),
-      hl_group = add_highlight and (is_today and '@org.agenda.today' or '@org.agenda.weekend') or nil,
+      hl_group = add_highlight
+          and ((is_today and is_weekend) and '@org.agenda.weekend.today' or (is_today and '@org.agenda.today') or '@org.agenda.weekend')
+        or nil,
     }, {
       metadata = {
         agenda_day = agenda_day.day,

--- a/syntax/orgagenda.vim
+++ b/syntax/orgagenda.vim
@@ -4,6 +4,7 @@ syn match @org.agenda.tag /:[^ ]*:$/
 hi default link @org.agenda.day Statement
 hi default link @org.agenda.today @org.bold
 hi default link @org.agenda.weekend @org.bold
+hi default link @org.agenda.weekend.today @org.bold
 hi default link @org.agenda.header Comment
 hi default link @org.agenda.separator Comment
 hi default @org.agenda.tag gui=bold cterm=bold


### PR DESCRIPTION
## Summary

This PR adds `@org.agenda.weekend.today` highlight when today is weekend day, this way we can color weekdays and weekend differently, while keep using underline to mark the current day.

The idea and naming comes from [modus-themes](https://github.com/protesilaos/modus-themes/blob/f71db69bad2d4bac680960273b663c73c305a413/modus-themes.el#L6461) (so its from the OG orgmode actually).

## Changes

- Highlight logic in `lua/orgmode/agenda/types/agenda.lua`
- Mentioned the new highlight in docs (both doc/orgmode.txt and docs/configurations.org)
- Linked the highlight to `@org.bold` in the syntax file

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
