### PR TITLE
fix: OrgConfigOpts mandatory arguments

### DIFF
--- a/lua/orgmode/config/_meta.lua
+++ b/lua/orgmode/config/_meta.lua
@@ -252,7 +252,7 @@
 ---@field org_id_method? 'uuid' | 'ts' | 'org' What method to use to generate ids via org.id module. Default: 'uuid'
 ---@field org_id_prefix? string | nil Prefix to apply to id when `org_id_method = 'org'`. Default: nil
 ---@field org_id_link_to_org_use_id? boolean If true, Storing a link to the headline will automatically generate ID for that headline. Default: false
----@field org_use_property_inheritance boolean | string | string[] If true, properties are inherited by sub-headlines; may also be a regex or list of property names. Default: false
+---@field org_use_property_inheritance? boolean | string | string[] If true, properties are inherited by sub-headlines; may also be a regex or list of property names. Default: false
 ---@field org_babel_default_header_args? table<string, string> Default header args for org-babel blocks: Default: { [':tangle'] = 'no', [':noweb'] = 'no' }
 ---@field win_split_mode? 'horizontal' | 'vertical' | 'auto' | 'float' | string[] How to open agenda and capture windows. Default: 'horizontal'
 ---@field win_border? 'none' | 'single' | 'double' | 'rounded' | 'solid' | 'shadow' | string[] Border configuration for `win_split_mode = 'float'`. Default: 'single'
@@ -260,4 +260,4 @@
 ---@field mappings? OrgMappingsConfig Mappings configuration
 ---@field emacs_config? OrgEmacsConfig Emacs cnfiguration
 ---@field ui? OrgUiConfig UI configuration
----@field hyperlinks OrgHyperlinksConfig  Custom sources for hyperlinks
+---@field hyperlinks? OrgHyperlinksConfig  Custom sources for hyperlinks


### PR DESCRIPTION
## Summary

When calling `require('orgmode').setup{}`, `lua_ls` will say 
```
Diagnostics:
1. Missing required fields in type `OrgConfigOpts`: `org_use_property_inheritance`, `hyperlinks` [missing-fields]
```
Those two parameters were presumably unintentionally made mandatory.

## Changes

Add two question marks in the meta file describing the setup arguments.

Note: I erased the long checklist because I think it’s not relevant to such a trivial change. You should feel free to simply close this PR if this was not a bug. Thanks a lot for your work on this plugin.