### PR TITLE
fix(agenda): goto item with multiple tabpages

### DIFF
--- a/lua/orgmode/agenda/init.lua
+++ b/lua/orgmode/agenda/init.lua
@@ -516,7 +516,7 @@ function Agenda:goto_item()
     return
   end
   local target_window = nil
-  for _, win in ipairs(vim.api.nvim_list_wins()) do
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
     local ft = vim.api.nvim_get_option_value('filetype', {
       buf = vim.api.nvim_win_get_buf(win),
     })
@@ -526,7 +526,7 @@ function Agenda:goto_item()
   end
 
   if not target_window then
-    for _, win in ipairs(vim.api.nvim_list_wins()) do
+    for _, win in ipairs(vim.api.nvim_tabpage_list_wins(0)) do
       local buf = vim.api.nvim_win_get_buf(win)
       local ft = vim.api.nvim_get_option_value('filetype', { buf = buf })
       local modifiable = vim.api.nvim_get_option_value('modifiable', { buf = buf })


### PR DESCRIPTION
How to reproduce:
1. open two tabpages
2. in the first tabpage, open the agenda or todo list (there should now be three windows: in the first tabpage: an orgagenda and an empty buffer, in the second tabpage: an empty buffer)
3. move cursor to an item in the agenda
4. attempt to open item in split window (<TAB>)

Expected result: the item should open in the window for the empty buffer in the first tabpage
Actual Result: the item opens in the window for the agenda

Having an org buffer in a window in the second tabpage will cause a similar effect. Also notice that the order of the tab pages matter for triggering the bug, as the search for a suitable window will pick the last window found, which will be in the second tabpage.

The bug is caused by the fact that win_id2win() will be called with the window id of the window found in the second tabpage, returning 0, making the command "0windcmd w" stay in the current window.

This patch fixes the issue by limiting the search for a suitable window to the current tabpage. A further improvement could be to break the for loops as soon a suitable window is found, but since that would only be noticeable when the current tabpage is already split in more than one window, and would break current behavior, it is left as is.

## Summary

This PR adds fixes a bug in the agenda view.

## Related Issues

None

Related #

Closes #

## Changes

No major changes


## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
