### PR TITLE
fix(links): creating link from visual mode

### DIFF
--- a/lua/orgmode/org/links/init.lua
+++ b/lua/orgmode/org/links/init.lua
@@ -145,11 +145,10 @@ function OrgLinks:insert_link(link_location, desc)
       insert_to = link.range.end_col + 1
       target_col = target_col + link.range.start_col
     elseif vim.fn.mode() == 'v' then
-      local start_pos = vim.fn.getpos('v')
-      local end_pos = vim.fn.getpos('.')
-      insert_from = start_pos[3] - 1
-      insert_to = end_pos[3] + 1
-      target_col = target_col + start_pos[3]
+      local region = vim.fn.getregionpos(vim.fn.getpos('v'), vim.fn.getpos('.'))
+      insert_from = region[1][1][3] - 1
+      insert_to = region[1][2][3] + 1
+      target_col = target_col + region[1][1][3]
     else
       local colnr = vim.fn.col('.')
       insert_from = colnr


### PR DESCRIPTION
## Summary

Selecting a region from right to left could lead to insert_from > insert_to, which isn't handled in later code. By using getregionpos the regions will be in the correct order.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Closes #900 

## Changes

<!-- List the major changes made in this PR. -->

- Switched from using plain getpos to using getregionpos

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
