### PR TITLE
fix(agenda): align multi-week spans to the start weekday

### DIFF
--- a/docs/configuration.org
+++ b/docs/configuration.org
@@ -626,17 +626,20 @@ Example: If Today is =2021-06-10=, and we have these tasks:
 - Type: =string|number=
 - Default: ='week'=
 /possible string values/: =day=, =week=, =month=, =year=
+/possible number values/: number of days to show (example: =14= for a two week agenda)
 Default time span shown when agenda is opened.
 
 *** org_agenda_start_on_weekday
 :PROPERTIES:
 :CUSTOM_ID: org_agenda_start_on_weekday
 :END:
-- Type: =number=
+- Type: =number|false=
 - Default: =1=
 From which day in week (ISO weekday, 1 is Monday) to show the agenda.
-Applies only to =week= and number span.
-If set to =false=, starts from today
+Applies only to spans that cover whole weeks: the =week= span, and
+numeric spans that are a multiple of 7 (=7=, =14=, =21=, ...).
+All other spans start from today.
+If set to =false=, starts from today.
 
 *** org_agenda_start_day
 :PROPERTIES:
@@ -733,7 +736,7 @@ These arguments are shared between all of the agenda types:
 
 =agenda= type arguments:
 - =org_agenda_span= =string|number= - Set custom span for the view. In same format as [[#org_agenda_span][org_agenda_span]]
-- =org_agenda_start_on_weekday= =number= - Set custom start day for the view. In same format as [[#org_agenda_start_on_weekday][org_agenda_start_on_weekday]]
+- =org_agenda_start_on_weekday= =number|false= - Set custom start day for the view. In same format as [[#org_agenda_start_on_weekday][org_agenda_start_on_weekday]]
 - =org_agenda_start_day= =string= - Set custom start day offset for the view. In same format as [[#org_agenda_start_day][org_agenda_start_day]]
 
 =tags= and =tags_todo= type arguments:

--- a/lua/orgmode/agenda/types/agenda.lua
+++ b/lua/orgmode/agenda/types/agenda.lua
@@ -23,7 +23,7 @@ local Promise = require('orgmode.utils.promise')
 ---@field agenda_files string | string[] | nil
 ---@field span? OrgAgendaSpan
 ---@field from? OrgDate
----@field start_on_weekday? number
+---@field start_on_weekday? number | false
 ---@field start_day? string
 ---@field header? string
 ---@field show_clock_report? boolean
@@ -43,7 +43,7 @@ local Promise = require('orgmode.utils.promise')
 ---@field from? OrgDate
 ---@field to? OrgDate
 ---@field bufnr? number
----@field start_on_weekday? number
+---@field start_on_weekday? number | false
 ---@field start_day? string
 ---@field header? string
 ---@field show_clock_report? boolean
@@ -620,8 +620,9 @@ function OrgAgendaType:_set_date_range(from)
   from = from or self.from
 
   if self.start_on_weekday then
-    local is_week = span == 'week' or span == '7'
-    if is_week and from:is_same(Date.today(), 'week') then
+    local days = span == 'week' and 7 or tonumber(span)
+    local is_whole_weeks = days ~= nil and days >= 7 and days % 7 == 0
+    if is_whole_weeks and from:is_same(Date.today(), 'week') then
       from = from:set_isoweekday(self.start_on_weekday)
     end
   end

--- a/lua/orgmode/config/_meta.lua
+++ b/lua/orgmode/config/_meta.lua
@@ -204,7 +204,7 @@
 ---@field org_deadline_warning_days? number Number of days during which deadline becomes visible in today's agenda. Default: 14
 ---@field org_agenda_min_height? number Minimum height of the agenda window. Default: 16
 ---@field org_agenda_span? OrgAgendaSpan Default time span for the agenda view. Default: 'week'
----@field org_agenda_start_on_weekday? number | false From which day in week (ISO weekday, 1 is Monday) to show the agenda. Applies only to `week` span. Default: 1
+---@field org_agenda_start_on_weekday? number | false From which day in week (ISO weekday, 1 is Monday) to show the agenda. Applies only to spans covering whole weeks (`week`, 7, 14, 21, ...); other spans start from today. Default: 1
 ---@field org_agenda_start_day? string | nil Offset applied to the `org_agenda_start_on_weekday` in format `+1d`, `+2w`, etc. Default: nil
 ---@field calendar_week_start_day? 0 | 1 From which day to start the week in the Calendar. 0 is Sunday, 1 is Monday. Default: 1
 ---@field calendar? OrgCalendarSettings Calendar settings

--- a/tests/plenary/agenda/agenda_item_spec.lua
+++ b/tests/plenary/agenda/agenda_item_spec.lua
@@ -1,4 +1,5 @@
 local AgendaItem = require('orgmode.agenda.agenda_item')
+local AgendaType = require('orgmode.agenda.types.agenda')
 local Date = require('orgmode.objects.date')
 local Highlights = require('orgmode.colors.highlights')
 local config = require('orgmode.config')
@@ -496,5 +497,25 @@ describe('Agenda item', function()
     assert.are.same('', agenda_item_deadline.label)
 
     config:extend({ org_agenda_skip_deadline_if_done = false })
+  end)
+
+  it('aligns whole-week spans to the configured start weekday', function()
+    local weekday = config.org_agenda_start_on_weekday
+    for _, span in ipairs({ 'week', 7, 14, 21, 28 }) do
+      local view = AgendaType:new({ span = span }) ---@diagnostic disable-line: missing-fields
+      assert.are.same({ span = span, weekday = weekday }, { span = span, weekday = view.from:get_isoweekday() })
+    end
+  end)
+
+  it('starts other spans from today', function()
+    for _, span in ipairs({ 'day', 'month', 'year', 3, 10, 15 }) do
+      local view = AgendaType:new({ span = span }) ---@diagnostic disable-line: missing-fields
+      assert.are.same(Date.today():to_date_string(), view.from:to_date_string())
+    end
+  end)
+
+  it('starts from today when the start weekday is disabled', function()
+    local view = AgendaType:new({ span = 14, start_on_weekday = false }) ---@diagnostic disable-line: missing-fields
+    assert.are.same(Date.today():to_date_string(), view.from:to_date_string())
   end)
 end)


### PR DESCRIPTION
## Summary

`org_agenda_start_on_weekday` was only honored for the `week` span and the
string `'7'`, so numeric spans never aligned. Setting `org_agenda_span = 14`
started the range on today rather than the configured weekday, leaving no way
to get a two-week agenda that begins on a week boundary.

The documentation disagreed with itself and with the code:

| Source | Claim |
| --- | --- |
| `docs/configuration.org` | applies to `week` and number span |
| `lua/orgmode/config/_meta.lua:207` | applies only to `week` span |
| `_set_date_range` | `span == 'week' or span == '7'` |


## Changes

Resolve the span to a day count and align whenever it covers whole weeks
(7, 14, 21, ...). Spans with no fixed length (`day`, `month`, `year`) and
partial weeks such as 10 keep starting from today.

Partial weeks are excluded deliberately: `advance_span` steps by exactly one
span, so only whole-week jumps preserve the alignment when paging with
`f`/`b`. Aligning a 10-day span would give one correct view and then drift,
which is worse than never aligning.

### On the removal of the `'7'` special case

The removed `span == '7'` branch was not working behavior thus was dropped. A
string span aligns correctly, but then crashes immediately afterward in the
same function:

```lua
    local modifier = { [span] = 1 }
    if type(span) == 'number' then
      modifier = { day = span }
    end
    to = from:add(modifier)
```

With `span = '7'`, `type(span) == 'number'` is false, so `modifier` becomes
`{ ['7'] = 1 }`, and `Date:add` does `date[opt] = date[opt] + val` against an
`osdate` field that doesn't exist, which throws the error: `attempt to perform arithmetic on a nil
value`.

It is also unreachable through config, since `Config:get_agenda_span`
validates string spans against `{'day', 'month', 'week', 'year'}` and falls
back to `week`. Only an explicit `org_agenda_span = '7'` in a custom command's
opts gets past that, straight into the crash. `tonumber` replaces the branch
with the numeric spans that actually work.

Numeric-string spans remain broken elsewhere (`advance_span` builds
`{ [self.span] = direction }` the same way, `_get_title` would print
`'7'-agenda`). Fixing that properly means normalizing `span` to a number at
construction and is left out of scope.

### Relation to Emacs

Emacs restricts this to 7 and 14 days. From the `org-agenda-start-on-weekday`
docstring in `lisp/org/org-agenda.el`:

```lisp
(defcustom org-agenda-start-on-weekday 1
  "Non-nil means start the overview always on the specified weekday.
0 denotes Sunday, 1 denotes Monday, etc.
When nil, always start on the current day.
Custom commands can set this variable in the options section.

This variable only applies when agenda spans either 7 or 14 days."
  :group 'org-agenda-daily/weekly
  :type '(choice (const :tag "Today" nil)
		 (integer :tag "Weekday No.")))

...

	   (org-agenda-start-on-weekday
	    (and (or (eq ndays 7) (eq ndays 14))

```

Note the check is on `ndays`, so the integer `14` does align in Emacs
(`org-agenda-ndays-to-span` normalizes it to `fortnight` first).

This means that accepting any multiple of 7 is a deliberate superset.
I'm happy to narrow it to `days == 7 or days == 14` for exact parity if
you'd prefer, but I think aligning with multiples of 7 makes more sense than
some arbitrary limit. I can easily imagine myself using a 21 or 28 day agenda.


### Type hints

`OrgAgendaTypeOpts.start_on_weekday` and `OrgAgendaType.start_on_weekday` were
annotated `number`, but `false` is supported: the constructor uses
`utils.if_nil` rather than `or` specifically so an explicit `false` isn't
replaced by the config default, and `if self.start_on_weekday then` consumes it.

`_meta.lua` already typed the user-facing option as `number | false`, and
`configuration.org` documented the behavior ("If set to `false`, starts from today")
while its `Type:` line said `number`. Corrected everywhere to match, which is why
`agenda.lua` has changes outside `_set_date_range`.


### Tests

Added three tests to verify behavior.


## Checklist

I confirm that I have:

- [x] **Followed the
      [Conventional Commits](https://www.conventionalcommits.org/)
      specification** (e.g., `feat: add new feature`, `fix: correct bug`,
      `docs: update documentation`).
- [x] **My PR title also follows the conventional commits specification.**
- [x] **Updated relevant documentation,** if necessary.
- [x] **Thoroughly tested my changes.**
- [x] **Added tests** (if applicable) and verified existing tests pass with
      `make test`.
- [x] **Checked for breaking changes** and documented them, if any.
