### PR TITLE
fix(docs): ensure at least one space before toc link

### DIFF
--- a/doc/orgmode.txt
+++ b/doc/orgmode.txt
@@ -13,13 +13,13 @@ Table of Contents                                  *orgmode-table-of-contents*
   - Features                                  |orgmode-configuration-features|
   - User interface                      |orgmode-configuration-user-interface|
 2. Troubleshooting                                   |orgmode-troubleshooting|
-  - Indentation is not working|orgmode-troubleshooting-indentation-is-not-working|
-  - I get treesitter/query.lua errors when opening agenda/capture prompt or org files|orgmode-troubleshooting-i-get-treesitter/query.lua-errors-when-opening-agenda/capture-prompt-or-org-files|
-  - I get .../orgmode/parser/org.so is not a valid Win32 application on Windows|orgmode-troubleshooting-i-get-.../orgmode/parser/org.so-is-not-a-valid-win32-application-on-windows|
-  - Dates are not in English|orgmode-troubleshooting-dates-are-not-in-english|
-  - Chinese characters are not displayed correctly in agenda|orgmode-troubleshooting-chinese-characters-are-not-displayed-correctly-in-agenda|
+  - Indentation is not working |orgmode-troubleshooting-indentation-is-not-working|
+  - I get treesitter/query.lua errors when opening agenda/capture prompt or org files |orgmode-troubleshooting-i-get-treesitter/query.lua-errors-when-opening-agenda/capture-prompt-or-org-files|
+  - I get .../orgmode/parser/org.so is not a valid Win32 application on Windows |orgmode-troubleshooting-i-get-.../orgmode/parser/org.so-is-not-a-valid-win32-application-on-windows|
+  - Dates are not in English |orgmode-troubleshooting-dates-are-not-in-english|
+  - Chinese characters are not displayed correctly in agenda |orgmode-troubleshooting-chinese-characters-are-not-displayed-correctly-in-agenda|
   - Links are not concealed  |orgmode-troubleshooting-links-are-not-concealed|
-  - Jumping to file path is not working for paths with forward slash|orgmode-troubleshooting-jumping-to-file-path-is-not-working-for-paths-with-forward-slash|
+  - Jumping to file path is not working for paths with forward slash |orgmode-troubleshooting-jumping-to-file-path-is-not-working-for-paths-with-forward-slash|
 
 ==============================================================================
 1. Configuration                                       *orgmode-configuration*

--- a/scripts/panvimdoc.lua
+++ b/scripts/panvimdoc.lua
@@ -147,10 +147,10 @@ local function renderToc()
     for _, elem in pairs(toc) do
       local level, item, link = elem[1], elem[2], elem[3]
       if level == 1 then
-        local padding = string.rep(" ", 78 - #item - #link)
+        local padding = string.rep(" ", math.max(78 - #item - #link, 1))
         add(item .. padding .. link)
       elseif level == 2 then
-        local padding = string.rep(" ", 74 - #item - #link)
+        local padding = string.rep(" ", math.max(74 - #item - #link, 1))
         add("  - " .. item .. padding .. link)
       end
     end


### PR DESCRIPTION
For the links to work, they need to be preceded by at least one space.

## Summary

<!-- Give a brief description of what your PR does. -->

This PR fixes the links in the table of content in the troubleshooting section.

## Related Issues

<!-- Link issues that are related to this PR. You may link issues you think should be closed by this PR. -->

Closes #1158 

## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
