### PR TITLE
fix(highlighter): Schedule callback for todos

### DIFF
--- a/lua/orgmode/colors/highlighter/todos.lua
+++ b/lua/orgmode/colors/highlighter/todos.lua
@@ -44,7 +44,7 @@ function OrgTodos:_add_highlights()
     end
   end
 
-  return Promise.all(actions):next(function(line_parts)
+  return Promise.all(actions):next(vim.schedule_wrap(function(line_parts)
     local all_lines = {}
     for _, line_part in ipairs(line_parts) do
       utils.concat(all_lines, line_part)
@@ -53,7 +53,7 @@ function OrgTodos:_add_highlights()
     if vim.bo.filetype == 'org' then
       tree_utils.restart_highlights()
     end
-  end)
+  end))
 end
 
 return OrgTodos


### PR DESCRIPTION
Fix error E5560: nvim_get_option_value must not be called in a fast event context

## Summary

<!-- Give a brief description of what your PR does. -->

After commit b6be301, if a particular ```org_todo_keyword_faces = {...}``` configuration is used, opening an org file returns message ```Autocommands for "org": Vim(append):vim.schedule callback: unhandled promise rejection: { "...\\bundle\\orgmode/lua/orgmode/colors/highlighter/todos.lua:53: E5560: nvim_get_option_value must not be called in a fast event context" }```


## Changes

<!-- List the major changes made in this PR. -->

- Following suggestion from :help E5560 the Promise callback is scheduled using vim.schedule_wrap

## Checklist

I confirm that I have:

- [X] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [X] **My PR title also follows the conventional commits specification.**
- [ ] **Updated relevant documentation,** if necessary.
- [ ] **Thoroughly tested my changes.**
- [ ] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [ ] **Checked for breaking changes** and documented them, if any.
