### PR TITLE
docs: add plugin "org-links.nvim"

### DIFF
--- a/docs/plugins.org
+++ b/docs/plugins.org
@@ -20,6 +20,7 @@ Orgmode supports various plugins to extend its functionality or make it more pre
   - [[#org-bulletsnvim][org-bullets.nvim]]
   - [[#headlinesnvim][headlines.nvim]]
   - [[#org-modernnvim][org-modern.nvim]]
+  - [[#org-linksnvim][org-links.nvim]]
 - [[#other][Other]]
 - [[#example-configuration][Example configuration]]
 
@@ -186,6 +187,22 @@ require("orgmode").setup({
   },
 })
 #+end_src
+
+*** org-links.nvim
+:PROPERTIES:
+:CUSTOM_ID: org-linksnvim
+:END:
+Link: [[https://github.com/tangledhelix/org-links.nvim][org-links.nvim]]
+Prettify links: display only label (or undecorated link, if no label)
+
+Run after the orgmode setup.
+#+BEGIN_SRC lua
+-- Your orgmode setup
+require('orgmode').setup()
+
+--Setup org-links
+require('org-links').setup()
+#+END_SRC
 
 ** Other
 :PROPERTIES:


### PR DESCRIPTION
## Summary

This PR documents an aesthetic plugin which prettifies links, displaying only the label if one is specified. This can make the display much nicer for very long URLs.

<https://github.com/tangledhelix/org-links.nvim>

## Related Issues

None

## Changes

- Add plugin to list
- Add new section briefly describing and linking to the plugin

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [X] **Updated relevant documentation,** if necessary.
- [X] **Thoroughly tested my changes.**
- [X] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [X] **Checked for breaking changes** and documented them, if any.
