### PR TITLE
fix: correct Windows localized date encoding

### DIFF
--- a/lua/orgmode/objects/date.lua
+++ b/lua/orgmode/objects/date.lua
@@ -76,6 +76,24 @@ OrgDate.__index = OrgDate
 ---@param format? string
 ---@return osdate
 local function os_date(timestamp, format)
+  if format and vim.fn.has('win32') == 1 then
+    local locale = os.setlocale(nil, 'time')
+    local utf8_locale
+    if locale then
+      if vim.endswith(locale, 'UTF-8') then
+        utf8_locale = locale
+      else
+        utf8_locale = locale:gsub('%.[^.]+$', '') .. '.UTF-8'
+      end
+    end
+    local changed_locale = utf8_locale and os.setlocale(utf8_locale, 'time')
+    if changed_locale then
+      local date = os.date(format, timestamp)
+      os.setlocale(locale, 'time')
+      return date --[[@as osdate]]
+    end
+  end
+
   return os.date(format or '*t', timestamp) --[[@as osdate]]
 end
 
@@ -409,7 +427,7 @@ function OrgDate:to_string()
     format = format .. ' %a'
   end
 
-  local date = tostring(os.date(format, self.timestamp))
+  local date = tostring(os_date(self.timestamp, format))
 
   if self:has_time() then
     date = date .. ' ' .. self:format_time()
@@ -446,7 +464,7 @@ end
 ---@param format string
 ---@return string
 function OrgDate:format(format)
-  return tostring(os.date(format, self.timestamp))
+  return tostring(os_date(self.timestamp, format))
 end
 
 ---@return string
@@ -456,7 +474,7 @@ function OrgDate:format_time()
   end
   local t = self:format(time_format)
   if self.timestamp_end then
-    t = t .. '-' .. os.date(time_format, self.timestamp_end)
+    t = t .. '-' .. os_date(self.timestamp_end, time_format)
   end
   return t
 end


### PR DESCRIPTION
## Summary

This PR fixes localized date formatting on Windows when the time locale uses a non-UTF-8 code page.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Related #

Closes #

## Changes

- Temporarily formats dates with a UTF-8 `LC_TIME` locale on Windows
- Routes date string formatting through the shared `os_date()` helper

| Before | After |
| --- | --- |
| <img width="580" height="185" alt="image" src="https://github.com/user-attachments/assets/f92da0bc-89a9-46a0-b990-d4213014b6bf" /> | <img width="224" height="177" alt="image" src="https://github.com/user-attachments/assets/2a77ed85-781d-4da6-aa6d-28b286eb999e" /> |

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
