### PR TITLE
fix(priority): don't insert an empty [# ] cookie when clearing priority

### DIFF
--- a/lua/orgmode/files/headline.lua
+++ b/lua/orgmode/files/headline.lua
@@ -347,9 +347,17 @@ end
 ---@param priority string
 function Headline:set_priority(priority)
   local _, priority_node = self:get_priority()
+  priority = vim.trim(priority)
+
+  if priority == '' then
+    if priority_node then
+      return self:_set_node_text(priority_node, '')
+    end
+    return
+  end
+
   if priority_node then
-    local text = (vim.trim(priority) == '') and '' or ('[#%s]'):format(priority)
-    return self:_set_node_text(priority_node, text)
+    return self:_set_node_text(priority_node, ('[#%s]'):format(priority))
   end
 
   local todo, todo_node = self:get_todo()

--- a/tests/plenary/ui/mappings/priority_spec.lua
+++ b/tests/plenary/ui/mappings/priority_spec.lua
@@ -62,6 +62,17 @@ describe('Priority mappings', function()
     assert.are.same('* TODO Test orgmode', vim.fn.getline(1))
   end)
 
+  it('should do nothing if <Space> is pressed on a line without a priority', function()
+    alpha_config()
+    helpers.create_file({
+      '* TODO Test orgmode',
+    })
+    vim.fn.cursor(1, 1)
+    assert.are.same('* TODO Test orgmode', vim.fn.getline(1))
+    vim.cmd('norm ,o, \r')
+    assert.are.same('* TODO Test orgmode', vim.fn.getline(1))
+  end)
+
   it('should add a priority if the item does not already have one', function()
     helpers.create_file({
       '* TODO Test orgmode',


### PR DESCRIPTION
## Summary
- `Headline:set_priority` only treated a blank priority as "remove the cookie"
  when a cookie already existed. The other branches ran when the headline had no
  cookie yet and always built a new one, even for a blank priority. As a result,
  pressing `<Space>` at the priority prompt on a headline with no existing cookie
  returned `" "` from `PriorityState:prompt_user`, fell through to an insertion
  branch, and produced a literal `[# ]` cookie instead of clearing the priority.

## Changes
- Move the empty-priority check to the top of `set_priority` so it applies to all
  paths: if the trimmed priority is empty, remove the existing cookie if present,
  otherwise do nothing. The insertion branches now only run with a real priority
  and can no longer fabricate an empty `[# ]` cookie.
- Add a test covering `<Space>` on a headline without an existing priority.

## Checklist
I confirm that I have:
- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
